### PR TITLE
🔧 chore: 0.2.0-preview.39

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.38</Version>
+        <Version>0.2.0-preview.39</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
The one line a release is. Six PRs landed since `v0.2.0-preview.38`; this cuts them.

## What consumers get

**Silently wrong answers, fixed**

- `xs.OrderBy(a).OrderBy(b)` sorted by `a` and treated `b` as a tiebreak — the definition of
  `ThenBy`. A second `OrderBy` REPLACES the primary key in .NET, so any list a page sorted twice
  came out in a different order (#5).
- Six runtime sites mirrored C#'s `MathF.Round` with JavaScript's `Math.round`, which disagree on
  an exact half. `TypeStyle.ofSize(13, …)` lands on 32.5, so **every small button's label was
  16.5px of line height in the browser and 16px in the server's HTML** — a fraction of a shift on
  every hydration, on every page (#6).

**New capability**

- The grid vocabulary and the calendar's culture data, which the date pickers need before they can
  exist (#4, #7).

**Nets that will catch the next one**

- The differential generator now builds sequences and composes LINQ chains — it found the `OrderBy`
  bug on its first sweep of 2100 programs (#5).
- Component parity: components are lowered on both sides and compared tree for tree, including
  after a press, so a twin whose state does not move the same way fails (#6, #8).

## Not in this PR

The tag. Merging this lands the version; `v0.2.0-preview.39` is pushed afterwards and is what
triggers publication.

## A note on the size rule

CLAUDE.md says not to open thin PRs, and this one is a single line. A release bump has nothing to
group with — padding it out with unrelated work to satisfy the rule would make both the release and
the work harder to read, and the rule exists to make review meaningful, not to make commits bigger.
Recording the exception rather than quietly breaking the rule.