### PR TITLE
✅ test: the generator learns the compat types, and parity covers thirty-one components

### DIFF
--- a/src/eQuantic.UI.Components/Stepper.cs
+++ b/src/eQuantic.UI.Components/Stepper.cs
@@ -33,6 +33,14 @@ public sealed class Stepper : StatelessComponent
     /// <summary>Announced by the control; the number alone says nothing about what it counts.</summary>
     public string Label { get; init; } = "";
 
+    /// <summary>
+    /// What a screen reader announces for one of the two buttons. With a Label it names the thing
+    /// being stepped ("Increase quantity"); WITHOUT one it is the verb alone, because
+    /// <c>$"Increase {Label}"</c> on an empty Label announces "Increase " — a trailing space, and
+    /// a name that says what the button does to nothing in particular.
+    /// </summary>
+    private string Action(string verb) => Label.Length == 0 ? verb : $"{verb} {Label}";
+
     public override VisualNode Build(ComponentContext context)
     {
         var theme = context.Theme;
@@ -42,7 +50,7 @@ public sealed class Stepper : StatelessComponent
 
         var row = new Row(gap: 0) { Height = SizeValue.Fill, Cross = CrossAlign.Center };
         row.Add(Arm(theme, Icons.Minus, height, canDecrement,
-            () => OnChanged?.Invoke(Value - Step), $"Decrease {Label}"));
+            () => OnChanged?.Invoke(Value - Step), Action("Decrease")));
 
         // The value HUGS between the arms with a floor, rather than flexing: a Flexible here makes
         // the whole control greedy, and a Stepper next to a label ate the label's row.
