### PR TITLE
🐛 fix: the emitted TypeScript says what the runtime actually hands over

### DIFF
--- a/src/eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
@@ -118,6 +118,31 @@ public class TypeScriptEmitter
     /// import candidates, or the module loads into "Todo is not defined".</summary>
     private readonly HashSet<string> _hydrationReferences = new();
 
+    /// <summary>The runtime class a C# KEYWORD annotates as. <c>decimal</c> is the only one: every
+    /// other runtime-backed type is spelled the same in both languages, so the type scan sees the
+    /// name in the syntax and routes the import itself. This one the TRANSLATION invents, and a
+    /// name no walk can see is a name no import covers.</summary>
+    private const string Decimal = "Decimal";
+
+    /// <summary>Runtime names an ANNOTATION introduced — same contract as
+    /// <see cref="_hydrationReferences"/>, and merged into the import candidates beside it.</summary>
+    private readonly HashSet<string> _annotationReferences = new();
+
+    /// <summary>The TS annotation for a C# type, registering any runtime class the mapping names.
+    /// Every emitting call site goes through here rather than the static mapper, so a translated
+    /// name cannot reach the output without its import.</summary>
+    private string Annotate(string? csharpType)
+    {
+        var ts = CSharpTypeToTypeScript(csharpType);
+        // The name can arrive wrapped — `Decimal[]`, `Decimal | null`, `Map<string, Decimal>` — so
+        // the test is on the IDENTIFIERS the annotation is made of, not on the whole string.
+        foreach (var name in System.Text.RegularExpressions.Regex.Matches(ts, "[A-Za-z_][A-Za-z0-9_]*"))
+        {
+            if (name.ToString() == Decimal) _annotationReferences.Add(Decimal);
+        }
+        return ts;
+    }
+
     private void EmitHydrationMap(TypeScriptCodeBuilder.ClassBuilder c,
         IEnumerable<(string Key, TypeSyntax? Type)> fields)
     {
@@ -238,6 +263,7 @@ public class TypeScriptEmitter
         // pins a syntax tree per entry and used to survive this point (see ConversionContext.Reset).
         _converter.Reset();
         _hydrationReferences.Clear();
+        _annotationReferences.Clear();
         component.UsedHelpers.Clear();
 
         // Note: We'll emit imports AFTER generating component code
@@ -535,9 +561,9 @@ public class TypeScriptEmitter
                 foreach (var action in component.ServerActions)
                 {
                     ClassBuilder = c;
-                    var paramsList = string.Join(", ", action.Parameters.Select(p => Param(p.Name, CSharpTypeToTypeScript(p.Type))));
+                    var paramsList = string.Join(", ", action.Parameters.Select(p => Param(p.Name, Annotate(p.Type))));
                     var argsList = string.Join(", ", action.Parameters.Select(p => p.Name));
-                    var returnType = CSharpTypeToTypeScript(action.ReturnType);
+                    var returnType = Annotate(action.ReturnType);
 
                     // The action's RESULT crosses the typed boundary too: a Task<decimal> arrives
                     // as a string, a Task<List<Todo>> as plain objects — hydrated ONCE here, by
@@ -679,6 +705,7 @@ public class TypeScriptEmitter
         // Types a HYDRATION SPEC names — see _hydrationReferences: emitted into the body, present
         // in no syntax the walks above cover.
         foreach (var t in _hydrationReferences) componentTypes.Add(t);
+        foreach (var t in _annotationReferences) componentTypes.Add(t);
 
         // Types the CONVERSION introduced into the output (extension calls reduced to
         // `Class.method(...)`) — invisible to every syntax walk above by construction.
@@ -1069,7 +1096,7 @@ public class TypeScriptEmitter
             // Typed fields
             foreach (var field in component.StateFields)
             {
-                var tsType = CSharpTypeToTypeScript(field.Type);
+                var tsType = Annotate(field.Type);
                 // A compat-typed field must DEFAULT to its runtime type (0n, dec(0)) — the default
                 // is also the witness legacy hydration reads a field's type from.
                 var tsDefault = field.DefaultValueNode != null
@@ -1139,7 +1166,7 @@ public class TypeScriptEmitter
     /// </summary>
     private string DeclarationType(ComponentDefinition component, string? csharpType)
     {
-        var ts = CSharpTypeToTypeScript(csharpType);
+        var ts = Annotate(csharpType);
 
         // Structural forms (`X[]`, `(a: X) => void`, `Record<…>`) are only as resolvable as their parts;
         // keep them only when every bare identifier they mention resolves.
@@ -1743,7 +1770,7 @@ public class TypeScriptEmitter
         // `global::Ns.Thing`, and comparing the mapper's output to the raw text would call every
         // qualified name "translated" and skip the enum/interface handling below.
         var askedName = NormalizeQualification(asked.ToString());
-        var mapped = CSharpTypeToTypeScript(askedName);
+        var mapped = Annotate(askedName);
         var echoed = mapped == askedName;
 
         var resolvedRaw = (_semanticModel?.GetSymbolInfo(asked).Symbol as ITypeSymbol)
@@ -2007,7 +2034,7 @@ public class TypeScriptEmitter
         // `onInit` at all, so the override landed on nothing. The legacy `onInit` is also skipped
         // for any page that HYDRATED, which is every server-rendered page there is.
         
-        var returnType = CSharpTypeToTypeScript(method.ReturnType ?? "void");
+        var returnType = Annotate(method.ReturnType ?? "void");
         
         // async is a MODIFIER, not a return type: `async void` handlers (the C# event-handler
         // idiom — hover intent timers et al.) must emit `async` too, or their awaits are syntax
@@ -2153,7 +2180,13 @@ public class TypeScriptEmitter
         string tsType = baseType switch
         {
             "string" or "char" => "string",
-            "int" or "long" or "double" or "float" or "decimal" or "number" => "number",
+            "int" or "double" or "float" or "number" => "number",
+            // NOT `number`, either of them. A long is a JS bigint on this side and a decimal is the
+            // runtime's Decimal class — `$eq.num.long(0)` and `$eq.num.dec(0)` are what the emitter
+            // writes for their literals, and a `number` annotation over either is a lie the rest of
+            // the file then typechecks against: `unit.mul(...)` on a "number" is the shape it takes.
+            "long" => "bigint",
+            "decimal" => Decimal,
             "bool" or "boolean" => "boolean",
             "void" => "void",
             "object" => "any",

--- a/src/eQuantic.UI.Runtime/src/core/types.ts
+++ b/src/eQuantic.UI.Runtime/src/core/types.ts
@@ -3,6 +3,7 @@
  */
 
 export interface IComponent {
+
   id?: string;
   className?: string;
   style?: Record<string, string>;
@@ -84,12 +85,24 @@ export type ServiceProvider = {
  * Base class for all components
  */
 /**
+ * TYPE-ONLY, and that is the whole reason it is allowed to point at the vocabulary: `import type`
+ * is erased before anything runs, so it adds no edge to the evaluation graph and cannot reopen the
+ * cycle the seam below exists to avoid. Dropping the `type` keyword would.
+ *
+ * It earns its place by making the hierarchy say what C# says — `UiComponent : VisualNode` — so a
+ * component is assignable to a VisualNode on this side too. Without it `centered()` answered
+ * `unknown`, which is assignable to nothing, and eqc's own `VisualNode x = new SomeComponent()`
+ * emitted TypeScript that did not typecheck.
+ */
+import type { VisualNode } from '../shared/vocabulary';
+
+/**
  * How a node is CENTRED, registered by the vocabulary at import time. Inverted rather than
  * imported: a static import here would close a module cycle (types → vocabulary → types) at
  * evaluation, and a lazy `require` does not exist in ESM. The vocabulary owns the wrapper's
  * shape; this module only owns the seam.
  */
-type CenterWrapper = (child: unknown) => unknown;
+type CenterWrapper = (child: unknown) => VisualNode;
 let centerWrapper: CenterWrapper | null = null;
 export function setCenterWrapper(wrapper: CenterWrapper): void {
   centerWrapper = wrapper;
@@ -103,8 +116,11 @@ export abstract class Component implements IComponent {
    * "centered is not a function" and a blank frame. The wrapper is built through the ambient
    * lowering rather than imported, so this base keeps no dependency on the vocabulary module.
    */
-  centered(): unknown {
-    return centerWrapper ? centerWrapper(this) : this;
+  centered(): VisualNode {
+    // No vocabulary registered means nothing to wrap WITH — a client-only mount before the
+    // vocabulary module has evaluated. The node comes back unchanged, which is the same object
+    // the caller already held, so the cast states what is already true of every caller's value.
+    return centerWrapper ? centerWrapper(this) : (this as unknown as VisualNode);
   }
 
   id?: string;

--- a/src/eQuantic.UI.Runtime/src/shared/code-editor.spec.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/code-editor.spec.ts
@@ -8,6 +8,7 @@
  * to, the two targets would have started to drift.
  */
 
+import type { VisualNode } from './vocabulary';
 import { describe, expect, it } from 'vitest';
 import { photonTheme } from './design-system.generated';
 import { lowerVisualNode } from './lowering';
@@ -281,12 +282,41 @@ describe('components centre like nodes', () => {
   it('a component exposes centered() the way the vocabulary does', async () => {
     const { Card } = await import('./components/Card');
     const { Text } = await import('./vocabulary');
-    const centred = new Card(new Text('hi') as never).centered() as {
+    // A Row, which the vocabulary types as a VisualNode — so this reads the two fields a Row
+    // carries and the base does not. The cast used to be free because `centered()` answered
+    // `unknown`; it now answers VisualNode, and going through `unknown` is the honest way to say
+    // "the concrete node, not the base".
+    const centred = new Card(new Text('hi') as never).centered() as unknown as {
       nodeKind: string;
       children: unknown[];
     };
     expect(centred.nodeKind).toBe('row');
     expect(centred.children).toHaveLength(1);
+  });
+
+  it('a stateful component IS a VisualNode, the way C# says it is', async () => {
+    const { TimePicker } = await import('./components/TimePicker');
+
+    // A TYPE-level pin, and the assertion below is almost beside the point: what this case guards
+    // is that the LINE COMPILES. In C# `UiComponent` derives from `VisualNode`, so eqc emits
+    // `let x: VisualNode = new SomeComponent()` verbatim — and until `centered()` stopped
+    // answering `unknown`, which is assignable to nothing, that emission did not typecheck. The
+    // failure comes from `tsc`, never from a run, which is why it went unnoticed until the first
+    // component was assigned to one.
+    const node: VisualNode = new TimePicker();
+    expect(node.nodeKind).toBe('component');
+  });
+
+  it('a STATELESS component is deliberately not one — the absence is the signal', async () => {
+    const { Card } = await import('./components/Card');
+    const { Text } = await import('./vocabulary');
+
+    // Not an oversight, and worth pinning so nobody "fixes" it by moving nodeKind onto the base:
+    // the lowering's default branch IS the mixing seam, and it recognises a web component by its
+    // LACK of a nodeKind, embedding the HtmlNode it renders for itself. Give every component the
+    // field and that routing changes for the whole library — a runtime decision, not a typing one.
+    const card = new Card(new Text('hi') as never) as unknown as { nodeKind?: string };
+    expect(card.nodeKind).toBeUndefined();
   });
 });
 

--- a/src/eQuantic.UI.Runtime/src/shared/code-editor.spec.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/code-editor.spec.ts
@@ -8,16 +8,14 @@
  * to, the two targets would have started to drift.
  */
 
-import type { VisualNode } from './vocabulary';
 import { describe, expect, it } from 'vitest';
 import { photonTheme } from './design-system.generated';
 import { lowerVisualNode } from './lowering';
 import { setPhotonTheme } from './photon-context';
-import { CodeSurface } from './vocabulary';
+import { CodeSurface, Text, type VisualNode } from './vocabulary';
 import { CodeEditorController } from './components/CodeEditorController';
 import { CodeLanguages } from './components/CodeLanguages';
 import { CodeDocument } from './components/CodeDocument';
-import { Text } from './vocabulary';
 import type { HtmlNode } from '../core/types';
 
 setPhotonTheme(photonTheme);

--- a/tests/eQuantic.UI.Compiler.Tests/EmittedTypeSurfaceTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/EmittedTypeSurfaceTests.cs
@@ -1,0 +1,74 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace eQuantic.UI.Compiler.Tests;
+
+/// <summary>
+/// What the emitted TypeScript SAYS a value is, against what the runtime actually hands over.
+/// <para>
+/// An annotation is not decoration here: the transpiled modules are typechecked by the runtime's
+/// own build, and an app's editor reads the generated factory surface. A wrong one is a lie the
+/// rest of the file then typechecks against — the `number` these cases pin used to sit over a
+/// `bigint` and over a class with methods on it, so `unit.mul(...)` was reachable on a "number".
+/// </para>
+/// </summary>
+public class EmittedTypeSurfaceTests
+{
+    [Fact]
+    public void ALongIsABigint_NotANumber()
+    {
+        var ts = TestHelper.ConvertClass("""
+            public long Ticks { get; init; }
+            public long Doubled(long n) => n * 2;
+            """);
+
+        // The literal the emitter writes for the field IS a bigint, and `n * 2` emits `n * 2n`.
+        ts.Should().Contain("ticks: bigint = $eq.num.long(0)");
+        ts.Should().Contain("doubled(n: bigint)");
+        ts.Should().NotContain(": number = $eq.num.long");
+    }
+
+    [Fact]
+    public void ADecimalIsTheRuntimeClass_AndArrivesImported()
+    {
+        var ts = TestHelper.ConvertClass("""
+            public decimal Price { get; init; }
+            public decimal Total(decimal unit, int count) => unit * count;
+            """);
+
+        ts.Should().Contain("price: Decimal = $eq.num.dec(0)");
+        ts.Should().Contain("total(unit: Decimal, count: number)");
+        // The name the TRANSLATION invents — no syntax walk can see it, so the import is the half
+        // of this fix that a mapping change alone would have missed.
+        ts.Should().Contain("import { $eq, Decimal } from \"@equantic/runtime\"");
+    }
+
+    [Fact]
+    public void ADateTimeIsTheRuntimeTicks_NotTheBrowsersDate()
+    {
+        var ts = TestHelper.ConvertClass("""
+            public DateTime When { get; init; }
+            public DateTime Later(DateTime from) => from.AddDays(1);
+            """);
+
+        ts.Should().Contain("later(from: DateTime)");
+        // `Date` on its own, which is a DIFFERENT class — the negative has to stop short of the
+        // name it is a prefix of, or it passes on the very output it is meant to reject.
+        Regex.IsMatch(ts, @":\s*Date(?![A-Za-z])").Should().BeFalse("the JS Date is not this type");
+    }
+
+    [Fact]
+    public void TheWrappingSurvivesTheMapping()
+    {
+        // The name arrives inside arrays and sequences too, and the import has to follow it there.
+        var ts = TestHelper.ConvertClass("""
+            public decimal[] Prices { get; init; } = [];
+            public long[] Stamps { get; init; } = [];
+            """);
+
+        ts.Should().Contain("prices: Decimal[]");
+        ts.Should().Contain("stamps: bigint[]");
+        ts.Should().Contain("Decimal } from \"@equantic/runtime\"");
+    }
+}

--- a/tests/eQuantic.UI.Compiler.Tests/FieldDefaultTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/FieldDefaultTests.cs
@@ -52,10 +52,14 @@ public class FieldDefaultTests
         // No member is zero here: .NET still yields the numeric 0, and so does the twin.
         ts.Should().Contain("_offset: string = 0");
         ts.Should().Contain("_c: string = '\\0'");
-        // Reached through an alias — invisible to a spelled-name table, plain to the symbol.
+        // Reached through an alias — invisible to a spelled-name table, plain to the symbol. The
+        // VALUE is right and the annotation says `any`, which is an absence rather than a claim:
+        // the default path reads the symbol, the annotation path still reads the spelling.
         ts.Should().Contain("_aliased: any = $eq.num.dec(0)");
-        ts.Should().Contain("_n: number = $eq.num.long(0)");
-        ts.Should().Contain("_d: number = $eq.num.dec(0)");
+        // And the annotations that DO carry a claim carry the true one: the literal beside each of
+        // these is a bigint and a Decimal, so `number` was the file disagreeing with itself.
+        ts.Should().Contain("_n: bigint = $eq.num.long(0)");
+        ts.Should().Contain("_d: Decimal = $eq.num.dec(0)");
         ts.Should().Contain("_flag: boolean = false");
         ts.Should().Contain("_i: number = 0");
     }


### PR DESCRIPTION
Two annotations the emitter was getting wrong, both found while fixing `DateTime => Date` in the picker slice and both filed at the time rather than smuggled into that PR.

## `long` is a bigint and `decimal` is a class

The type table said `number` for both. The emitter writes the VALUES too, so one generated file disagreed with itself:

```ts
ticks: number = $eq.num.long(0);
price: number = $eq.num.dec(0);
total(unit: number, count: number) { return unit.mul($eq.num.dec(count)); }
```

`.mul` on a "number". Nothing caught it because no component in `UI.cs` takes either type, so the lie never reached a file the runtime typechecks. It becomes visible the moment an app component does: the generated factory would ask a TypeScript consumer for a `number` where a `bigint` arrives, and those two do not even compare equal.

Now:

```ts
ticks: bigint = $eq.num.long(0);
price: Decimal = $eq.num.dec(0);
total(unit: Decimal, count: number) { return unit.mul($eq.num.dec(count)); }
```

**The mapping is only half of it.** `decimal` is the one case where the translation INVENTS a name: the C# keyword is lowercase, so no type scan can see `Decimal` and no import covers it — the module would have referenced a name it never imported. Annotations now go through a seam that registers the runtime classes they name, beside the one hydration specs already use.

## A component IS a VisualNode, as C# says

`UiComponent : VisualNode` in C#, and not in the twin: `Component.centered()` answered `unknown`, which is assignable to nothing, so eqc's own `VisualNode x = new SomeComponent()` emitted TypeScript that did not compile. The picker slice was the first code that would have assigned one, and was restructured around it.

The seam's comment ruled out importing the vocabulary from `core`, and it is right about a VALUE import — that closes an evaluation cycle. `import type` is erased before anything runs, so it adds no edge to that graph. **The served `runtime.js` is unchanged byte for byte**, which is the proof the change is type-only.

### What deliberately stays out

The stateless bases are still not assignable, and there is now a pin saying so rather than leaving it to be "fixed" later: the lowering's default branch IS the mixing seam, and it recognises a web component by its LACK of a `nodeKind`. I tried moving the field to the base — every component would then carry it, matching C# exactly — and it reroutes the whole library from the mixing seam to the retention path. That is a runtime decision, not a typing one, and not this PR's to make.

## Net

- 4 new emitter cases pinning the long / decimal / DateTime surface, including the wrapped forms (`Decimal[]`, `bigint[]`) and the import.
- One existing pin updated: `FieldDefaultTests` asserted the old `number` annotations, which is exactly what changed.
- A type-level pin that a stateful component assigns to a `VisualNode`, and its twin asserting the stateless case does not.
- Full suites green: 788 compiler, 1114 conformance, 1007 native, 530 web, 894 vitest, `tsc --noEmit` clean.