### PR TITLE
🐛 fix: a second OrderBy restarts the ordering — and the generator that found it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,11 @@ The flow:
 3. **Copilot reviews automatically.** ALWAYS go back and read its comments after opening the PR,
    and address them (fix, or reply saying why not). A PR is not done when it is opened.
 4. **Complete the PR yourself** once the review is clean and CI is green — that is what lands the
-   change on main.
+   change on main. The ruleset requires every review thread RESOLVED (not merely replied to), and
+   `gh pr merge` only says "the base branch policy prohibits the merge" when one is open. Resolving
+   is GraphQL-only: read `pullRequest.reviewThreads` for the unresolved id, then
+   `resolveReviewThread`. Copilot is not requested on open — it arrives on its own a few minutes
+   later, and asking for it fails, so wait rather than retry.
 5. **Cutting a version is OPTIONAL** and separate. Merging a PR does not imply a release. Bump and
    tag only when Edgar asks — see **Version Management** below for what a bump touches.
 

--- a/src/eQuantic.UI.Compiler/CodeGen/Strategies/Linq/OrderByStrategy.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Strategies/Linq/OrderByStrategy.cs
@@ -38,14 +38,22 @@ public class OrderByStrategy : IConversionStrategy
                && inv.Expression is MemberAccessExpressionSyntax acc
                && OrderMethods.Contains(acc.Name.Identifier.Text))
         {
+            var method = acc.Name.Identifier.Text;
             if (inv.ArgumentList.Arguments.Count > 0)
             {
                 var selector = context.Converter.ConvertExpression(inv.ArgumentList.Arguments[0].Expression);
-                var descending = acc.Name.Identifier.Text.EndsWith("Descending");
+                var descending = method.EndsWith("Descending");
                 keys.Insert(0, (selector, descending)); // outer call = later (lower-priority) key
             }
             source = acc.Expression;
             current = acc.Expression;
+
+            // An OrderBy is a PRIMARY key: it does not refine the ordering under it, it REPLACES
+            // it. `xs.OrderBy(a).OrderBy(b)` sorts by b, and the a-ordering survives only as the
+            // tiebreak a stable sort gives it — so the chain is CUT here and what is under it
+            // becomes the source, which sorts itself. Composing both keys into one comparator is
+            // what ThenBy means, and it silently produced a different order.
+            if (!method.StartsWith("ThenBy", StringComparison.Ordinal)) break;
         }
 
         var src = context.Converter.ConvertExpression(source);

--- a/tests/eQuantic.UI.Conformance.Tests/GeneratedDifferentialTests.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/GeneratedDifferentialTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text;
 using eQuantic.UI.Conformance.Tests.Infrastructure;
 using Xunit;
@@ -24,6 +25,12 @@ public class GeneratedDifferentialTests
     [InlineData(0xE0502u)]
     [InlineData(0xE0503u)]
     [InlineData(0xE0504u)]
