### PR TITLE
🐛 fix: a text entry sat at the top of its box, and autofill painted over it

### DIFF
--- a/src/eQuantic.UI.Web/TokenCss.cs
+++ b/src/eQuantic.UI.Web/TokenCss.cs
@@ -465,7 +465,27 @@ public static class PhotonCssGenerator
         // Text entry mechanics (spec B9): the input is chrome-less — the container shows focus —
         // and the placeholder rides TextMuted. Values are tokens; only mechanics live here.
         css.AppendLine(".eq-entry { outline: none; }");
+        // The .eq-field shell FILLS its container and centres what is in it. Without this it was a
+        // plain block of content height, so an entry dropped straight into a fixed-height Box —
+        // which is what a hand-built field does, and what the framework's own TextInput avoids
+        // only because it wraps the entry in a centred Row — sat against the top edge: measured at
+        // 0px above and 24px below inside a 44dp box, with the caret and the placeholder up there
+        // with it. Centring here fixes every composition instead of asking each one to remember a
+        // Row, and a multi-line entry is unaffected (its height is its own, and centring a single
+        // child that already fills the line is a no-op).
+        css.AppendLine(".eq-field { display: flex; align-items: center; height: 100%; }");
         css.AppendLine(".eq-entry::placeholder { color: var(--eq-color-text-muted); }");
+        // AUTOFILL. Chrome paints its own background and text colour over an autofilled control,
+        // ignoring ours — so a themed field showed a pale rectangle floating inside it, in the one
+        // flow (a filled form) where the app looks least finished. Clipping that background to the
+        // TEXT makes it invisible while leaving the field's own surface alone, and the fill colour
+        // and caret come back to the theme. The state sticks through hover, focus and active, so
+        // every one of them has to say it.
+        css.AppendLine(".eq-entry:-webkit-autofill, .eq-entry:-webkit-autofill:hover, "
+            + ".eq-entry:-webkit-autofill:focus, .eq-entry:-webkit-autofill:active { "
+            + "-webkit-background-clip: text; background-clip: text; "
+            + "-webkit-text-fill-color: var(--eq-color-text-primary); "
+            + "caret-color: var(--eq-color-text-primary); }");
         // The entry's description twin: clipped, NOT display:none — a hidden target still reads
         // for aria-describedby, but only a rendered one announces as a live region.
         css.AppendLine(".eq-desc { position: absolute; width: 1px; height: 1px; margin: -1px; border: 0; padding: 0; clip-path: inset(50%); overflow: hidden; white-space: nowrap; }");

--- a/tests/eQuantic.UI.Web.Tests/EntryAlignmentTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/EntryAlignmentTests.cs
@@ -1,0 +1,55 @@
+using eQuantic.UI.Primitives;
+using eQuantic.UI.Web;
+using FluentAssertions;
+
+namespace eQuantic.UI.Web.Tests;
+
+/// <summary>
+/// A text entry sits in the MIDDLE of the box it was given, and an autofilled one keeps the
+/// field's own surface.
+/// <para>
+/// Both were reported from a real form. The entry hugged the top edge — measured in the browser at
+/// 0px above and 24px below inside a 44dp box, caret and placeholder included — because the
+/// <c>.eq-field</c> shell was a plain block of content height, sitting at the top of whatever
+/// container it was dropped into. The framework's own TextInput escaped it by wrapping the entry
+/// in a centred Row, which is exactly the kind of thing every hand-built field has to remember and
+/// nobody does.
+/// </para>
+/// <para>
+/// The autofill half is Chrome painting its own background and text colour over an autofilled
+/// control: a pale rectangle floating inside a themed field, in the one flow where a form looks
+/// least finished. Clipping that background to the TEXT makes it invisible without needing to know
+/// the surrounding colour, which is what lets one rule serve every theme.
+/// </para>
+/// </summary>
+public class EntryAlignmentTests
+{
+    private static string Sheet() => PhotonCssGenerator.Generate(PhotonTheme.Instance);
+
+    [Fact]
+    public void TheFieldShellFillsItsBoxAndCentresTheEntry()
+    {
+        var css = Sheet();
+        var rule = css.Split('\n').Single(line => line.TrimStart().StartsWith(".eq-field {"));
+
+        rule.Should().Contain("display: flex")
+            .And.Contain("align-items: center")
+            .And.Contain("height: 100%");
+    }
+
+    [Fact]
+    public void AnAutofilledEntryKeepsTheFieldsSurfaceAndTheThemesInk()
+    {
+        var css = Sheet();
+
+        // The state sticks through hover, focus and active — Chrome re-asserts it on each, so a
+        // rule that names only the base selector loses the field again the moment it is touched.
+        foreach (var state in new[] { ":-webkit-autofill", ":-webkit-autofill:hover",
+                                      ":-webkit-autofill:focus", ":-webkit-autofill:active" })
+            css.Should().Contain($".eq-entry{state}");
+
+        css.Should().Contain("-webkit-background-clip: text")
+            .And.Contain("-webkit-text-fill-color: var(--eq-color-text-primary)")
+            .And.Contain("caret-color: var(--eq-color-text-primary)");
+    }
+}


### PR DESCRIPTION
## Why

Reported from a real form, with two screenshots and two symptoms: the placeholder and caret sat at the **top** of every field, and a Chrome-autofilled field showed a pale rectangle floating inside the themed box.

One shared cause. The `.eq-field` shell that wraps every `TextEntry` was a plain block of content height, so an entry dropped straight into a fixed-height `Box` sat against the top edge. Measured in the browser against the reported composition: **0px above, 24px below** inside a 44dp box.

The framework's own `TextInput` escaped it only because it wraps the entry in a centred `Row`. Every hand-built field — the site's `SiteForm.Shell`, which is what the screenshots show — puts the entry straight in the box, which is the obvious thing to write and the thing that breaks.

## What lands

- `.eq-field` fills its container and centres what is in it. The same measurement now reads **12/12**, verified against the served stylesheet. A multi-line entry is unchanged: its height is its own, and centring a single child that already fills the line is a no-op — measured before and after to be sure.
- An autofilled entry keeps the field's surface. Chrome paints its own background and text colour over the control and re-asserts it on hover, focus and active; clipping that background to the **text** makes it invisible without needing to know the surrounding colour, so one rule serves every theme. The fill and caret colours come back to the tokens.

## How it was found, because I nearly shipped the wrong fix

My first hypothesis was `display: block` on the `<input>` — an input is inline-block, sits on a baseline, and half-leading pushes it up. It sounded right. The A/B in the browser said it changed **nothing**.

The sample I was testing against did not reproduce the bug at all, because it uses `TextInput` with its centring `Row`. Only after finding the actual screen from the screenshot — `CareersApplyPage` via `SiteForm.Shell` — did the shape reproduce, and the measurement blamed the wrapper rather than the input. The `display: block` hypothesis was dropped: it was not what the measurement supported.

One more thing worth recording: the first "verification" I ran was against a **stale server process**, which served half the rules and made the fix look inert. Restarting it is what produced the real numbers.

## The nets

Two regression tests over the generated stylesheet: the shell's three declarations, and all four autofill selectors with the three properties each needs. Web, design and server suites green.
