### PR TITLE
🐛 fix: two types of one name are a build error, not a file that overwrites the other

### DIFF
--- a/src/eQuantic.Build/Program.cs
+++ b/src/eQuantic.Build/Program.cs
@@ -378,13 +378,17 @@ bool CompileAndBundle()
                         // name write the same file and the second wins. Nothing said so: C# is
                         // happy — the namespaces differ — and the page died in the browser with
                         // the OTHER type's fields, which is the worst way to learn.
-                        if (written.Claim(result.ComponentName, file, result.TypeScript,
-                                path => Path.GetRelativePath(dir, path)) is { } collision)
+                        var claim = written.Claim(result.ComponentName, file, result.TypeScript,
+                            path => Path.GetRelativePath(dir, path), out var collision);
+                        if (claim == eQuantic.UI.Compiler.Services.TwinClaim.Collision)
                         {
                             Console.Error.WriteLine($"{file}(1,1): error EQ1005: {collision}");
                             hasErrors = true;
                             continue;
                         }
+                        // The same module already on disk: writing it again would rewrite its map
+                        // with one pointing at a different C# file.
+                        if (claim == eQuantic.UI.Compiler.Services.TwinClaim.Repeat) continue;
 
                         File.WriteAllText(tsPath, result.TypeScript);
                         

--- a/src/eQuantic.Build/Program.cs
+++ b/src/eQuantic.Build/Program.cs
@@ -323,6 +323,8 @@ bool CompileAndBundle()
     try
     {
         var hasErrors = false;
+        // Which names are already taken — see EmittedTwins for why a name collision is an error.
+        var written = new eQuantic.UI.Compiler.Services.EmittedTwins();
         var entryPoints = new List<string>();
         
         if (!Directory.Exists(intermediateDir)) Directory.CreateDirectory(intermediateDir);
@@ -371,6 +373,19 @@ bool CompileAndBundle()
                     if (result.Success)
                     {
                         var tsPath = Path.Combine(intermediateDir, $"{result.ComponentName}.ts");
+
+                        // A twin is named for its TYPE, not its namespace, so two types with one
+                        // name write the same file and the second wins. Nothing said so: C# is
+                        // happy — the namespaces differ — and the page died in the browser with
+                        // the OTHER type's fields, which is the worst way to learn.
+                        if (written.Claim(result.ComponentName, file, result.TypeScript,
+                                path => Path.GetRelativePath(dir, path)) is { } collision)
+                        {
+                            Console.Error.WriteLine($"{file}(1,1): error EQ1005: {collision}");
+                            hasErrors = true;
+                            continue;
+                        }
+
                         File.WriteAllText(tsPath, result.TypeScript);
                         
                         if (!string.IsNullOrEmpty(result.SourceMap))

--- a/src/eQuantic.UI.Compiler/Services/EmittedTwins.cs
+++ b/src/eQuantic.UI.Compiler/Services/EmittedTwins.cs
@@ -14,7 +14,12 @@ namespace eQuantic.UI.Compiler.Services;
 /// </summary>
 public sealed class EmittedTwins
 {
-    private readonly Dictionary<string, (string Source, string TypeScript)> _written = new(StringComparer.Ordinal);
+    // Keyed the way a FILESYSTEM is, not the way C# is. `Seat` and `seat` are two types to the
+    // language and one file to Windows and to macOS as it ships — so an ordinal key would let the
+    // second overwrite the first on the machines most people build on, and pass on Linux. A source
+    // tree has to build the same everywhere, so the case-only pair is refused too.
+    private readonly Dictionary<string, (string Name, string Source, string TypeScript)> _written =
+        new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Records a twin about to be written, and answers the error when its name is already taken by
@@ -31,13 +36,17 @@ public sealed class EmittedTwins
             var other = first.Source == source
                 ? "another type of the same name in this file"
                 : $"the one in '{describeSource(first.Source)}'";
-            return $"two types are named '{name}' — this one and {other}. Their twins are ONE "
-                + "file, and the second would silently replace the first: the code that used one "
-                + "would get the other's members. Namespaces do not separate them, because a twin "
-                + "is named for its TYPE. Rename one of them.";
+            var named = first.Name == name
+                ? $"two types are named '{name}'"
+                : $"'{name}' and '{first.Name}' differ only in case, and a filename on Windows and "
+                  + "on macOS does not";
+            return $"{named} — this one and {other}. Their twins are ONE file, and the second "
+                + "would silently replace the first: the code that used one would get the other's "
+                + "members. Namespaces do not separate them, because a twin is named for its TYPE. "
+                + "Rename one of them.";
         }
 
-        _written[name] = (source, typeScript);
+        _written[name] = (name, source, typeScript);
         return null;
     }
 }

