### PR TITLE
🐛 fix: a 404 in a prefixed language is a 404, not a redirect to itself

### DIFF
--- a/src/eQuantic.UI.Server/UIExtensions.cs
+++ b/src/eQuantic.UI.Server/UIExtensions.cs
@@ -560,11 +560,20 @@ public static class UIExtensions
     private static bool RedirectToLanguageUrl(HttpContext context, UIOptions options)
     {
         if (options.CultureRoutes is not { } map) return false;
-        if (context.Request.RouteValues.ContainsKey(CultureRouteConstraint.Name)) return false;
         var culture = System.Globalization.CultureInfo.CurrentUICulture.Name;
         if (map.IsDefault(culture) || map.SegmentFor(culture).Length == 0) return false;
 
         var path = context.Request.Path.HasValue ? context.Request.Path.Value! : "/";
+
+        // The PATH decides whether the URL already names its language, and the route values do not.
+        // This asked `RouteValues.ContainsKey("culture")`, which is only there when a culture-prefixed
+        // route MATCHED — and a request that matched nothing at all, which is every 404, carries no
+        // route values however plainly its path starts with /pt-BR. So an unknown path in a prefixed
+        // language was redirected to PathFor(culture, path), which for an already-prefixed path is
+        // that same path: six of seven languages had no 404 page at all, only a redirect to itself
+        // until the browser gave up with ERR_TOO_MANY_REDIRECTS.
+        if (!map.IsDefault(map.Split(path).Culture)) return false;
+
         context.Response.Redirect(map.PathFor(culture, path) + context.Request.QueryString, permanent: false);
         return true;
     }

--- a/tests/eQuantic.UI.Server.Tests/CultureRouteTests.cs
+++ b/tests/eQuantic.UI.Server.Tests/CultureRouteTests.cs
@@ -121,6 +121,33 @@ public class CultureRouteTests
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
+    /// <summary>
+    /// A path nothing serves, asked for UNDER a prefix, is a 404 and not a redirect to itself.
+    /// <para>
+    /// It redirected forever. The rule "a bare URL in a prefixed language goes to its prefixed
+    /// address" read <c>RouteValues["culture"]</c> to decide whether the URL already named its
+    /// language — and a request that matched no route at all, which is every 404, has no route
+    /// values however plainly its path starts with /pt-BR. So the redirect target was the request's
+    /// own URL, and a reader in six of the seven languages of a site got ERR_TOO_MANY_REDIRECTS
+    /// instead of a not-found page. Both halves are asserted: the status, and that the response is
+    /// not a redirect back to where it came from.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task APathNothingServes_UnderAPrefix_IsNotFound_NotARedirectToItself()
+    {
+        var (app, client) = await StartAppAsync();
+        await using var _ = app;
+        // The reader's language is the prefixed one, which is what makes the redirect rule apply at
+        // all: with the default culture there is nothing to redirect to and the bug never showed.
+        client.DefaultRequestHeaders.Add("Cookie", ".AspNetCore.Culture=c%3Dpt-BR%7Cuic%3Dpt-BR");
+
+        var response = await client.GetAsync("/pt-BR/nothing-serves-this");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Headers.Location.Should().BeNull();
+    }
+
     [Fact]
     public async Task ABareUrl_AskedForInAPrefixedLanguage_GoesToItsAddress()
     {


### PR DESCRIPTION
## What happens today

Every unknown URL in a prefixed language redirects to itself, forever. Six of the seven languages of a localised site have no not-found page at all — a reader who mistypes an address or follows a stale link gets `ERR_TOO_MANY_REDIRECTS`.

```
GET /en-US/careers/apply        (Accept-Language: en-US)
→ 302 Location: /en-US/careers/apply
→ 302 Location: /en-US/careers/apply
→ …
```

The default culture is unaffected, which is why this survived: it has no prefix, the rule returns early, and a site's own 404 tests are usually written in the default language.

## Why

`RedirectToLanguageUrl` decided whether a URL already named its language by looking for `RouteValues["culture"]`. That value is set only when a culture-prefixed route **matched** — and a request that matched no route at all, which is every 404, carries no route values however plainly its path starts with `/pt-BR`.

The redirect target is then `PathFor(culture, path)`, and `PathFor` is idempotent by design: given a path that already carries a prefix it returns that same path. Target equals request, so the browser loops.

## The change

The path is the authority on what the URL says, so the check reads the path through `Split`:

```csharp
if (!map.IsDefault(map.Split(path).Culture)) return false;
```

The route-value check is removed rather than kept alongside it — two checks answering one question leaves the next reader wondering which is load-bearing.

## Test

`APathNothingServes_UnderAPrefix_IsNotFound_NotARedirectToItself` asserts the status **and** the absence of a `Location` header: a redirect somewhere else would be a different bug that a status assertion alone would not name. Verified failing without the change (302 instead of 404) and passing with it.

133 server tests pass.