+    // Four more batches once lists and LINQ chains joined the grammar: the surface the generator
+    // walks is much wider than it was, so the permanent sweep grew with it.
+    [InlineData(0xE0505u)]
+    [InlineData(0xE0506u)]
+    [InlineData(0xE0507u)]
+    [InlineData(0xE0508u)]
     public void GeneratedPrograms_MatchDotNet(uint batchSeed)
     {
         Skip.IfNot(JsExecutor.IsAvailable, "No JS engine available.");
@@ -54,7 +61,7 @@ public class GeneratedDifferentialTests
     /// a handful of mutating statements, then a deterministic fold of every local into one value —
     /// so no generated work is unobservable.
     /// </summary>
-    private sealed class ProgramGenerator
+    internal sealed class ProgramGenerator
     {
         private uint _state;
         public ProgramGenerator(uint seed) => _state = seed == 0 ? 1u : seed;
@@ -72,6 +79,7 @@ public class GeneratedDifferentialTests
         private readonly List<string> _ints = [];
         private readonly List<string> _bools = [];
         private readonly List<string> _strings = [];
+        private readonly List<string> _lists = [];
 
         public string Generate()
         {
@@ -89,6 +97,16 @@ public class GeneratedDifferentialTests
             program.Append($"var {name0} = {BoolExpr(2)}; ");
             _bools.Add(name0);
 
+            var listCount = 1 + Pick(2);
+            for (var i = 0; i < listCount; i++)
+            {
+                var name = $"xs{i}";
+                var items = 2 + Pick(4);
+                var values = string.Join(", ", Enumerable.Range(0, items).Select(_ => Pick(20).ToString()));
+                program.Append($"var {name} = new[] {{ {values} }}; ");
+                _lists.Add(name);
+            }
+
             var stringCount = 1 + Pick(2);
             for (var i = 0; i < stringCount; i++)
             {
@@ -104,6 +122,7 @@ public class GeneratedDifferentialTests
             program.Append("var acc = 17; ");
             foreach (var n in _ints) program.Append($"acc = acc * 31 + {n}; ");
             foreach (var b in _bools) program.Append($"acc = acc * 2 + ({b} ? 1 : 0); ");
+            foreach (var xs in _lists) program.Append($"acc = acc * 7 + {IntChain(xs)}; ");
             var fold = new StringBuilder("return $\"{acc}");
             foreach (var s in _strings) fold.Append($"|{{{s}}}");
             fold.Append("\";");
@@ -114,8 +133,14 @@ public class GeneratedDifferentialTests
 
         private string Statement()
         {
-            switch (Pick(6))
+            switch (Pick(8))
             {
+                case 6:
+                    // A chain whose result feeds an accumulator: the interplay between operators is
+                    // what no hand-written case enumerates.
+                    return $"{IntVar()} += {IntChain(ListVar())}; ";
+                case 7:
+                    return $"{StringVar()} += string.Join(\"-\", {Chain(ListVar(), 1 + Pick(2))}); ";
                 case 0:
                     return $"if ({BoolExpr(2)}) {{ {IntVar()} += {IntExpr(1)}; }} else {{ {IntVar()} -= {IntExpr(1)}; }} ";
                 case 1:
@@ -135,6 +160,55 @@ public class GeneratedDifferentialTests
                 default:
                     return $"{BoolVar()} = !{BoolVar()} || {BoolExpr(1)}; ";
             }
+        }
+
+        private string ListVar() => _lists[Pick(_lists.Count)];
+
+        /// <summary>
+        /// A LINQ chain over a list, ending in something the fold can observe as an INT. Only
+        /// operators that are total are used: an empty sequence must not throw, so Max and Min go
+        /// through DefaultIfEmpty and First is always FirstOrDefault. Values stay small because
+        /// Enumerable.Sum is checked in .NET and would throw on overflow rather than diverge —
+        /// which would be the generator testing itself, not the compiler.
+        /// </summary>
+        private string IntChain(string source)
+        {
+            var chain = Chain(source, Pick(3));
+            return Pick(8) switch
+            {
+                0 => $"{chain}.Count()",
+                1 => $"{chain}.Sum()",
+                2 => $"{chain}.DefaultIfEmpty(0).Max()",
+                3 => $"{chain}.DefaultIfEmpty(0).Min()",
+                4 => $"{chain}.Aggregate(7, (a, b) => a % 1000 * 3 + b)",
+                5 => $"{chain}.FirstOrDefault()",
+                6 => $"{chain}.ElementAtOrDefault({Pick(4)})",
+                _ => $"({chain}.Any(x => x % {2 + Pick(4)} == 0) ? 1 : 0)",
+            };
+        }
+
+        /// <summary>A run of sequence-to-sequence operators. Every one of them is total and keeps
+        /// the element type an int, so any two compose and the result is always observable.</summary>
+        private string Chain(string source, int links)
+        {
+            var chain = source;
+            for (var i = 0; i < links; i++)
+            {
+                chain = Pick(10) switch
+                {
+                    0 => $"{chain}.Where(x => x % {2 + Pick(4)} != {Pick(2)})",
+                    1 => $"{chain}.Select(x => x * {1 + Pick(3)} + {Pick(5)})",
+                    2 => $"{chain}.Take({Pick(5)})",
+                    3 => $"{chain}.Skip({Pick(3)})",
+                    4 => $"{chain}.Distinct()",
+                    5 => $"{chain}.OrderBy(x => x % {2 + Pick(5)})",
+                    6 => $"{chain}.Reverse()",
+                    7 => $"{chain}.TakeWhile(x => x < {5 + Pick(15)})",
+                    8 => $"{chain}.Append({Pick(20)})",
+                    _ => $"{chain}.Concat({ListVar()})",
+                };
+            }
+            return chain;
         }
 
         private string IntVar() => _ints[Pick(_ints.Count)];

--- a/tests/eQuantic.UI.Conformance.Tests/GeneratedDifferentialTests.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/GeneratedDifferentialTests.cs
@@ -61,7 +61,7 @@ public class GeneratedDifferentialTests
     /// a handful of mutating statements, then a deterministic fold of every local into one value —
     /// so no generated work is unobservable.
     /// </summary>
-    internal sealed class ProgramGenerator
+    private sealed class ProgramGenerator
     {
         private uint _state;
         public ProgramGenerator(uint seed) => _state = seed == 0 ? 1u : seed;

--- a/tests/eQuantic.UI.Conformance.Tests/OrderByThenByConformanceTests.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/OrderByThenByConformanceTests.cs
@@ -41,7 +41,7 @@ public class OrderByThenByConformanceTests
     /// which is what ThenBy means — found by the differential generator, which reached the shape
     /// three times in two thousand programs before anyone wrote it down.
     /// </summary>
-    [Theory]
+    [SkippableTheory]
     [InlineData("return string.Join(\"-\", new[]{4,15,3,15}.OrderBy(x => x % 2).OrderBy(x => x % 6));")]
     [InlineData("return string.Join(\"-\", new[]{4,15,3,15}.OrderBy(x => x % 2).ThenBy(x => x % 6));")]
     [InlineData("return string.Join(\"-\", new[]{5,3,8,1,9}.OrderBy(x => x % 3).OrderBy(x => x % 2));")]
@@ -49,6 +49,9 @@ public class OrderByThenByConformanceTests
     [InlineData("return string.Join(\"-\", new[]{5,3,8,1,9}.OrderBy(x => x % 3).ThenBy(x => x).OrderBy(x => x % 2));")]
     [InlineData("return string.Join(\"-\", new[]{7,2,9,4}.OrderBy(x => x % 2).OrderBy(x => x % 3).ThenBy(x => x));")]
     [InlineData("return new[]{4,15,3,15}.OrderBy(x => x % 2).OrderBy(x => x % 6).ElementAtOrDefault(3);")]
-    public void ASecondOrderByRestartsTheOrdering(string statements) =>
+    public void ASecondOrderByRestartsTheOrdering(string statements)
+    {
+        Skip.IfNot(JsExecutor.IsAvailable, "No JS engine available.");
         ConformanceRunner.AssertStatementsSameAsDotNet(statements);
+    }
 }

--- a/tests/eQuantic.UI.Conformance.Tests/OrderByThenByConformanceTests.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/OrderByThenByConformanceTests.cs
@@ -32,4 +32,23 @@ public class OrderByThenByConformanceTests
         else
             ConformanceRunner.AssertSameAsDotNet(code);
     }
+
+    /// <summary>
+    /// A second <c>OrderBy</c> REPLACES the primary key; it does not refine the one under it. The
+    /// earlier ordering survives only as the tiebreak a stable sort gives it, so
+    /// <c>OrderBy(a).OrderBy(b)</c> and <c>OrderBy(a).ThenBy(b)</c> are different orders whenever
+    /// b has ties that a would break. Both were emitted as one comparator with a as the primary,
+    /// which is what ThenBy means — found by the differential generator, which reached the shape
+    /// three times in two thousand programs before anyone wrote it down.
+    /// </summary>
+    [Theory]
+    [InlineData("return string.Join(\"-\", new[]{4,15,3,15}.OrderBy(x => x % 2).OrderBy(x => x % 6));")]
+    [InlineData("return string.Join(\"-\", new[]{4,15,3,15}.OrderBy(x => x % 2).ThenBy(x => x % 6));")]
+    [InlineData("return string.Join(\"-\", new[]{5,3,8,1,9}.OrderBy(x => x % 3).OrderBy(x => x % 2));")]
+    [InlineData("return string.Join(\"-\", new[]{5,3,8,1,9}.OrderByDescending(x => x % 3).OrderBy(x => x % 2));")]
+    [InlineData("return string.Join(\"-\", new[]{5,3,8,1,9}.OrderBy(x => x % 3).ThenBy(x => x).OrderBy(x => x % 2));")]
+    [InlineData("return string.Join(\"-\", new[]{7,2,9,4}.OrderBy(x => x % 2).OrderBy(x => x % 3).ThenBy(x => x));")]
+    [InlineData("return new[]{4,15,3,15}.OrderBy(x => x % 2).OrderBy(x => x % 6).ElementAtOrDefault(3);")]
+    public void ASecondOrderByRestartsTheOrdering(string statements) =>
+        ConformanceRunner.AssertStatementsSameAsDotNet(statements);
 }


### PR DESCRIPTION
Slice (3) of `docs/COVERAGE-PLAN.md`: widen the differential generator, and act on what it finds.

## The generator could not reach LINQ

It walked ints, bools and strings through control flow and never built a sequence, so the
largest surface in the compiler was the one surface it could not test. It now declares array
locals and composes chains over them — a run of sequence-to-sequence operators landing on a
terminal the observable fold reads as an int.

Every operator in the grammar is **total**, which is what keeps a failure meaningful rather than
self-inflicted: an empty sequence must not throw, so `Max`/`Min` go through `DefaultIfEmpty` and
`First` is always `FirstOrDefault`; values stay small because `Enumerable.Sum` is checked in .NET
and would throw on overflow, which would be the generator testing its own grammar.

## What it found, on the first sweep

Three divergences in 2100 programs, all one root cause: **`xs.OrderBy(a).OrderBy(b)` was emitted
as `OrderBy(a).ThenBy(b)`**.

In .NET a second `OrderBy` REPLACES the primary key. The earlier ordering survives only as the
tiebreak a stable sort gives it, so the two forms differ whenever `b` has ties that `a` would
break. The strategy walked the whole ordering chain and composed every key into one comparator
with the innermost as primary — the definition of `ThenBy`. Any page that sorted a list twice got
a different order, silently.

The chain is cut at an `OrderBy` now: what sits under it becomes the source and sorts itself, and
the outer sort refines it through JavaScript's stable sort, which is the same guarantee LINQ
makes. `ThenBy` was already correct and stays byte-identical.

After the fix the same 2100 programs are clean, and the permanent sweep doubles to eight batches
(240 programs a run). Seven cases pin the semantics directly, including one that reads through
`ElementAtOrDefault` so the ORDER is observed and not merely the set.

## Also here

One paragraph in CLAUDE.md for two things learned closing #3: replying to Copilot does not resolve
its thread, and the ruleset requires every thread resolved — `gh` reports only "the base branch
policy prohibits the merge", and resolving is GraphQL-only. Copilot is also not requested on open;
it arrives by itself a few minutes later and asking for it fails, so the instruction is to wait.

## Verification

Conformance 1067, Compiler 784, Web 484, Server 132, Design 103. No committed twin changes — the
fix alters output only for a chain no shared component writes.