--- a/src/eQuantic.UI.Compiler/Services/EmittedTwins.cs
+++ b/src/eQuantic.UI.Compiler/Services/EmittedTwins.cs
@@ -22,31 +22,53 @@ public sealed class EmittedTwins
         new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Records a twin about to be written, and answers the error when its name is already taken by
-    /// a DIFFERENT twin. Compared by CONTENT rather than by source path: two types of one name in
-    /// the same file collide just as surely as two in different files, and a type legitimately
-    /// emitted twice writes the same bytes and is not a collision at all.
+    /// Records a twin about to be written and says what the writer should do with it.
     /// </summary>
-    /// <returns>Null when the name is free (or re-emitting the same twin); the message otherwise.</returns>
-    public string? Claim(string name, string source, string typeScript, Func<string, string> describeSource)
+    /// <remarks>
+    /// Compared by CONTENT rather than by source path: two types of one name in the same file
+    /// collide just as surely as two in different files, and a type that reaches the writer twice
+    /// with the same bytes is not a collision at all. That repeat is a <see cref="TwinClaim.Repeat"/>
+    /// rather than a second write, because the SOURCE MAP is not identical even when the module
+    /// is — it embeds the path and content of the C# it came from, so writing it again would leave
+    /// the module mapped to the wrong file and send a debugger to the wrong line.
+    /// </remarks>
+    public TwinClaim Claim(string name, string source, string typeScript, Func<string, string> describeSource,
+        out string? error)
     {
-        if (_written.TryGetValue(name, out var first))
+        error = null;
+        if (!_written.TryGetValue(name, out var first))
         {
-            if (first.TypeScript == typeScript) return null;
-            var other = first.Source == source
-                ? "another type of the same name in this file"
-                : $"the one in '{describeSource(first.Source)}'";
-            var named = first.Name == name
-                ? $"two types are named '{name}'"
-                : $"'{name}' and '{first.Name}' differ only in case, and a filename on Windows and "
-                  + "on macOS does not";
-            return $"{named} — this one and {other}. Their twins are ONE file, and the second "
-                + "would silently replace the first: the code that used one would get the other's "
-                + "members. Namespaces do not separate them, because a twin is named for its TYPE. "
-                + "Rename one of them.";
+            _written[name] = (name, source, typeScript);
+            return TwinClaim.Fresh;
         }
 
-        _written[name] = (name, source, typeScript);
-        return null;
+        if (first.TypeScript == typeScript) return TwinClaim.Repeat;
+
+        var other = first.Source == source
+            ? "another type of the same name in this file"
+            : $"the one in '{describeSource(first.Source)}'";
+        var named = first.Name == name
+            ? $"two types are named '{name}'"
+            : $"'{name}' and '{first.Name}' differ only in case, and a filename on Windows and "
+              + "on macOS does not";
+        error = $"{named} — this one and {other}. Their twins are ONE file, and the second "
+            + "would silently replace the first: the code that used one would get the other's "
+            + "members. Namespaces do not separate them, because a twin is named for its TYPE. "
+            + "Rename one of them.";
+        return TwinClaim.Collision;
     }
+}
+
+/// <summary>What the writer should do with a twin it is about to write.</summary>
+public enum TwinClaim
+{
+    /// <summary>The name was free: write the module and its map.</summary>
+    Fresh,
+
+    /// <summary>The same module, already written. Writing it again would rewrite its map with one
+    /// that points at a different C# file — skip it.</summary>
+    Repeat,
+
+    /// <summary>A different type wants a name that is taken. The build stops; see the error.</summary>
+    Collision,
 }