@@ -62,7 +70,7 @@ public sealed class Stepper : StatelessComponent
         row.Add(new Box(new BoxStyle { MinWidth = height, Height = SizeValue.Fill }, reading));
 
         row.Add(Arm(theme, Icons.Plus, height, canIncrement,
-            () => OnChanged?.Invoke(Value + Step), $"Increase {Label}"));
+            () => OnChanged?.Invoke(Value + Step), Action("Increase")));
 
         return new Box(new BoxStyle
         {

--- a/src/eQuantic.UI.Runtime/src/shared/__transpiled__/Stepper.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/__transpiled__/Stepper.ts
@@ -34,12 +34,16 @@ export class Stepper extends StatelessComponent {
         let canDecrement = !this.disabled && this.value - this.step >= this.min;
         let canIncrement = !this.disabled && this.value + this.step <= this.max;
         let row = new Row(0, 'start', 'center', false, null, null, { height: SizeValue.fill, cross: 'center' });
-        row.add(Stepper.arm(theme, 'minus', height, canDecrement, () => this.onChanged?.(this.value - this.step), `Decrease ${this.label}`));
+        row.add(Stepper.arm(theme, 'minus', height, canDecrement, () => this.onChanged?.(this.value - this.step), this.action('Decrease')));
         let reading = new Row(0, 'start', 'center', false, null, null, { height: SizeValue.fill, main: 'center', cross: 'center' });
         reading.add(new Text(`${this.value}${this.suffix}`, 'label', this.disabled ? theme.textMuted : theme.textPrimary, 1, 'start', false, false, null, { align: 'center', tabular: true, styleOverride: theme.type('label').withSize(Sizing.labelSize(this.size, context.density)) }));
         row.add(new Box(new BoxStyle({ minWidth: height, height: SizeValue.fill }), reading));
-        row.add(Stepper.arm(theme, 'plus', height, canIncrement, () => this.onChanged?.(this.value + this.step), `Increase ${this.label}`));
+        row.add(Stepper.arm(theme, 'plus', height, canIncrement, () => this.onChanged?.(this.value + this.step), this.action('Increase')));
         return new Box(new BoxStyle({ width: SizeValue.hug, height: height, background: this.disabled ? theme.surfaceSubtle : theme.surface, cornerRadius: new CornerRadii(Sizing.radius(this.size)), borderWidth: 1, borderColor: theme.borderStrong, opacity: this.disabled ? theme.disabledOpacity : 1 }), row);
+    }
+
+    action(verb: string) {
+        return this.label.length === 0 ? verb : `${verb} ${this.label}`;
     }
 
     static arm(theme: any, glyph: IconsValue, height: number, enabled: boolean, onPressed: () => void, label: string) {

--- a/src/eQuantic.UI.Runtime/src/shared/component-parity.fixture.json
+++ b/src/eQuantic.UI.Runtime/src/shared/component-parity.fixture.json
@@ -934,7 +934,7 @@
             {
               "tag": "button",
               "attrs": {
-                "aria-label": "Decrease ",
+                "aria-label": "Decrease",
                 "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1jjc6f6 eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
               },
               "events": [
@@ -1018,7 +1018,161 @@
             {
               "tag": "button",
               "attrs": {
-                "aria-label": "Increase ",
+                "aria-label": "Increase",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1jjc6f6 eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
+              },
+              "events": [
+                "click"
+              ],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1xrfuoj eq-bo3n4y"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "svg",
+                          "attrs": {
+                            "aria-hidden": "true",
+                            "class": "eq-16x7aca eq-7gvrt4 eq-96qelu eq-i95eb9",
+                            "fill": "currentColor",
+                            "viewBox": "0 0 24 24"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "path",
+                              "attrs": {
+                                "d": "M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                              },
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "stepper-labelled": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-1e8yzyr eq-1eb13m5 eq-1o1uad7 eq-5hocaj eq-bo3n4y eq-cl6mtg"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-ewlixa eq-m92pvu eq-mc2xdp"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Decrease quantity",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1jjc6f6 eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
+              },
+              "events": [
+                "click"
+              ],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1xrfuoj eq-bo3n4y"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "svg",
+                          "attrs": {
+                            "aria-hidden": "true",
+                            "class": "eq-16x7aca eq-7gvrt4 eq-96qelu eq-i95eb9",
+                            "fill": "currentColor",
+                            "viewBox": "0 0 24 24"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "path",
+                              "attrs": {
+                                "d": "M19 13H5v-2h14z"
+                              },
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-ca9a4c"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-11aex6p eq-16x7aca eq-1hwu9wq eq-1txto41 eq-5augbd eq-5goeua eq-7gvrt4 eq-epaxs4 eq-jsw0f2 eq-mbtjfn eq-type-label eq-y9mhin"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "3",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Increase quantity",
                 "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1jjc6f6 eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
               },
               "events": [

--- a/src/eQuantic.UI.Runtime/src/shared/component-parity.fixture.json
+++ b/src/eQuantic.UI.Runtime/src/shared/component-parity.fixture.json
@@ -508,6 +508,1723 @@
       ]
     }
   ],
+  "badge": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-17a2pwz eq-17gcljg eq-1eb13m5 eq-1hgsylc eq-1or4gpz eq-bo3n4y eq-guk3hb"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "span",
+              "attrs": {
+                "class": "eq-16x7aca eq-17jb6qs eq-1eg324q eq-5goeua eq-epaxs4 eq-mbtjfn eq-pbx3g3 eq-r94c75 eq-type-caption eq-vrom5h"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "#text",
+                  "text": "7",
+                  "attrs": {},
+                  "events": [],
+                  "children": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "badge-overflow": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-17a2pwz eq-17gcljg eq-1eb13m5 eq-1or4gpz eq-bo3n4y eq-guk3hb eq-jq1py4"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "span",
+              "attrs": {
+                "class": "eq-16x7aca eq-17jb6qs eq-1dakdsg eq-1eg324q eq-5goeua eq-epaxs4 eq-mbtjfn eq-pbx3g3 eq-type-caption eq-vrom5h"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "#text",
+                  "text": "99\u002B",
+                  "attrs": {},
+                  "events": [],
+                  "children": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "card": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-15bwtfr eq-1eb13m5 eq-1eviv88 eq-1gsypk4 eq-1pwthtl eq-5hocaj eq-7ow04d eq-ag04go"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "span",
+          "attrs": {
+            "class": "eq-7gvrt4 eq-type-bodym"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "#text",
+              "text": "body",
+              "attrs": {},
+              "events": [],
+              "children": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "checkbox-on": [
+    {
+      "tag": "button",
+      "attrs": {
+        "aria-checked": "true",
+        "aria-label": "Accept",
+        "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+        "role": "checkbox"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-1iu691c eq-1uhnwvg eq-ewlixa eq-m92pvu eq-mc2xdp"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1eb13m5 eq-bo3n4y eq-iuiqgs eq-jq1py4 eq-s01o67 eq-z2pkxm"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "svg",
+                      "attrs": {
+                        "aria-hidden": "true",
+                        "class": "eq-16x7aca eq-19vml7g eq-1dakdsg eq-1or4gpz",
+                        "fill": "currentColor",
+                        "viewBox": "0 0 24 24"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "path",
+                          "attrs": {
+                            "d": "M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                          },
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "span",
+              "attrs": {
+                "class": "eq-12qw9lh eq-7gvrt4 eq-h7owsy eq-mbtjfn eq-type-bodym eq-xkrzsg"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "#text",
+                  "text": "Accept",
+                  "attrs": {},
+                  "events": [],
+                  "children": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "checkbox-off": [
+    {
+      "tag": "button",
+      "attrs": {
+        "aria-checked": "false",
+        "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+        "role": "checkbox"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-1iu691c eq-1uhnwvg eq-ewlixa eq-m92pvu eq-mc2xdp"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1eb13m5 eq-1iq7nu eq-bo3n4y eq-iuiqgs eq-s01o67 eq-z2pkxm"
+              },
+              "events": [],
+              "children": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "chip": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-12ve49g eq-17a2pwz eq-1eb13m5 eq-1su9m49 eq-bo3n4y eq-hw1jqi"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu eq-v9un6z"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "span",
+              "attrs": {
+                "class": "eq-16x7aca eq-1nj1bb6 eq-1x60j26 eq-5goeua eq-a53ok4 eq-epaxs4 eq-mbtjfn eq-pbx3g3 eq-type-caption eq-y9mhin"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "#text",
+                  "text": "Filter",
+                  "attrs": {},
+                  "events": [],
+                  "children": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "chip-selected": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-17a2pwz eq-1eb13m5 eq-1nzghh4 eq-1su9m49 eq-bo3n4y eq-hw1jqi eq-p7ntc"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu eq-v9un6z"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "svg",
+              "attrs": {
+                "aria-hidden": "true",
+                "class": "eq-16x7aca eq-19vml7g eq-1h2zrd3 eq-1or4gpz",
+                "fill": "currentColor",
+                "viewBox": "0 0 24 24"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "path",
+                  "attrs": {
+                    "d": "M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                  },
+                  "events": [],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "tag": "span",
+              "attrs": {
+                "class": "eq-16x7aca eq-1h2zrd3 eq-1x60j26 eq-5goeua eq-a53ok4 eq-epaxs4 eq-mbtjfn eq-pbx3g3 eq-type-caption eq-y9mhin"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "#text",
+                  "text": "Chosen",
+                  "attrs": {},
+                  "events": [],
+                  "children": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "divider": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-1eb13m5 eq-5ew4ww eq-akjizx eq-bo3n4y eq-rx01wr eq-yjvyu6"
+      },
+      "events": [],
+      "children": []
+    }
+  ],
+  "divider-vertical": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-1eb13m5 eq-1gudvpj eq-1h3pxaa eq-1jjc6f6 eq-bo3n4y eq-yjvyu6"
+      },
+      "events": [],
+      "children": []
+    }
+  ],
+  "banner": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-15bwtfr eq-1eb13m5 eq-5ew4ww eq-akjizx eq-fkv60s eq-ufuzv4"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-196dx6e eq-1eb13m5 eq-1uhnwvg eq-1w1wt6p eq-m92pvu eq-mc2xdp"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "svg",
+              "attrs": {
+                "aria-hidden": "true",
+                "class": "eq-16x7aca eq-17y6yig eq-96qelu eq-i95eb9",
+                "fill": "currentColor",
+                "viewBox": "0 0 24 24"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "path",
+                  "attrs": {
+                    "d": "M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2m1 15h-2v-2h2zm0-4h-2V7h2z"
+                  },
+                  "events": [],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-168ghzj eq-5ew4ww"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-11yg588 eq-1eb13m5 eq-aexooi eq-m7pi4h eq-m92pvu eq-mc2xdp"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-12qw9lh eq-17y6yig eq-a53ok4 eq-gxup24 eq-h7owsy eq-mbtjfn eq-pbx3g3 eq-type-caption eq-xkrzsg eq-y9mhin"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "Careful",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-112ynfn eq-17y6yig eq-a53ok4 eq-gxup24 eq-h7owsy eq-mbtjfn eq-oy7q1x eq-pbx3g3 eq-type-caption eq-xkrzsg"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "Something needs attention",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "stepper": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-1e8yzyr eq-1eb13m5 eq-1o1uad7 eq-5hocaj eq-bo3n4y eq-cl6mtg"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-ewlixa eq-m92pvu eq-mc2xdp"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Decrease ",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1jjc6f6 eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
+              },
+              "events": [
+                "click"
+              ],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1xrfuoj eq-bo3n4y"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "svg",
+                          "attrs": {
+                            "aria-hidden": "true",
+                            "class": "eq-16x7aca eq-7gvrt4 eq-96qelu eq-i95eb9",
+                            "fill": "currentColor",
+                            "viewBox": "0 0 24 24"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "path",
+                              "attrs": {
+                                "d": "M19 13H5v-2h14z"
+                              },
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-ca9a4c"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-11aex6p eq-16x7aca eq-1hwu9wq eq-1txto41 eq-5augbd eq-5goeua eq-7gvrt4 eq-epaxs4 eq-jsw0f2 eq-mbtjfn eq-type-label eq-y9mhin"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "3",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Increase ",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1jjc6f6 eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
+              },
+              "events": [
+                "click"
+              ],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1xrfuoj eq-bo3n4y"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "svg",
+                          "attrs": {
+                            "aria-hidden": "true",
+                            "class": "eq-16x7aca eq-7gvrt4 eq-96qelu eq-i95eb9",
+                            "fill": "currentColor",
+                            "viewBox": "0 0 24 24"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "path",
+                              "attrs": {
+                                "d": "M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+                              },
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "pagination": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-19dgm5h eq-1eb13m5 eq-1uhnwvg eq-ewlixa eq-m92pvu eq-mc2xdp"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "button",
+          "attrs": {
+            "aria-label": "Previous",
+            "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+            "style": "--eq-pressed-bg: light-dark(#eff1f4, #1c232b)"
+          },
+          "events": [
+            "click"
+          ],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-189q21e eq-1e8yzyr eq-1eb13m5 eq-1o1uad7 eq-1su9m49 eq-1vzw3dm eq-bo3n4y eq-hw1jqi"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu eq-v9un6z"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-16x7aca eq-1hwu9wq eq-1x60j26 eq-5goeua eq-7gvrt4 eq-a53ok4 eq-epaxs4 eq-mbtjfn eq-type-label eq-y9mhin"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "Previous",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-1gwdd6k eq-1uhnwvg eq-ewlixa eq-m92pvu eq-mc2xdp"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Page 1",
+                "aria-pressed": "false",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
+              },
+              "events": [
+                "click"
+              ],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-189q21e eq-18tlusk eq-1eb13m5 eq-2s6r7n eq-8jbob8 eq-bo3n4y eq-hj6cvq"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "span",
+                          "attrs": {
+                            "class": "eq-16x7aca eq-1nj1bb6 eq-5augbd eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-caption"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "#text",
+                              "text": "1",
+                              "attrs": {},
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Page 2",
+                "aria-pressed": "true",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-18tlusk eq-1eb13m5 eq-2s6r7n eq-8jbob8 eq-bo3n4y eq-hj6cvq eq-jq1py4"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "span",
+                          "attrs": {
+                            "class": "eq-16x7aca eq-1dakdsg eq-5augbd eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-caption"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "#text",
+                              "text": "2",
+                              "attrs": {},
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Page 3",
+                "aria-pressed": "false",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
+              },
+              "events": [
+                "click"
+              ],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-189q21e eq-18tlusk eq-1eb13m5 eq-2s6r7n eq-8jbob8 eq-bo3n4y eq-hj6cvq"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "span",
+                          "attrs": {
+                            "class": "eq-16x7aca eq-1nj1bb6 eq-5augbd eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-caption"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "#text",
+                              "text": "3",
+                              "attrs": {},
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Page 4",
+                "aria-pressed": "false",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
+              },
+              "events": [
+                "click"
+              ],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-189q21e eq-18tlusk eq-1eb13m5 eq-2s6r7n eq-8jbob8 eq-bo3n4y eq-hj6cvq"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "span",
+                          "attrs": {
+                            "class": "eq-16x7aca eq-1nj1bb6 eq-5augbd eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-caption"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "#text",
+                              "text": "4",
+                              "attrs": {},
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Page 5",
+                "aria-pressed": "false",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable"
+              },
+              "events": [
+                "click"
+              ],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-189q21e eq-18tlusk eq-1eb13m5 eq-2s6r7n eq-8jbob8 eq-bo3n4y eq-hj6cvq"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "span",
+                          "attrs": {
+                            "class": "eq-16x7aca eq-1nj1bb6 eq-5augbd eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-caption"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "#text",
+                              "text": "5",
+                              "attrs": {},
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "button",
+          "attrs": {
+            "aria-label": "Next",
+            "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+            "style": "--eq-pressed-bg: light-dark(#eff1f4, #1c232b)"
+          },
+          "events": [
+            "click"
+          ],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-189q21e eq-1e8yzyr eq-1eb13m5 eq-1o1uad7 eq-1su9m49 eq-1vzw3dm eq-bo3n4y eq-hw1jqi"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu eq-v9un6z"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-16x7aca eq-1hwu9wq eq-1x60j26 eq-5goeua eq-7gvrt4 eq-a53ok4 eq-epaxs4 eq-mbtjfn eq-type-label eq-y9mhin"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "Next",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "page-indicator": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-1eb13m5 eq-1uhnwvg eq-ewlixa eq-m7pi4h eq-m92pvu eq-mc2xdp"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1371iuq eq-154xbjv eq-17a2pwz eq-1eb13m5 eq-8ktm3z eq-bo3n4y eq-rxm3as"
+          },
+          "events": [],
+          "children": []
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1371iuq eq-17a2pwz eq-1eb13m5 eq-bo3n4y eq-jq1py4 eq-r2od8e eq-rxm3as"
+          },
+          "events": [],
+          "children": []
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1371iuq eq-154xbjv eq-17a2pwz eq-1eb13m5 eq-8ktm3z eq-bo3n4y eq-rxm3as"
+          },
+          "events": [],
+          "children": []
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1371iuq eq-154xbjv eq-17a2pwz eq-1eb13m5 eq-8ktm3z eq-bo3n4y eq-rxm3as"
+          },
+          "events": [],
+          "children": []
+        }
+      ]
+    }
+  ],
+  "tooltip": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-anchorhost eq-hoverreveal"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "span",
+          "attrs": {
+            "aria-describedby": "eq-tip-1xtgw69",
+            "class": "eq-7gvrt4 eq-type-bodym"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "#text",
+              "text": "hover",
+              "attrs": {},
+              "events": [],
+              "children": []
+            }
+          ]
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-anchor-panel eq-anchor-t-center eq-low5pc",
+            "id": "eq-tip-1xtgw69",
+            "role": "tooltip"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-18tlusk eq-1eb13m5 eq-60rbl8 eq-71rsfd"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "span",
+                  "attrs": {
+                    "class": "eq-16x7aca eq-5goeua eq-epaxs4 eq-k0ph0b eq-mbtjfn eq-type-caption"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "#text",
+                      "text": "the tip",
+                      "attrs": {},
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "tabs": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-15qobfw eq-1eb13m5 eq-1uhnwvg eq-5ew4ww eq-akjizx eq-bo3n4y eq-ewlixa eq-m92pvu eq-mc2xdp"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-168ghzj eq-5ew4ww"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "One",
+                "aria-selected": "false",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1jjc6f6 eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+                "role": "tab",
+                "style": "--eq-pressed-bg: light-dark(#eff1f4, #1c232b)",
+                "tabindex": "-1"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-11yg588 eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-aexooi eq-m92pvu eq-mc2xdp"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-168ghzj eq-1gudvpj"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "span",
+                              "attrs": {
+                                "class": "eq-16x7aca eq-1ehjvh5 eq-1hwu9wq eq-1xfx61h eq-5goeua eq-epaxs4 eq-gxup24 eq-mbtjfn eq-type-caption eq-y9mhin"
+                              },
+                              "events": [],
+                              "children": [
+                                {
+                                  "tag": "#text",
+                                  "text": "One",
+                                  "attrs": {},
+                                  "events": [],
+                                  "children": []
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-5ew4ww eq-akjizx eq-bo3n4y eq-i65znl eq-kngwsg eq-xhcqoy"
+                      },
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-168ghzj eq-5ew4ww"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Two",
+                "aria-selected": "true",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1jjc6f6 eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+                "role": "tab",
+                "style": "--eq-pressed-bg: light-dark(#eff1f4, #1c232b)",
+                "tabindex": "-1"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-11yg588 eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-aexooi eq-m92pvu eq-mc2xdp"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-168ghzj eq-1gudvpj"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "span",
+                              "attrs": {
+                                "class": "eq-16x7aca eq-17jb6qs eq-1ehjvh5 eq-1hwu9wq eq-1piw7rt eq-5goeua eq-epaxs4 eq-gxup24 eq-mbtjfn eq-type-caption"
+                              },
+                              "events": [],
+                              "children": [
+                                {
+                                  "tag": "#text",
+                                  "text": "Two",
+                                  "attrs": {},
+                                  "events": [],
+                                  "children": []
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-5ew4ww eq-akjizx eq-bo3n4y eq-i65znl eq-xhcqoy"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "class": "eq-1eb13m5 eq-1fggo7a eq-5ew4ww eq-akjizx eq-bo3n4y eq-i65znl eq-jq1py4"
+                          },
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-168ghzj eq-5ew4ww"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Three",
+                "aria-selected": "false",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1jjc6f6 eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+                "role": "tab",
+                "style": "--eq-pressed-bg: light-dark(#eff1f4, #1c232b)",
+                "tabindex": "-1"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-11yg588 eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-aexooi eq-m92pvu eq-mc2xdp"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-168ghzj eq-1gudvpj"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "span",
+                              "attrs": {
+                                "class": "eq-16x7aca eq-1ehjvh5 eq-1hwu9wq eq-1xfx61h eq-5goeua eq-epaxs4 eq-gxup24 eq-mbtjfn eq-type-caption eq-y9mhin"
+                              },
+                              "events": [],
+                              "children": [
+                                {
+                                  "tag": "#text",
+                                  "text": "Three",
+                                  "attrs": {},
+                                  "events": [],
+                                  "children": []
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-5ew4ww eq-akjizx eq-bo3n4y eq-i65znl eq-kngwsg eq-xhcqoy"
+                      },
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "search-field": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-12ve49g eq-17a2pwz eq-1eb13m5 eq-5ew4ww eq-akjizx eq-bo3n4y eq-cl6mtg eq-hebsiu"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-196dx6e eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-ewlixa eq-m92pvu eq-mc2xdp"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "svg",
+              "attrs": {
+                "aria-hidden": "true",
+                "class": "eq-16x7aca eq-1xfx61h eq-96qelu eq-i95eb9",
+                "fill": "currentColor",
+                "viewBox": "0 0 24 24"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "path",
+                  "attrs": {
+                    "d": "M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.7.7l.27.28v.79l5 4.99L20.49 19zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14"
+                  },
+                  "events": [],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-168ghzj eq-5ew4ww"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-field"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "input",
+                      "attrs": {
+                        "aria-label": "Search\u2026",
+                        "class": "eq-1esejbi eq-1etnzxl eq-1uykvw eq-7gvrt4 eq-akjizx eq-byqqyj eq-entry eq-type-bodym",
+                        "placeholder": "Search\u2026",
+                        "type": "text",
+                        "value": "term"
+                      },
+                      "events": [],
+                      "children": []
+                    },
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "aria-live": "polite",
+                        "class": "eq-desc"
+                      },
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Clear search",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+                "style": "--eq-pressed-bg: light-dark(#e2e5ea, #2a323d)"
+              },
+              "events": [
+                "click"
+              ],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-17a2pwz eq-1eb13m5 eq-1m836id eq-bo3n4y eq-cl6mtg eq-ra6ajf"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "svg",
+                          "attrs": {
+                            "aria-hidden": "true",
+                            "class": "eq-16x7aca eq-1xfx61h eq-96qelu eq-i95eb9",
+                            "fill": "currentColor",
+                            "viewBox": "0 0 24 24"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "path",
+                              "attrs": {
+                                "d": "M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              },
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "text-input": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-11yg588 eq-1eb13m5 eq-1pyii92 eq-5ew4ww eq-aexooi eq-akjizx eq-m92pvu eq-mc2xdp"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-11yg588 eq-1eb13m5 eq-5ew4ww eq-aexooi eq-akjizx eq-m92pvu eq-mc2xdp eq-v9un6z"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "span",
+              "attrs": {
+                "class": "eq-1nj1bb6 eq-type-label"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "#text",
+                  "text": "Label",
+                  "attrs": {},
+                  "events": [],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-15qobfw eq-1e8yzyr eq-1eb13m5 eq-1o1uad7 eq-5ew4ww eq-5hocaj eq-akjizx eq-bo3n4y eq-hebsiu"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-196dx6e eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-ewlixa eq-m92pvu eq-mc2xdp"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-168ghzj eq-5ew4ww"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "class": "eq-field"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "input",
+                              "attrs": {
+                                "aria-label": "Label",
+                                "class": "eq-1esejbi eq-1etnzxl eq-1uykvw eq-7gvrt4 eq-akjizx eq-byqqyj eq-entry eq-type-bodyl",
+                                "type": "text",
+                                "value": "value"
+                              },
+                              "events": [],
+                              "children": []
+                            },
+                            {
+                              "tag": "span",
+                              "attrs": {
+                                "aria-live": "polite",
+                                "class": "eq-desc"
+                              },
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "span",
+          "attrs": {
+            "class": "eq-16x7aca eq-1xfx61h eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-caption"
+          },
+          "events": [],
+          "children": []
+        }
+      ]
+    }
+  ],
+  "radio-group": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-11yg588 eq-1eb13m5 eq-5ew4ww eq-aexooi eq-akjizx eq-m7pi4h eq-m92pvu eq-mc2xdp"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-11yg588 eq-1eb13m5 eq-5ew4ww eq-aexooi eq-akjizx eq-m7pi4h eq-m92pvu eq-mc2xdp"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-checked": "true",
+                "aria-label": "a",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-akjizx eq-byqqyj eq-p7nbpw eq-pressable",
+                "role": "radio",
+                "tabindex": "-1"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1iu691c eq-1uhnwvg eq-5ew4ww eq-akjizx eq-bo3n4y eq-ewlixa eq-m92pvu eq-mc2xdp eq-vwp2xk"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-17a2pwz eq-1eb13m5 eq-6w1srn eq-bo3n4y eq-iuiqgs eq-s01o67"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "div",
+                              "attrs": {
+                                "class": "eq-17a2pwz eq-1eb13m5 eq-1jmiv2e eq-1yewskx eq-bo3n4y eq-jq1py4"
+                              },
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-16x7aca eq-5goeua eq-7gvrt4 eq-epaxs4 eq-mbtjfn eq-type-bodym"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "a",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-checked": "false",
+                "aria-label": "b",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-akjizx eq-byqqyj eq-p7nbpw eq-pressable",
+                "role": "radio",
+                "tabindex": "-1"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1iu691c eq-1uhnwvg eq-5ew4ww eq-akjizx eq-bo3n4y eq-ewlixa eq-m92pvu eq-mc2xdp eq-vwp2xk"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-17a2pwz eq-1eb13m5 eq-1iq7nu eq-bo3n4y eq-iuiqgs eq-s01o67"
+                      },
+                      "events": [],
+                      "children": []
+                    },
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-16x7aca eq-5goeua eq-7gvrt4 eq-epaxs4 eq-mbtjfn eq-type-bodym"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "b",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "empty-state": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-1eb13m5 eq-1m2fmjk eq-5ew4ww eq-aexooi eq-akjizx eq-ewlixa eq-m92pvu eq-mc2xdp"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-12ve49g eq-17a2pwz eq-1b1jdyl eq-1eb13m5 eq-8y94ea eq-bo3n4y"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-6gdbvu eq-akjizx eq-ewlixa eq-m92pvu"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "svg",
+                  "attrs": {
+                    "aria-hidden": "true",
+                    "class": "eq-16x7aca eq-1su9m49 eq-1xfx61h eq-1xtjgfe",
+                    "fill": "currentColor",
+                    "viewBox": "0 0 24 24"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "path",
+                      "attrs": {
+                        "d": "M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.7.7l.27.28v.79l5 4.99L20.49 19zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14"
+                      },
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "aria-hidden": "true",
+            "class": "eq-1or4gpz eq-bo3n4y"
+          },
+          "events": [],
+          "children": []
+        },
+        {
+          "tag": "span",
+          "attrs": {
+            "class": "eq-114sn1y eq-12qw9lh eq-7gvrt4 eq-h7owsy eq-mbtjfn eq-mxq5ld eq-pbx3g3 eq-type-title eq-xkrzsg eq-y9mhin"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "#text",
+              "text": "Nothing here",
+              "attrs": {},
+              "events": [],
+              "children": []
+            }
+          ]
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "aria-hidden": "true",
+            "class": "eq-1371iuq eq-bo3n4y"
+          },
+          "events": [],
+          "children": []
+        },
+        {
+          "tag": "span",
+          "attrs": {
+            "class": "eq-12qw9lh eq-1nj1bb6 eq-h7owsy eq-mbtjfn eq-type-bodym eq-xkrzsg"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "#text",
+              "text": "Try another term",
+              "attrs": {},
+              "events": [],
+              "children": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "select-opens": [
     {
       "tag": "div",

--- a/src/eQuantic.UI.Runtime/src/shared/component-parity.spec.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/component-parity.spec.ts
@@ -93,6 +93,7 @@ function cases(): Record<string, { node: unknown; presses: number[] }> {
     'divider-vertical': still(new Divider('none', 'vertical')),
     banner: still(new Banner('destructive', 'Careful', 'Something needs attention')),
     stepper: still(new Stepper(3)),
+    'stepper-labelled': still(Object.assign(new Stepper(3), { label: 'quantity' })),
     pagination: still(new Pagination(5, 2)),
     'page-indicator': still(new PageIndicator(4, 1)),
     tooltip: still(new Tooltip(new Text('hover', 'bodyM', photonTheme.textPrimary), 'the tip')),

--- a/src/eQuantic.UI.Runtime/src/shared/component-parity.spec.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/component-parity.spec.ts
@@ -23,6 +23,21 @@ import type { HtmlNode } from '../core/types';
 import { Column, Text } from './vocabulary';
 import { Accordion } from './components/Accordion';
 import { AccordionItem } from './components/AccordionItem';
+import { Badge } from './components/Badge';
+import { Card } from './components/Card';
+import { Checkbox } from './components/Checkbox';
+import { Chip } from './components/Chip';
+import { Divider } from './components/Divider';
+import { Banner } from './components/Banner';
+import { Stepper } from './components/Stepper';
+import { Pagination } from './components/Pagination';
+import { PageIndicator } from './components/PageIndicator';
+import { Tooltip } from './components/Tooltip';
+import { Tabs } from './components/Tabs';
+import { SearchField } from './components/SearchField';
+import { TextInput } from './components/TextInput';
+import { RadioGroup } from './components/RadioGroup';
+import { EmptyState } from './components/EmptyState';
 import { Avatar } from './components/Avatar';
 import { Button } from './components/Button';
 import { ProgressBar } from './components/ProgressBar';
@@ -67,6 +82,25 @@ function cases(): Record<string, { node: unknown; presses: number[] }> {
       ),
     ),
     'button-in-column': still(column(8, new Button('A'), new Button('B', 'outline'))),
+    badge: still(new Badge(7)),
+    'badge-overflow': still(new Badge(140, 99, 'primary')),
+    card: still(new Card(new Text('body', 'bodyM', photonTheme.textPrimary))),
+    'checkbox-on': still(new Checkbox(true, null, 'Accept')),
+    'checkbox-off': still(new Checkbox(false)),
+    chip: still(new Chip('Filter')),
+    'chip-selected': still(new Chip('Chosen', 'filter', true)),
+    divider: still(new Divider()),
+    'divider-vertical': still(new Divider('none', 'vertical')),
+    banner: still(new Banner('destructive', 'Careful', 'Something needs attention')),
+    stepper: still(new Stepper(3)),
+    pagination: still(new Pagination(5, 2)),
+    'page-indicator': still(new PageIndicator(4, 1)),
+    tooltip: still(new Tooltip(new Text('hover', 'bodyM', photonTheme.textPrimary), 'the tip')),
+    tabs: still(new Tabs(['One', 'Two', 'Three'], 1)),
+    'search-field': still(new SearchField('term')),
+    'text-input': still(new TextInput('value', null, 'Label')),
+    'radio-group': still(new RadioGroup(['a', 'b'], 0)),
+    'empty-state': still(new EmptyState('search', 'Nothing here', 'Try another term')),
     'select-opens': { node: new Select(['alpha', 'beta', 'gamma'], 0), presses: [0] },
     'accordion-switches': {
       node: new Accordion(
@@ -151,6 +185,9 @@ function frames(node: unknown, presses: number[]): unknown[] {
 }
 
 /** A lowered node the way the C# half writes it — the shapes have to be byte-comparable. */
+/** Handlers the twin attaches that SSR never emits — see lowerTextEntry. */
+const CLIENT_ONLY_EVENTS = new Set(['focus', 'blur', 'input', 'keydown', 'paste', 'cut', 'copy']);
+
 function canonical(node: HtmlNode): unknown {
   const attrs: Record<string, string> = {};
   for (const key of Object.keys(node.attributes ?? {}).sort()) {
@@ -161,10 +198,28 @@ function canonical(node: HtmlNode): unknown {
   if (node.key !== undefined && node.key !== null) result.key = node.key;
   if (node.textContent !== undefined && node.textContent !== null) result.text = node.textContent;
   result.attrs = attrs;
-  result.events = Object.keys(node.events ?? {}).sort();
+  // CLIENT-ONLY handlers are excluded, by design and not by convenience: lowerTextEntry says it
+  // produces "identical DOM to the C# SSR realizer, PLUS the client-only handlers", because the
+  // server sends markup and the client attaches behaviour. Comparing them would fail on a
+  // difference the product intends. The twin's own specs are what hold these.
+  result.events = Object.keys(node.events ?? {})
+    .filter((name) => !CLIENT_ONLY_EVENTS.has(name))
+    .sort();
   result.children = (node.children ?? []).map(canonical);
   return result;
 }
+
+/**
+ * Cases whose trees do NOT agree yet, each for a reason worth writing down rather than papering
+ * over. They still run: the assertion is inverted, so the day a case starts agreeing the suite
+ * fails and the entry comes out — the list can only shrink.
+ *
+ * - `text-input`: the twin gives the empty helper line a text node and C# gives the span no child
+ *   at all, so the client's tree has one node the server's HTML does not. That is the shape the
+ *   forms work already met once — an empty SSR text the reconciler never filled — and fixing it
+ *   is a hydration decision in TextInput, which is someone else's open work right now.
+ */
+const KNOWN_DIVERGENCES = new Set(['text-input']);
 
 describe('component parity: the twin lowers to the tree C# lowers to', () => {
   const pinned = fixture as Record<string, unknown>;
@@ -175,7 +230,8 @@ describe('component parity: the twin lowers to the tree C# lowers to', () => {
   });
 
   for (const [name, { node, presses }] of Object.entries(built)) {
-    it(`${name} lowers identically${presses.length > 0 ? ' through its presses' : ''}`, () => {
+    const known = KNOWN_DIVERGENCES.has(name);
+    it(`${name} lowers identically${presses.length > 0 ? ' through its presses' : ''}${known ? ' (known divergence)' : ''}`, () => {
       const actual = frames(node, presses);
       // A structural mismatch reads as "expected {…} to deeply equal {…}" and tells you nothing
       // about WHERE. EQ_PARITY_DIFF=1 prints both trees so the differing attribute is visible.
@@ -184,6 +240,15 @@ describe('component parity: the twin lowers to the tree C# lowers to', () => {
           `\n=== ${name}\n--- C#\n${JSON.stringify(pinned[name], null, 1)}` +
             `\n--- twin\n${JSON.stringify(actual, null, 1)}`,
         );
+      }
+      if (known) {
+        // Recorded rather than hidden, and the list may only SHRINK: a case in it still runs, so
+        // the day it starts agreeing the test says so and the entry comes out.
+        expect(
+          JSON.stringify(actual),
+          `${name} now AGREES — remove it from KNOWN_DIVERGENCES`,
+        ).not.toEqual(JSON.stringify(pinned[name]));
+        return;
       }
       expect(actual).toEqual(pinned[name]);
     });

--- a/src/eQuantic.UI.Runtime/src/shared/component-parity.spec.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/component-parity.spec.ts
@@ -186,8 +186,18 @@ function frames(node: unknown, presses: number[]): unknown[] {
 }
 
 /** A lowered node the way the C# half writes it — the shapes have to be byte-comparable. */
-/** Handlers the twin attaches that SSR never emits — see lowerTextEntry. */
+/**
+ * Handlers `lowerTextEntry` attaches to the entry ELEMENT itself, which SSR never emits: it says
+ * it produces "identical DOM to the C# SSR realizer, plus the client-only handlers", because the
+ * server sends markup and the client attaches behaviour. C# attaches none of these, so there is no
+ * matching filter on that side — the asymmetry is the point.
+ *
+ * Scoped to the entry's own tag on purpose. Other components attach the same NAMES for their own
+ * reasons — the spreadsheet surface listens for keydown and the clipboard trio — and filtering
+ * globally would hide a real regression the day one of those joins the fixture.
+ */
 const CLIENT_ONLY_EVENTS = new Set(['focus', 'blur', 'input', 'keydown', 'paste', 'cut', 'copy']);
+const ENTRY_TAGS = new Set(['input', 'textarea']);
 
 function canonical(node: HtmlNode): unknown {
   const attrs: Record<string, string> = {};
@@ -199,12 +209,9 @@ function canonical(node: HtmlNode): unknown {
   if (node.key !== undefined && node.key !== null) result.key = node.key;
   if (node.textContent !== undefined && node.textContent !== null) result.text = node.textContent;
   result.attrs = attrs;
-  // CLIENT-ONLY handlers are excluded, by design and not by convenience: lowerTextEntry says it
-  // produces "identical DOM to the C# SSR realizer, PLUS the client-only handlers", because the
-  // server sends markup and the client attaches behaviour. Comparing them would fail on a
-  // difference the product intends. The twin's own specs are what hold these.
+  const entry = ENTRY_TAGS.has(node.tag);
   result.events = Object.keys(node.events ?? {})
-    .filter((name) => !CLIENT_ONLY_EVENTS.has(name))
+    .filter((name) => !(entry && CLIENT_ONLY_EVENTS.has(name)))
     .sort();
   result.children = (node.children ?? []).map(canonical);
   return result;

--- a/src/eQuantic.UI.Runtime/src/shared/components/Stepper.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/components/Stepper.ts
@@ -34,12 +34,16 @@ export class Stepper extends StatelessComponent {
         let canDecrement = !this.disabled && this.value - this.step >= this.min;
         let canIncrement = !this.disabled && this.value + this.step <= this.max;
         let row = new Row(0, 'start', 'center', false, null, null, { height: SizeValue.fill, cross: 'center' });
-        row.add(Stepper.arm(theme, 'minus', height, canDecrement, () => this.onChanged?.(this.value - this.step), `Decrease ${this.label}`));
+        row.add(Stepper.arm(theme, 'minus', height, canDecrement, () => this.onChanged?.(this.value - this.step), this.action('Decrease')));
         let reading = new Row(0, 'start', 'center', false, null, null, { height: SizeValue.fill, main: 'center', cross: 'center' });
         reading.add(new Text(`${this.value}${this.suffix}`, 'label', this.disabled ? theme.textMuted : theme.textPrimary, 1, 'start', false, false, null, { align: 'center', tabular: true, styleOverride: theme.type('label').withSize(Sizing.labelSize(this.size, context.density)) }));
         row.add(new Box(new BoxStyle({ minWidth: height, height: SizeValue.fill }), reading));
-        row.add(Stepper.arm(theme, 'plus', height, canIncrement, () => this.onChanged?.(this.value + this.step), `Increase ${this.label}`));
+        row.add(Stepper.arm(theme, 'plus', height, canIncrement, () => this.onChanged?.(this.value + this.step), this.action('Increase')));
         return new Box(new BoxStyle({ width: SizeValue.hug, height: height, background: this.disabled ? theme.surfaceSubtle : theme.surface, cornerRadius: new CornerRadii(Sizing.radius(this.size)), borderWidth: 1, borderColor: theme.borderStrong, opacity: this.disabled ? theme.disabledOpacity : 1 }), row);
+    }
+
+    action(verb: string) {
+        return this.label.length === 0 ? verb : `${verb} ${this.label}`;
     }
 
     static arm(theme: any, glyph: IconsValue, height: number, enabled: boolean, onPressed: () => void, label: string) {

--- a/tests/eQuantic.UI.Conformance.Tests/GeneratedDifferentialTests.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/GeneratedDifferentialTests.cs
@@ -20,6 +20,16 @@ public class GeneratedDifferentialTests
 {
     private const int CasesPerBatch = 30;
 
+    /// <summary>
+    /// Types the generated programs use. An enum is a member-NAME string at run time and a
+    /// record compares by VALUE; neither can be declared inside a generated statement block, so
+    /// they live here and the grammar leans on them.
+    /// </summary>
+    private const string Prelude = """
+        public enum Suit { Clubs, Hearts, Spades }
+        public sealed record Card(int Rank, Suit Suit);
+        """;
+
     [SkippableTheory]
     [InlineData(0xE0501u)]
     [InlineData(0xE0502u)]
@@ -41,7 +51,7 @@ public class GeneratedDifferentialTests
             var program = new ProgramGenerator(batchSeed * 2654435761u + (uint)index).Generate();
             try
             {
-                ConformanceRunner.AssertStatementsSameAsDotNet(program);
+                ConformanceRunner.AssertStatementsSameAsDotNet(program, Prelude);
             }
             catch (Exception ex)
             {
@@ -80,6 +90,11 @@ public class GeneratedDifferentialTests
         private readonly List<string> _bools = [];
         private readonly List<string> _strings = [];
         private readonly List<string> _lists = [];
+        private readonly List<string> _longs = [];
+        private readonly List<string> _decimals = [];
+        private readonly List<string> _chars = [];
+        private readonly List<string> _suits = [];
+        private readonly List<string> _nullables = [];
 
         public string Generate()
         {
@@ -96,6 +111,35 @@ public class GeneratedDifferentialTests
             var name0 = "f0";
             program.Append($"var {name0} = {BoolExpr(2)}; ");
             _bools.Add(name0);
+
+            // The COMPAT types, which JavaScript does not have and every divergence so far has
+            // lived in: a long is a BigInt, a decimal is a Decimal object, a char is a 1-length
+            // string that promotes to its code unit. Values stay small — the documented overflow
+            // limits are pinned elsewhere and are not what this hunts.
+            for (var i = 0; i < 1 + Pick(2); i++)
+            {
+                var name = $"L{i}";
+                program.Append($"long {name} = {Pick(40)}L; ");
+                _longs.Add(name);
+            }
+            for (var i = 0; i < 1 + Pick(2); i++)
+            {
+                var name = $"m{i}";
+                program.Append($"decimal {name} = {Pick(100)}.{Pick(90) + 10}m; ");
+                _decimals.Add(name);
+            }
+            var charName = "c0";
+            program.Append($"char {charName} = '{(char)('a' + Pick(26))}'; ");
+            _chars.Add(charName);
+
+            // An ENUM crosses as its member NAME, and a NULLABLE has to keep "no value" apart
+            // from zero — two more places the two runtimes do not agree by default.
+            var suitName = "u0";
+            program.Append($"Suit {suitName} = Suit.{Suits[Pick(3)]}; ");
+            _suits.Add(suitName);
+            var maybeName = "q0";
+            program.Append($"int? {maybeName} = {(Pick(2) == 0 ? "null" : Pick(30).ToString())}; ");
+            _nullables.Add(maybeName);
 
             var listCount = 1 + Pick(2);
             for (var i = 0; i < listCount; i++)
@@ -119,12 +163,25 @@ public class GeneratedDifferentialTests
             for (var i = 0; i < statements; i++) program.Append(Statement());
 
             // The observable fold: every local reaches the result, so nothing generated is dead.
+            // The fold stays INSIDE an int. Mixing by 31 overflows in a handful of steps once
+            // the grammar grew, and an int overflowing in the default context is a documented
+            // divergence pinned elsewhere — reaching it here would make every program fail for
+            // the one reason this generator is meant not to hunt.
             program.Append("var acc = 17; ");
-            foreach (var n in _ints) program.Append($"acc = acc * 31 + {n}; ");
-            foreach (var b in _bools) program.Append($"acc = acc * 2 + ({b} ? 1 : 0); ");
-            foreach (var xs in _lists) program.Append($"acc = acc * 7 + {IntChain(xs)}; ");
+            foreach (var n in _ints) program.Append($"acc = (acc * 31 + {n}) % 1000003; ");
+            foreach (var b in _bools) program.Append($"acc = (acc * 2 + ({b} ? 1 : 0)) % 1000003; ");
+            foreach (var xs in _lists) program.Append($"acc = (acc * 7 + {IntChain(xs)}) % 1000003; ");
+            // A char folds through its CODE UNIT, the way C# promotes it.
+            foreach (var c in _chars) program.Append($"acc = (acc * 5 + {c}) % 1000003; ");
+            foreach (var q in _nullables) program.Append($"acc = (acc * 3 + ({q} ?? -1)) % 1000003; ");
             var fold = new StringBuilder("return $\"{acc}");
             foreach (var s in _strings) fold.Append($"|{{{s}}}");
+            // A long and a decimal are OBSERVED as text: their runtime representations differ from
+            // JavaScript's numbers, so printing them is what compares the value and not a coercion.
+            foreach (var l in _longs) fold.Append($"|{{{l}}}");
+            foreach (var m in _decimals) fold.Append($"|{{{m}}}");
+            foreach (var c in _chars) fold.Append($"|{{{c}}}");
+            foreach (var u in _suits) fold.Append($"|{{{u}}}");
             fold.Append("\";");
             program.Append(fold);
 
@@ -133,8 +190,39 @@ public class GeneratedDifferentialTests
 
         private string Statement()
         {
-            switch (Pick(8))
+            switch (Pick(16))
             {
+                case 12:
+                    // A switch EXPRESSION over an enum: member names on one side, strings on the other.
+                    return $"{IntVar()} += {SuitVar()} switch {{ Suit.Clubs => 1, Suit.Hearts => 2, _ => 3 }}; ";
+                case 13:
+                    return $"{SuitVar()} = {BoolExpr(1)} ? Suit.{Suits[Pick(3)]} : {SuitVar()}; ";
+                case 14:
+                    // A record compares by VALUE, and a property pattern binds through it.
+                {
+                    // A fresh NAME per statement: a pattern variable is scoped to the enclosing
+                    // block in C#, so two of these with one name is CS0128 — the generator
+                    // failing to compile its own program, which is not what it hunts.
+                    var card = $"card{_names++}";
+                    return $"var {card} = new Card({Pick(10)}, {SuitVar()}); "
+                           + $"if ({card} is {{ Rank: > 4 }} big{_names}) {{ {IntVar()} += big{_names}.Rank; }} "
+                           + $"if ({card} == new Card({card}.Rank, {card}.Suit)) {{ {IntVar()} += 1; }} ";
+                }
+                case 15:
+                {
+                    var bound = $"got{_names++}";
+                    return $"if ({NullableVar()} is int {bound}) {{ {IntVar()} += {bound}; }} else {{ {IntVar()} -= 2; }} ";
+                }
+                case 8:
+                    return $"{LongVar()} = {LongVar()} {(Pick(2) == 0 ? "+" : "-")} {Pick(30)}L; ";
+                case 9:
+                    return $"{DecVar()} = {DecVar()} {(Pick(2) == 0 ? "+" : "*")} {1 + Pick(5)}.{Pick(9)}m; ";
+                case 10:
+                    // A char compared and promoted: both are places C# and JavaScript disagree
+                    // unless the compiler says which one it means.
+                    return $"if ({CharVar()} > 'm') {{ {IntVar()} += {CharVar()} - 'a'; }} else {{ {IntVar()} -= 1; }} ";
+                case 11:
+                    return $"{StringVar()} += {(Pick(2) == 0 ? LongVar() : DecVar())}.ToString(); ";
                 case 6:
                     // A chain whose result feeds an accumulator: the interplay between operators is
                     // what no hand-written case enumerates.
@@ -210,6 +298,18 @@ public class GeneratedDifferentialTests
             }
             return chain;
         }
+
+        /// <summary>Fresh names for the variables a pattern binds — see case 14.</summary>
+        private int _names;
+
+        private static readonly string[] Suits = ["Clubs", "Hearts", "Spades"];
+
+        private string SuitVar() => _suits[Pick(_suits.Count)];
+        private string NullableVar() => _nullables[Pick(_nullables.Count)];
+
+        private string LongVar() => _longs[Pick(_longs.Count)];
+        private string DecVar() => _decimals[Pick(_decimals.Count)];
+        private string CharVar() => _chars[Pick(_chars.Count)];
 
         private string IntVar() => _ints[Pick(_ints.Count)];
         private string BoolVar() => _bools[Pick(_bools.Count)];

--- a/tests/eQuantic.UI.Web.Tests/ComponentParityFixtureTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/ComponentParityFixtureTests.cs
@@ -51,6 +51,29 @@ public class ComponentParityFixtureTests
                                            new Text("two", TypeRole.Label, Theme.TextPrimary)), NoPresses),
         ("button-in-column", Stack(Space.S2, new Button("A"), new Button("B", Variant.Outline)), NoPresses),
 
+        // A BROAD sweep of the library. Every one of these has a twin whose constructor mirrors
+        // the C# one parameter for parameter, so the same arguments build the same component on
+        // both sides — which is what makes a difference in the lowered tree mean something.
+        ("badge", new Badge(7), NoPresses),
+        ("badge-overflow", new Badge(140, 99, Variant.Primary), NoPresses),
+        ("card", new Card(new Text("body", TypeRole.BodyM, Theme.TextPrimary)), NoPresses),
+        ("checkbox-on", new Checkbox(true, null, "Accept"), NoPresses),
+        ("checkbox-off", new Checkbox(false), NoPresses),
+        ("chip", new Chip("Filter"), NoPresses),
+        ("chip-selected", new Chip("Chosen", ChipKind.Filter, true), NoPresses),
+        ("divider", new Divider(), NoPresses),
+        ("divider-vertical", new Divider(DividerInset.None, DividerAxis.Vertical), NoPresses),
+        ("banner", new Banner(Variant.Destructive, "Careful", "Something needs attention"), NoPresses),
+        ("stepper", new Stepper(3), NoPresses),
+        ("pagination", new Pagination(5, 2), NoPresses),
+        ("page-indicator", new PageIndicator(4, 1), NoPresses),
+        ("tooltip", new Tooltip(new Text("hover", TypeRole.BodyM, Theme.TextPrimary), "the tip"), NoPresses),
+        ("tabs", new Tabs(["One", "Two", "Three"], 1), NoPresses),
+        ("search-field", new SearchField("term"), NoPresses),
+        ("text-input", new TextInput("value", null, "Label"), NoPresses),
+        ("radio-group", new RadioGroup(["a", "b"], 0), NoPresses),
+        ("empty-state", new EmptyState(Icons.Search, "Nothing here", "Try another term"), NoPresses),
+
         // DRIVEN: the state has to move the same way on both sides, and one lowering cannot show
         // that. Opening a Select and switching an Accordion's open section are the two smallest
         // changes of state that rewrite a subtree.

--- a/tests/eQuantic.UI.Web.Tests/ComponentParityFixtureTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/ComponentParityFixtureTests.cs
@@ -65,6 +65,7 @@ public class ComponentParityFixtureTests
         ("divider-vertical", new Divider(DividerInset.None, DividerAxis.Vertical), NoPresses),
         ("banner", new Banner(Variant.Destructive, "Careful", "Something needs attention"), NoPresses),
         ("stepper", new Stepper(3), NoPresses),
+        ("stepper-labelled", new Stepper(3) { Label = "quantity" }, NoPresses),
         ("pagination", new Pagination(5, 2), NoPresses),
         ("page-indicator", new PageIndicator(4, 1), NoPresses),
         ("tooltip", new Tooltip(new Text("hover", TypeRole.BodyM, Theme.TextPrimary), "the tip"), NoPresses),


### PR DESCRIPTION
Letting the instruments run until they stop finding things — which first meant letting them reach
further, because a dry instrument and an exhausted one look identical from the outside.

## The generator was exhausted, not satisfied

3600 fresh programs found nothing. Not because the compiler is right: because the grammar knew
`int`, `bool`, `string` and arrays of int, and had **never once written a `long`, a `decimal`, a
`char`, an enum, a nullable, a record or a pattern** — precisely where every divergence this month
has lived.

It writes all of them now, with the statements that drive them: a switch expression over an enum, a
property pattern binding through a record, a record compared by value, `is int x` on a nullable.

Two of the first findings were the **generator's own**, and both are worth recording:

- Pattern variables took a fixed name, so two of those statements in one block was CS0128 — the
  generator failing to compile its own program.
- The observable fold overflowed an int once the grammar grew. That is a **documented** divergence
  pinned elsewhere, so reaching it would make every program fail for the one reason this instrument
  exists not to hunt. The fold stays inside an int now.

Widened and fixed: **6000 programs, nothing**. That is dry rather than exhausted.

## Parity: 12 components → 31

Badge, card, checkbox, chip, divider, banner, stepper, pagination, page indicator, tooltip, tabs,
search field, text input, radio group, empty state and their variants. **Eighteen of the nineteen
agree tree for tree on the first run**, which is the good news in this PR.

## The nineteenth, recorded rather than hidden

`text-input`'s empty helper line gets a text node from the twin and **no child at all** from C#, so
the client's tree carries one node the server's HTML does not. That is the shape the forms work
already met once — an empty SSR text the reconciler never filled — and fixing it is a hydration
decision inside `TextInput`, which is someone else's open work right now (#11 is in that file's
neighbourhood).

`KNOWN_DIVERGENCES` holds it with the reason, **still runs it**, and asserts that it still differs:
the day it starts agreeing, the suite fails and the entry comes out. The list can only shrink.

## What is excluded, and why it is not convenience

Client-only handlers — focus, blur, input, paste, cut, copy, keydown. `lowerTextEntry` states that
it produces "identical DOM to the C# SSR realizer, **plus** the client-only handlers", because the
server sends markup and the client attaches behaviour. Comparing them would fail on a difference
the product intends; the twin's own specs hold them.

## Verification

Conformance 1067, Web 496, Compiler 784, vitest 835, tsc 0, eslint clean.