### PR TITLE
🔧 chore: 0.2.0-preview.41

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.40</Version>
+        <Version>0.2.0-preview.41</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
Seven PRs since `v0.2.0-preview.40`. Six of the seven are fixes, and one of those was a live crash
on the site's home page.

## What consumers get

**A production crash**

- A compat **property** — a `long`, a `decimal`, a date — crossed the hydration boundary as the raw
  JSON it was sent as, because the map covered fields only. The twin declared `bigint`, the payload
  delivered a number, and the first arithmetic threw `Cannot mix BigInt and other types` — after
  hydration, in the browser only, on a page the server had rendered perfectly. The unset case was
  broken too: a fourth copy of "default(T)" answered plain `0` for a `long`. Every date picker's
  `selected`/`min`/`max` was in the same position and would have arrived as an ISO string (#23).

**Silent wrong answers**

- Out of range is an error in .NET and a shrug in JavaScript: `"ab".Substring(9)` answered `""`,
  a missing dictionary key answered `undefined`. Both throw where .NET throws now, and a compound
  or `??=` write reads through the guard first, as the indexer getter does (#18).
- Two types of one name are one twin FILE, and the second silently replaced the first. C# is happy
  — the namespaces differ — and the page died in the browser with the other type's members. A build
  error now, refusing what it cannot represent (#19).
- The emitted TypeScript said things the runtime does not hand over (#20).
- A `Positioned` from a stateless component was laid out in flow instead of placed (#22).
- `Navigator.Go("https://elsewhere/docs")` matched the LOCAL `/docs` and rendered it, because the
  programmatic path matched on pathname alone while the click path checks the origin (#21).

**New capability**

- The three pickers — date, time, and the typed row that is the field rather than an escape (#17).

## Not in this PR

The tag. Merging lands the version; `v0.2.0-preview.41` is pushed afterwards and is what triggers
publication.