### PR TITLE
🔧 chore: 0.2.0-preview.40

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.39</Version>
+        <Version>0.2.0-preview.40</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
Six PRs since `v0.2.0-preview.39`, and the shape of them is worth reading: five of the six are
things nobody reported, found by instruments built for the purpose.

## What consumers get

**Crashes and wrong answers**

- A nullable date compared **threw** instead of answering. `DateTime`, `DateOnly`, `TimeOnly`,
  `TimeSpan` and `DateTimeOffset` are runtime classes here, so `==` became `left.equals(right)`
  whatever the operands were — while C# LIFTS those comparisons and simply answers. Nothing in the
  source reads as dangerous, which is why it survived until a page rendered on the server and died
  on hydration (#15).
- A `Stepper` with no label announced `"Decrease "` to a screen reader — trailing space, and a
  control name that says what the button does to nothing in particular (#14).
- A text entry sat at the top of its box, and autofill painted over it (#11).
- A 404 in a prefixed language redirected to itself instead of being a 404 (#10).

**New capability**

- The Calendar, a month at a time, over the grid vocabulary (#12).

**Faster**

- The semantic model is asked once per node instead of six times: 240,826 queries became 60,776,
  and warm compilation of the framework's own components went 2.8 s → 2.4 s (#13).

## Instruments, which is where five of the six came from

- The differential generator learned the compat types — `long`, `decimal`, `char`, enums,
  nullables, records, patterns. It had never written any of them, which is exactly where the
  divergences live; 6000 programs on the widened grammar now come back clean (#14).
- Component parity went from 12 components to 31, comparing the lowered tree on both sides
  including after a press (#14).
- The compiler has a perf harness at all, for the first time (#13).

## Not in this PR

The tag. Merging lands the version; `v0.2.0-preview.40` is pushed afterwards and is what triggers
publication.