--- a/src/eQuantic.UI.Compiler/Services/EmittedTwins.cs
+++ b/src/eQuantic.UI.Compiler/Services/EmittedTwins.cs
@@ -1,0 +1,43 @@
+namespace eQuantic.UI.Compiler.Services;
+
+/// <summary>
+/// Which twin has already been written under which NAME. A twin's file is named for its type —
+/// <c>BenchSeat.ts</c> — and nothing else, so two types called <c>BenchSeat</c> in different
+/// namespaces are one file, and the second silently replaces the first.
+/// <para>
+/// C# is perfectly happy with them: the namespaces separate the types. The failure arrives in the
+/// browser, where the code that constructed one gets the other's members — a component that dies
+/// on a field the class does not have, with nothing in the build to suggest why. This makes it a
+/// build ERROR instead, which is the whole of the fix: the compiler refuses what it cannot
+/// represent rather than picking one.
+/// </para>
+/// </summary>
+public sealed class EmittedTwins
+{
+    private readonly Dictionary<string, (string Source, string TypeScript)> _written = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Records a twin about to be written, and answers the error when its name is already taken by
+    /// a DIFFERENT twin. Compared by CONTENT rather than by source path: two types of one name in
+    /// the same file collide just as surely as two in different files, and a type legitimately
+    /// emitted twice writes the same bytes and is not a collision at all.
+    /// </summary>
+    /// <returns>Null when the name is free (or re-emitting the same twin); the message otherwise.</returns>
+    public string? Claim(string name, string source, string typeScript, Func<string, string> describeSource)
+    {
+        if (_written.TryGetValue(name, out var first))
+        {
+            if (first.TypeScript == typeScript) return null;
+            var other = first.Source == source
+                ? "another type of the same name in this file"
+                : $"the one in '{describeSource(first.Source)}'";
+            return $"two types are named '{name}' — this one and {other}. Their twins are ONE "
+                + "file, and the second would silently replace the first: the code that used one "
+                + "would get the other's members. Namespaces do not separate them, because a twin "
+                + "is named for its TYPE. Rename one of them.";
+        }
+
+        _written[name] = (source, typeScript);
+        return null;
+    }
+}

--- a/tests/eQuantic.UI.Compiler.Tests/EmittedTwinsTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/EmittedTwinsTests.cs
@@ -51,6 +51,24 @@ public class EmittedTwinsTests
         twins.Claim("Seat", "Other.cs", module, Here).Should().BeNull();
     }
 
+    /// <summary>`Seat` and `seat` are two types to C# and ONE file to Windows and to macOS as it
+    /// ships. Keying by ordinal would let the second overwrite the first on the machines most
+    /// people build on and pass on Linux, which is worse than either — a source tree has to build
+    /// the same everywhere.</summary>
+    [Fact]
+    public void NamesDifferingOnlyInCase_AreRefused_BecauseAFilenameDoesNotCare()
+    {
+        var twins = new EmittedTwins();
+        twins.Claim("Seat", "a.cs", "class Seat {}", Here).Should().BeNull();
+
+        var collision = twins.Claim("seat", "b.cs", "class seat {}", Here);
+
+        collision.Should().NotBeNull();
+        collision.Should().Contain("differ only in case",
+            "the message must say WHY two different names collide, or it reads as a compiler bug");
+        collision.Should().Contain("'seat'").And.Contain("'Seat'");
+    }
+
     [Fact]
     public void DifferentNames_NeverCollide()
     {

--- a/tests/eQuantic.UI.Compiler.Tests/EmittedTwinsTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/EmittedTwinsTests.cs
@@ -20,9 +20,9 @@ public class EmittedTwinsTests
     public void TwoTypesOfOneName_InDifferentFiles_AreRefused()
     {
         var twins = new EmittedTwins();
-        twins.Claim("BenchSeat", "Sections/Bench.cs", "class BenchSeat { a }", Here).Should().BeNull();
+        twins.Claim("BenchSeat", "Sections/Bench.cs", "class BenchSeat { a }", Here, out _).Should().Be(TwinClaim.Fresh);
 
-        var collision = twins.Claim("BenchSeat", "Pages/Bench.cs", "class BenchSeat { b }", Here);
+        twins.Claim("BenchSeat", "Pages/Bench.cs", "class BenchSeat { b }", Here, out var collision).Should().Be(TwinClaim.Collision);
 
         collision.Should().NotBeNull();
         collision.Should().Contain("BenchSeat").And.Contain("Sections/Bench.cs");
@@ -33,10 +33,11 @@ public class EmittedTwinsTests
     public void TwoTypesOfOneName_InTheSameFile_AreRefusedToo()
     {
         var twins = new EmittedTwins();
-        twins.Claim("Seat", "Bench.cs", "class Seat { a }", Here).Should().BeNull();
+        twins.Claim("Seat", "Bench.cs", "class Seat { a }", Here, out _).Should().Be(TwinClaim.Fresh);
 
-        twins.Claim("Seat", "Bench.cs", "class Seat { b }", Here)
-            .Should().Contain("another type of the same name in this file");
+        twins.Claim("Seat", "Bench.cs", "class Seat { b }", Here, out var same)
+            .Should().Be(TwinClaim.Collision);
+        same.Should().Contain("another type of the same name in this file");
     }
 
     [Fact]
@@ -46,9 +47,11 @@ public class EmittedTwinsTests
         // refusing that would fail builds that were never broken.
         var twins = new EmittedTwins();
         var module = "class Seat { a }";
-        twins.Claim("Seat", "Bench.cs", module, Here).Should().BeNull();
-        twins.Claim("Seat", "Bench.cs", module, Here).Should().BeNull();
-        twins.Claim("Seat", "Other.cs", module, Here).Should().BeNull();
+        twins.Claim("Seat", "Bench.cs", module, Here, out _).Should().Be(TwinClaim.Fresh);
+        // REPEAT, not Fresh: the writer must skip it. The module is identical but its source map
+        // is not — that embeds the C# path, so rewriting it would map the module to another file.
+        twins.Claim("Seat", "Bench.cs", module, Here, out _).Should().Be(TwinClaim.Repeat);
+        twins.Claim("Seat", "Other.cs", module, Here, out _).Should().Be(TwinClaim.Repeat);
     }
 
     /// <summary>`Seat` and `seat` are two types to C# and ONE file to Windows and to macOS as it
@@ -59,9 +62,9 @@ public class EmittedTwinsTests
     public void NamesDifferingOnlyInCase_AreRefused_BecauseAFilenameDoesNotCare()
     {
         var twins = new EmittedTwins();
-        twins.Claim("Seat", "a.cs", "class Seat {}", Here).Should().BeNull();
+        twins.Claim("Seat", "a.cs", "class Seat {}", Here, out _).Should().Be(TwinClaim.Fresh);
 
-        var collision = twins.Claim("seat", "b.cs", "class seat {}", Here);
+        twins.Claim("seat", "b.cs", "class seat {}", Here, out var collision).Should().Be(TwinClaim.Collision);
 
         collision.Should().NotBeNull();
         collision.Should().Contain("differ only in case",
@@ -73,8 +76,8 @@ public class EmittedTwinsTests
     public void DifferentNames_NeverCollide()
     {
         var twins = new EmittedTwins();
-        twins.Claim("Seat", "a.cs", "class Seat {}", Here).Should().BeNull();
-        twins.Claim("Bench", "b.cs", "class Bench {}", Here).Should().BeNull();
+        twins.Claim("Seat", "a.cs", "class Seat {}", Here, out _).Should().Be(TwinClaim.Fresh);
+        twins.Claim("Bench", "b.cs", "class Bench {}", Here, out _).Should().Be(TwinClaim.Fresh);
     }
 
     /// <summary>The shape the site actually hit: two records of one name, different members. The

--- a/tests/eQuantic.UI.Compiler.Tests/EmittedTwinsTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/EmittedTwinsTests.cs
@@ -1,0 +1,78 @@
+using eQuantic.UI.Compiler;
+using eQuantic.UI.Compiler.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace eQuantic.UI.Compiler.Tests;
+
+/// <summary>
+/// A twin's file is named for its TYPE and nothing else, so two types of one name are one file and
+/// the second replaces the first. C# is happy — the namespaces separate them — and the failure
+/// arrives in the browser as a component dying on a field its class does not have. Reported by the
+/// site, which met it with two `record BenchSeat` in different namespaces and spent the debugging
+/// on a runtime error whose cause was a build that had quietly dropped a file.
+/// </summary>
+public class EmittedTwinsTests
+{
+    private static string Here(string path) => path;
+
+    [Fact]
+    public void TwoTypesOfOneName_InDifferentFiles_AreRefused()
+    {
+        var twins = new EmittedTwins();
+        twins.Claim("BenchSeat", "Sections/Bench.cs", "class BenchSeat { a }", Here).Should().BeNull();
+
+        var collision = twins.Claim("BenchSeat", "Pages/Bench.cs", "class BenchSeat { b }", Here);
+
+        collision.Should().NotBeNull();
+        collision.Should().Contain("BenchSeat").And.Contain("Sections/Bench.cs");
+        collision.Should().Contain("named for its TYPE", "the message has to say WHY namespaces do not help");
+    }
+
+    [Fact]
+    public void TwoTypesOfOneName_InTheSameFile_AreRefusedToo()
+    {
+        var twins = new EmittedTwins();
+        twins.Claim("Seat", "Bench.cs", "class Seat { a }", Here).Should().BeNull();
+
+        twins.Claim("Seat", "Bench.cs", "class Seat { b }", Here)
+            .Should().Contain("another type of the same name in this file");
+    }
+
+    [Fact]
+    public void TheSameTwinEmittedTwice_IsNotACollision()
+    {
+        // Compared by CONTENT: a type that reaches the writer twice writes the same bytes, and
+        // refusing that would fail builds that were never broken.
+        var twins = new EmittedTwins();
+        var module = "class Seat { a }";
+        twins.Claim("Seat", "Bench.cs", module, Here).Should().BeNull();
+        twins.Claim("Seat", "Bench.cs", module, Here).Should().BeNull();
+        twins.Claim("Seat", "Other.cs", module, Here).Should().BeNull();
+    }
+
+    [Fact]
+    public void DifferentNames_NeverCollide()
+    {
+        var twins = new EmittedTwins();
+        twins.Claim("Seat", "a.cs", "class Seat {}", Here).Should().BeNull();
+        twins.Claim("Bench", "b.cs", "class Bench {}", Here).Should().BeNull();
+    }
+
+    /// <summary>The shape the site actually hit: two records of one name, different members. The
+    /// compiler emits both — it is the FILE they land in that is shared.</summary>
+    [Fact]
+    public void TheCompilerEmitsBothTypes_WhichIsWhyTheWriterHasToRefuse()
+    {
+        const string source = """
+            namespace App.Sections { public sealed record BenchSeat(string Label, int Row, string Tone); }
+            namespace App.Pages { public sealed record BenchSeat(string Name, bool Taken); }
+            """;
+        var results = new ComponentCompiler().CompileSource(source, "Bench.cs").ToList();
+
+        results.Should().HaveCount(2);
+        results.Select(r => r.ComponentName).Should().AllBe("BenchSeat");
+        results[0].TypeScript.Should().NotBe(results[1].TypeScript,
+            "they are different types — which is exactly what makes one file wrong");
+    }
+}


### PR DESCRIPTION
Reported by the site session, which met it for real.

## The failure

A twin's file is named for its **type** and nothing else — `BenchSeat.ts` — so two types called
`BenchSeat` in different namespaces are **one file**, and the second silently replaces the first.

C# is perfectly happy: the namespaces separate them, the project compiles, every test passes. The
failure arrives in the browser, where the code that constructed one gets the **other's members** —
a component dying on a field its class does not have, with nothing in the build to suggest why. The
site spent its debugging on a runtime error whose cause was a build that had quietly dropped a
file, and got out by renaming the record.

## The fix

`EQ1005` refuses it, naming both sources.

Compared by **content** rather than by path, which covers the two cases a path check gets wrong in
opposite directions: two types of one name in the **same file** collide just as surely, and a type
that reaches the writer twice writes the same bytes and is not a collision at all.

The rule lives in the compiler (`EmittedTwins`) rather than inline in the build tool, because
nothing references the build tool from a test project — a rule with no net is a rule only until
someone edits it.

## Why a diagnostic and not disambiguation

The site suggested a diagnostic and that is the right call. Naming twins by namespace instead would
change every import in every module, for a collision whose honest answer is to rename one type.

## The net

Five cases, including the shape the site actually hit: **the compiler emits BOTH types**, which is
precisely why the writer has to be the one to refuse.

## Verification

Compiler 789, Conformance 1114, Web 511, Server 133, Design 103.