### PR TITLE
✅ test: the composites join the parity sweep — 44 components, 1351 nodes

### DIFF
--- a/src/eQuantic.UI.Runtime/src/shared/component-parity.fixture.json
+++ b/src/eQuantic.UI.Runtime/src/shared/component-parity.fixture.json
@@ -2379,6 +2379,1153 @@
       ]
     }
   ],
+  "menu-closed": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-anchorhost"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "span",
+          "attrs": {
+            "aria-expanded": "false",
+            "aria-haspopup": "menu",
+            "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+            "role": "button",
+            "tabindex": "0"
+          },
+          "events": [
+            "click"
+          ],
+          "children": [
+            {
+              "tag": "button",
+              "attrs": {
+                "aria-label": "Open",
+                "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+                "style": "--eq-pressed-bg: light-dark(#00427f, #7cb5ee)"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1o1uad7 eq-1vzw3dm eq-bo3n4y eq-cl6mtg eq-jq1py4 eq-ky45n5 eq-xhcqoy"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-19dgm5h eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "span",
+                          "attrs": {
+                            "class": "eq-16x7aca eq-1cb9own eq-1dakdsg eq-1hwu9wq eq-5goeua eq-epaxs4 eq-jsw0f2 eq-mbtjfn eq-type-label eq-y9mhin"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "#text",
+                              "text": "Open",
+                              "attrs": {},
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "dialog": [
+    {
+      "tag": "div",
+      "attrs": {
+        "aria-label": "Delete this?",
+        "aria-modal": "true",
+        "class": "eq-overlay",
+        "data-eq-trap": "",
+        "role": "dialog",
+        "tabindex": "-1"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1avhl7d eq-1eviv88 eq-1jjc6f6 eq-akjizx eq-presence-fade",
+            "data-eq-exit": "fade"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-19zfii6 eq-1gudvpj eq-1jjc6f6 eq-1pwthtl eq-1w1wt6p eq-5ew4ww eq-akjizx eq-m92pvu eq-mc2xdp"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "button",
+                  "attrs": {
+                    "aria-label": "Dismiss",
+                    "class": "eq-1esejbi eq-1etnzxl eq-1jjc6f6 eq-1uykvw eq-akjizx eq-byqqyj eq-p7nbpw",
+                    "disabled": ""
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-15tkusa eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-5ew4ww eq-akjizx"
+                      },
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-19zfii6 eq-1gudvpj eq-1jjc6f6 eq-1p2uoqo eq-1w1wt6p eq-5ew4ww eq-akjizx eq-m92pvu eq-mc2xdp"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-18qb60o eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-5ew4ww eq-6gdbvu eq-aexooi eq-akjizx eq-ewlixa eq-m92pvu"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1eviv88 eq-1r0rwlh eq-1r3wfu2 eq-1wkm9k4 eq-5ew4ww eq-5hocaj eq-6rsuae eq-akjizx eq-z5ug94"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "class": "eq-11yg588 eq-13t9w9x eq-1eb13m5 eq-5ew4ww eq-aexooi eq-akjizx eq-m92pvu eq-mc2xdp"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "div",
+                              "attrs": {
+                                "class": "eq-11yg588 eq-19dgm5h eq-1eb13m5 eq-aexooi eq-m92pvu eq-mc2xdp"
+                              },
+                              "events": [],
+                              "children": [
+                                {
+                                  "tag": "span",
+                                  "attrs": {
+                                    "class": "eq-7gvrt4 eq-type-title"
+                                  },
+                                  "events": [],
+                                  "children": [
+                                    {
+                                      "tag": "#text",
+                                      "text": "Delete this?",
+                                      "attrs": {},
+                                      "events": [],
+                                      "children": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "tag": "span",
+                                  "attrs": {
+                                    "class": "eq-11mxutl eq-1nj1bb6 eq-h7owsy eq-mbtjfn eq-type-bodym eq-xkrzsg"
+                                  },
+                                  "events": [],
+                                  "children": [
+                                    {
+                                      "tag": "#text",
+                                      "text": "It cannot be undone.",
+                                      "attrs": {},
+                                      "events": [],
+                                      "children": []
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "tag": "div",
+                              "attrs": {
+                                "class": "eq-19dgm5h eq-1eb13m5 eq-1uhnwvg eq-ewlixa eq-hqijl0 eq-m92pvu"
+                              },
+                              "events": [],
+                              "children": [
+                                {
+                                  "tag": "button",
+                                  "attrs": {
+                                    "aria-label": "Cancel",
+                                    "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+                                    "data-eq-initial-focus": "",
+                                    "style": "--eq-pressed-bg: light-dark(#eff1f4, #1c232b)"
+                                  },
+                                  "events": [],
+                                  "children": [
+                                    {
+                                      "tag": "div",
+                                      "attrs": {
+                                        "class": "eq-189q21e eq-1eb13m5 eq-1o1uad7 eq-1vzw3dm eq-bo3n4y eq-cl6mtg eq-xhcqoy"
+                                      },
+                                      "events": [],
+                                      "children": [
+                                        {
+                                          "tag": "div",
+                                          "attrs": {
+                                            "class": "eq-19dgm5h eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu"
+                                          },
+                                          "events": [],
+                                          "children": [
+                                            {
+                                              "tag": "span",
+                                              "attrs": {
+                                                "class": "eq-16x7aca eq-1cb9own eq-1hwu9wq eq-5goeua eq-7gvrt4 eq-epaxs4 eq-jsw0f2 eq-mbtjfn eq-type-label eq-y9mhin"
+                                              },
+                                              "events": [],
+                                              "children": [
+                                                {
+                                                  "tag": "#text",
+                                                  "text": "Cancel",
+                                                  "attrs": {},
+                                                  "events": [],
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "tag": "button",
+                                  "attrs": {
+                                    "aria-label": "Delete",
+                                    "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+                                    "style": "--eq-pressed-bg: light-dark(#00427f, #7cb5ee)"
+                                  },
+                                  "events": [],
+                                  "children": [
+                                    {
+                                      "tag": "div",
+                                      "attrs": {
+                                        "class": "eq-1eb13m5 eq-1o1uad7 eq-1vzw3dm eq-bo3n4y eq-cl6mtg eq-jq1py4 eq-ky45n5 eq-xhcqoy"
+                                      },
+                                      "events": [],
+                                      "children": [
+                                        {
+                                          "tag": "div",
+                                          "attrs": {
+                                            "class": "eq-19dgm5h eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu"
+                                          },
+                                          "events": [],
+                                          "children": [
+                                            {
+                                              "tag": "span",
+                                              "attrs": {
+                                                "class": "eq-16x7aca eq-1cb9own eq-1dakdsg eq-1hwu9wq eq-5goeua eq-epaxs4 eq-jsw0f2 eq-mbtjfn eq-type-label eq-y9mhin"
+                                              },
+                                              "events": [],
+                                              "children": [
+                                                {
+                                                  "tag": "#text",
+                                                  "text": "Delete",
+                                                  "attrs": {},
+                                                  "events": [],
+                                                  "children": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "list-item": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-1dc1azv eq-1eb13m5 eq-5ew4ww eq-akjizx"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-1iu691c eq-1uhnwvg eq-5ew4ww eq-akjizx eq-b97nbe eq-ewlixa eq-m92pvu eq-mc2xdp"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-168ghzj eq-5ew4ww"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-11yg588 eq-1eb13m5 eq-aexooi eq-cjx69j eq-m92pvu eq-mc2xdp"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-16x7aca eq-1xqhk2i eq-5goeua eq-7gvrt4 eq-da01c7 eq-epaxs4 eq-jsw0f2 eq-mbtjfn eq-pbx3g3 eq-type-bodym"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "Title",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-16x7aca eq-1nj1bb6 eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-caption"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "and a subtitle",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "list-view": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-18plna0 eq-1gudvpj eq-1jjc6f6 eq-1k83940 eq-5ew4ww eq-81tj3u"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-11yg588 eq-1eb13m5 eq-5ew4ww eq-aexooi eq-akjizx eq-m92pvu eq-mc2xdp"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "span",
+              "attrs": {
+                "class": "eq-7gvrt4 eq-type-bodym"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "#text",
+                  "text": "row 0",
+                  "attrs": {},
+                  "events": [],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "tag": "span",
+              "attrs": {
+                "class": "eq-7gvrt4 eq-type-bodym"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "#text",
+                  "text": "row 1",
+                  "attrs": {},
+                  "events": [],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "tag": "span",
+              "attrs": {
+                "class": "eq-7gvrt4 eq-type-bodym"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "#text",
+                  "text": "row 2",
+                  "attrs": {},
+                  "events": [],
+                  "children": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "table": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-11yg588 eq-1eb13m5 eq-5ew4ww eq-aexooi eq-akjizx eq-m92pvu eq-mc2xdp"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-5ew4ww eq-7njlci eq-akjizx"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1avhl7d eq-1eb13m5 eq-1iu691c eq-akjizx eq-bg17ym"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "span",
+                  "attrs": {
+                    "class": "eq-16x7aca eq-1nj1bb6 eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-label"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "#text",
+                      "text": "Name",
+                      "attrs": {},
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                },
+                {
+                  "tag": "span",
+                  "attrs": {
+                    "class": "eq-16x7aca eq-1nj1bb6 eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-label"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "#text",
+                      "text": "Size",
+                      "attrs": {},
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-5ew4ww eq-akjizx eq-bo3n4y eq-rx01wr eq-yjvyu6"
+          },
+          "events": [],
+          "children": []
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-189q21e eq-1eb13m5 eq-1x3c6t9 eq-5ew4ww eq-7njlci eq-akjizx"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1avhl7d eq-1eb13m5 eq-1iu691c eq-akjizx eq-bg17ym"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "span",
+                  "attrs": {
+                    "class": "eq-16x7aca eq-5goeua eq-7gvrt4 eq-epaxs4 eq-mbtjfn eq-type-bodym"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "#text",
+                      "text": "a",
+                      "attrs": {},
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                },
+                {
+                  "tag": "span",
+                  "attrs": {
+                    "class": "eq-16x7aca eq-5goeua eq-7gvrt4 eq-epaxs4 eq-mbtjfn eq-type-bodym"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "#text",
+                      "text": "1",
+                      "attrs": {},
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-5ew4ww eq-akjizx eq-bo3n4y eq-rx01wr eq-yjvyu6"
+          },
+          "events": [],
+          "children": []
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-189q21e eq-1eb13m5 eq-1x3c6t9 eq-5ew4ww eq-7njlci eq-akjizx"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1avhl7d eq-1eb13m5 eq-1iu691c eq-akjizx eq-bg17ym"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "span",
+                  "attrs": {
+                    "class": "eq-16x7aca eq-5goeua eq-7gvrt4 eq-epaxs4 eq-mbtjfn eq-type-bodym"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "#text",
+                      "text": "b",
+                      "attrs": {},
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                },
+                {
+                  "tag": "span",
+                  "attrs": {
+                    "class": "eq-16x7aca eq-5goeua eq-7gvrt4 eq-epaxs4 eq-mbtjfn eq-type-bodym"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "#text",
+                      "text": "2",
+                      "attrs": {},
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "data-table": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-11yg588 eq-1eb13m5 eq-5ew4ww eq-aexooi eq-akjizx eq-m92pvu eq-mc2xdp"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-12ve49g eq-1aoicmy eq-1eb13m5 eq-5ew4ww eq-akjizx"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1avhl7d eq-1eb13m5 eq-akjizx eq-kazcmz"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-5ew4ww eq-7njlci eq-akjizx"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-akjizx eq-ewlixa eq-m92pvu eq-mc2xdp"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "class": "eq-1eb13m5 eq-1uhnwvg eq-5ew4ww eq-akjizx eq-ewlixa eq-m7pi4h eq-m92pvu eq-mc2xdp"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "span",
+                              "attrs": {
+                                "class": "eq-16x7aca eq-1xfx61h eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-caption"
+                              },
+                              "events": [],
+                              "children": [
+                                {
+                                  "tag": "#text",
+                                  "text": "NAME",
+                                  "attrs": {},
+                                  "events": [],
+                                  "children": []
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-5ew4ww eq-7njlci eq-akjizx"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-akjizx eq-ewlixa eq-hqijl0 eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "class": "eq-1eb13m5 eq-1uhnwvg eq-5ew4ww eq-akjizx eq-ewlixa eq-hqijl0 eq-m7pi4h eq-m92pvu"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "span",
+                              "attrs": {
+                                "class": "eq-16x7aca eq-1xfx61h eq-5goeua eq-epaxs4 eq-mbtjfn eq-type-caption"
+                              },
+                              "events": [],
+                              "children": [
+                                {
+                                  "tag": "#text",
+                                  "text": "SIZE",
+                                  "attrs": {},
+                                  "events": [],
+                                  "children": []
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-189q21e eq-1aoicmy eq-1eb13m5 eq-1x18l2e eq-5ew4ww eq-akjizx eq-hj6cvq"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1avhl7d eq-1eb13m5 eq-akjizx eq-kazcmz"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-5ew4ww eq-7njlci eq-akjizx"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-akjizx eq-ewlixa eq-m92pvu eq-mc2xdp"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "span",
+                          "attrs": {
+                            "class": "eq-7gvrt4 eq-type-bodym"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "#text",
+                              "text": "alpha",
+                              "attrs": {},
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-5ew4ww eq-7njlci eq-akjizx"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-akjizx eq-ewlixa eq-hqijl0 eq-m92pvu"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "span",
+                          "attrs": {
+                            "class": "eq-7gvrt4 eq-type-bodym"
+                          },
+                          "events": [],
+                          "children": [
+                            {
+                              "tag": "#text",
+                              "text": "1",
+                              "attrs": {},
+                              "events": [],
+                              "children": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "popover-closed": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-anchorhost"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "button",
+          "attrs": {
+            "aria-label": "Info",
+            "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-byqqyj eq-p7nbpw eq-pressable",
+            "style": "--eq-pressed-bg: light-dark(#00427f, #7cb5ee)"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1eb13m5 eq-1o1uad7 eq-1vzw3dm eq-bo3n4y eq-cl6mtg eq-jq1py4 eq-ky45n5 eq-xhcqoy"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-19dgm5h eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-6gdbvu eq-ewlixa eq-m92pvu"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-16x7aca eq-1cb9own eq-1dakdsg eq-1hwu9wq eq-5goeua eq-epaxs4 eq-jsw0f2 eq-mbtjfn eq-type-label eq-y9mhin"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "Info",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "drawer-open": [
+    {
+      "tag": "div",
+      "attrs": {
+        "aria-modal": "true",
+        "class": "eq-overlay",
+        "data-eq-trap": "",
+        "role": "dialog",
+        "tabindex": "-1"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1avhl7d eq-1eviv88"
+          },
+          "events": [],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-19zfii6 eq-1gudvpj eq-1jjc6f6 eq-1pwthtl eq-1w1wt6p eq-5ew4ww eq-akjizx eq-m92pvu eq-mc2xdp"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "button",
+                  "attrs": {
+                    "aria-label": "Dismiss",
+                    "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1jjc6f6 eq-1uykvw eq-akjizx eq-byqqyj eq-p7nbpw eq-pressable"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-15tkusa eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-5ew4ww eq-akjizx"
+                      },
+                      "events": [],
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-1ogof62 eq-1p2uoqo eq-1xlbso6 eq-4xxlvk eq-mfc69x"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-1eb13m5 eq-1eviv88 eq-1gudvpj eq-1jjc6f6 eq-1pcuafn eq-1ua9za6 eq-5hocaj eq-ag04go eq-bo3n4y eq-oeifaf eq-presence-fade",
+                    "data-eq-exit": "fade"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-7gvrt4 eq-type-bodym"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "side",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "accordion": [
+    {
+      "tag": "div",
+      "attrs": {
+        "class": "eq-11yg588 eq-1eb13m5 eq-5ew4ww eq-aexooi eq-akjizx eq-m92pvu eq-mc2xdp"
+      },
+      "events": [],
+      "children": [
+        {
+          "tag": "button",
+          "attrs": {
+            "aria-expanded": "false",
+            "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-akjizx eq-byqqyj eq-p7nbpw eq-pressable"
+          },
+          "events": [
+            "click"
+          ],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-15qobfw eq-189q21e eq-1eb13m5 eq-5ew4ww eq-akjizx eq-bo3n4y eq-hw1jqi"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-19dgm5h eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-akjizx eq-ewlixa eq-m92pvu eq-mc2xdp"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-7gvrt4 eq-type-label"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "First",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-168ghzj eq-5ew4ww"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "aria-hidden": "true",
+                            "class": "eq-168ghzj"
+                          },
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "svg",
+                      "attrs": {
+                        "aria-hidden": "true",
+                        "class": "eq-16x7aca eq-19vml7g eq-1nj1bb6 eq-1or4gpz",
+                        "fill": "currentColor",
+                        "viewBox": "0 0 24 24"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "path",
+                          "attrs": {
+                            "d": "m16.59 8.59-4.59 4.58-4.59-4.58L6 10l6 6 6-6z"
+                          },
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "div",
+          "attrs": {
+            "class": "eq-1eb13m5 eq-5ew4ww eq-akjizx eq-bo3n4y eq-rx01wr eq-yjvyu6"
+          },
+          "events": [],
+          "children": []
+        },
+        {
+          "tag": "button",
+          "attrs": {
+            "aria-expanded": "false",
+            "class": "eq-1esejbi eq-1etnzxl eq-1imlfss eq-1uykvw eq-akjizx eq-byqqyj eq-p7nbpw eq-pressable"
+          },
+          "events": [
+            "click"
+          ],
+          "children": [
+            {
+              "tag": "div",
+              "attrs": {
+                "class": "eq-15qobfw eq-189q21e eq-1eb13m5 eq-5ew4ww eq-akjizx eq-bo3n4y eq-hw1jqi"
+              },
+              "events": [],
+              "children": [
+                {
+                  "tag": "div",
+                  "attrs": {
+                    "class": "eq-19dgm5h eq-1eb13m5 eq-1gudvpj eq-1jjc6f6 eq-1uhnwvg eq-5ew4ww eq-akjizx eq-ewlixa eq-m92pvu eq-mc2xdp"
+                  },
+                  "events": [],
+                  "children": [
+                    {
+                      "tag": "span",
+                      "attrs": {
+                        "class": "eq-7gvrt4 eq-type-label"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "#text",
+                          "text": "Second",
+                          "attrs": {},
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "div",
+                      "attrs": {
+                        "class": "eq-168ghzj eq-5ew4ww"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "div",
+                          "attrs": {
+                            "aria-hidden": "true",
+                            "class": "eq-168ghzj"
+                          },
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "svg",
+                      "attrs": {
+                        "aria-hidden": "true",
+                        "class": "eq-16x7aca eq-19vml7g eq-1nj1bb6 eq-1or4gpz",
+                        "fill": "currentColor",
+                        "viewBox": "0 0 24 24"
+                      },
+                      "events": [],
+                      "children": [
+                        {
+                          "tag": "path",
+                          "attrs": {
+                            "d": "m16.59 8.59-4.59 4.58-4.59-4.58L6 10l6 6 6-6z"
+                          },
+                          "events": [],
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "select-opens": [
     {
       "tag": "div",

--- a/src/eQuantic.UI.Runtime/src/shared/component-parity.spec.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/component-parity.spec.ts
@@ -20,7 +20,7 @@ import { photonTheme } from './design-system.generated';
 import { lowerVisualNode } from './lowering';
 import { setPhotonTheme } from './photon-context';
 import type { HtmlNode } from '../core/types';
-import { Column, Text } from './vocabulary';
+import { Column, GridTrack, Text } from './vocabulary';
 import { Accordion } from './components/Accordion';
 import { AccordionItem } from './components/AccordionItem';
 import { Badge } from './components/Badge';
@@ -38,6 +38,18 @@ import { SearchField } from './components/SearchField';
 import { TextInput } from './components/TextInput';
 import { RadioGroup } from './components/RadioGroup';
 import { EmptyState } from './components/EmptyState';
+import { Menu } from './components/Menu';
+import { MenuItem } from './components/MenuItem';
+import { Dialog } from './components/Dialog';
+import { DialogAction } from './components/DialogAction';
+import { ListItem } from './components/ListItem';
+import { ListView } from './components/ListView';
+import { Table } from './components/Table';
+import { DataTable } from './components/DataTable';
+import { DataColumn } from './components/DataColumn';
+import { DataRow } from './components/DataRow';
+import { Popover } from './components/Popover';
+import { Drawer } from './components/Drawer';
 import { Avatar } from './components/Avatar';
 import { Button } from './components/Button';
 import { ProgressBar } from './components/ProgressBar';
@@ -110,6 +122,58 @@ function cases(): Record<string, { node: unknown; presses: number[] }> {
     'text-input': still(new TextInput('value', null, 'Label')),
     'radio-group': still(new RadioGroup(['a', 'b'], 0)),
     'empty-state': still(new EmptyState('search', 'Nothing here', 'Try another term')),
+    'menu-closed': still(new Menu(new Button('Open'), [new MenuItem('One'), new MenuItem('Two')])),
+    dialog: still(
+      new Dialog('Delete this?', 'It cannot be undone.', [
+        new DialogAction('Cancel', null, 'ghost'),
+        new DialogAction('Delete'),
+      ]),
+    ),
+    'list-item': still(new ListItem('Title', 'and a subtitle')),
+    'list-view': still(
+      new ListView(
+        3,
+        48,
+        (index: number) => new Text(`row ${index}`, 'bodyM', photonTheme.textPrimary),
+      ),
+    ),
+    table: still(
+      new Table(
+        ['Name', 'Size'],
+        [
+          ['a', '1'],
+          ['b', '2'],
+        ],
+      ),
+    ),
+    'data-table': still(
+      new DataTable(
+        [
+          new DataColumn('Name', GridTrack.flex()),
+          new DataColumn('Size', GridTrack.fixed(80), 'end'),
+        ],
+        [
+          new DataRow('a', [
+            new Text('alpha', 'bodyM', photonTheme.textPrimary),
+            new Text('1', 'bodyM', photonTheme.textPrimary),
+          ]),
+        ],
+      ),
+    ),
+    'popover-closed': still(
+      new Popover(
+        new Button('Info'),
+        new Text('the content', 'bodyM', photonTheme.textPrimary),
+        false,
+      ),
+    ),
+    'drawer-open': still(new Drawer(new Text('side', 'bodyM', photonTheme.textPrimary), true)),
+    accordion: still(
+      new Accordion([
+        new AccordionItem('First', new Text('one', 'bodyM', photonTheme.textPrimary)),
+        new AccordionItem('Second', new Text('two', 'bodyM', photonTheme.textPrimary)),
+      ]),
+    ),
     'select-opens': { node: new Select(['alpha', 'beta', 'gamma'], 0), presses: [0] },
     'accordion-switches': {
       node: new Accordion(
@@ -216,6 +280,9 @@ const ENTRY_TAGS = new Set(['input', 'textarea']);
 function canonical(node: HtmlNode): unknown {
   const attrs: Record<string, string> = {};
   for (const key of Object.keys(node.attributes ?? {}).sort()) {
+    // The channel KEY itself goes with the channel — a path the client stamps to find the element
+    // again after it mounts, which the server has no reason to write.
+    if (key === 'data-eq-scroll') continue;
     const value = node.attributes[key];
     if (value !== undefined && value !== null) attrs[key] = normalize(key, value);
   }
@@ -224,8 +291,15 @@ function canonical(node: HtmlNode): unknown {
   if (node.textContent !== undefined && node.textContent !== null) result.text = node.textContent;
   result.attrs = attrs;
   const entry = ENTRY_TAGS.has(node.tag);
+  // A SCROLL VIEW's after-pass channel is client-only for a reason the module states: "a windowed
+  // list is (offset, viewport) and neither is knowable before layout". The server has no layout, so
+  // it emits neither the channel key nor the listener that reports back through it. Recognised by
+  // the key itself rather than by tag, and only there — a scroll handler anywhere else still counts.
+  const scrollView = 'data-eq-scroll' in (node.attributes ?? {});
   result.events = Object.keys(node.events ?? {})
-    .filter((name) => !(entry && CLIENT_ONLY_EVENTS.has(name)))
+    .filter(
+      (name) => !(entry && CLIENT_ONLY_EVENTS.has(name)) && !(scrollView && name === 'scroll'),
+    )
     .sort();
   result.children = (node.children ?? []).map(canonical);
   return result;
@@ -276,4 +350,3 @@ describe('component parity: the twin lowers to the tree C# lowers to', () => {
     });
   }
 });
-

--- a/tests/eQuantic.UI.Web.Tests/ComponentParityFixtureTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/ComponentParityFixtureTests.cs
@@ -76,6 +76,28 @@ public class ComponentParityFixtureTests
         ("radio-group", new RadioGroup(["a", "b"], 0), NoPresses),
         ("empty-state", new EmptyState(Icons.Search, "Nothing here", "Try another term"), NoPresses),
 
+        // COMPOSITES: the components that build a tree rather than a control. They have the most
+        // structure, so the most surface on which two lowerings can quietly disagree — and every
+        // one of them takes an ITEM type whose twin has to line up as well.
+        ("menu-closed", new Menu(new Button("Open"), [new MenuItem("One"), new MenuItem("Two")]), NoPresses),
+        ("dialog", new Dialog("Delete this?", "It cannot be undone.",
+            [new DialogAction("Cancel", null, Variant.Ghost), new DialogAction("Delete")]), NoPresses),
+        ("list-item", new ListItem("Title", "and a subtitle"), NoPresses),
+        ("list-view", new ListView(3, 48f, index =>
+            new Text($"row {index}", TypeRole.BodyM, Theme.TextPrimary)), NoPresses),
+        ("table", new Table(["Name", "Size"], [["a", "1"], ["b", "2"]]), NoPresses),
+        ("data-table", new DataTable(
+            [new DataColumn("Name", GridTrack.Flex()), new DataColumn("Size", GridTrack.Fixed(80), TextAlignment.End)],
+            [new DataRow("a", [new Text("alpha", TypeRole.BodyM, Theme.TextPrimary),
+                               new Text("1", TypeRole.BodyM, Theme.TextPrimary)])]), NoPresses),
+        ("popover-closed", new Popover(new Button("Info"),
+            new Text("the content", TypeRole.BodyM, Theme.TextPrimary), false), NoPresses),
+        ("drawer-open", new Drawer(new Text("side", TypeRole.BodyM, Theme.TextPrimary), true), NoPresses),
+        ("accordion", new Accordion([
+            new AccordionItem("First") { Content = new Text("one", TypeRole.BodyM, Theme.TextPrimary) },
+            new AccordionItem("Second") { Content = new Text("two", TypeRole.BodyM, Theme.TextPrimary) },
+        ]), NoPresses),
+
         // DRIVEN: the state has to move the same way on both sides, and one lowering cannot show
         // that. Opening a Select and switching an Accordion's open section are the two smallest
         // changes of state that rewrite a subtree.


### PR DESCRIPTION
The components that build a **tree** rather than a control: Menu, Dialog, ListItem, ListView, Table,
DataTable, Popover, Drawer, Accordion. They carry the most structure, so the most surface on which
two lowerings can quietly disagree — and each takes an item type (`MenuItem`, `DialogAction`,
`DataColumn`, `DataRow`, `AccordionItem`) whose twin has to line up as well.

## What it found

**Eight of the nine agree tree for tree on the first run.** That is the finding: the composites were
not carrying anything.

The ninth is not a divergence either, and the runtime says why in its own words. A scroll view's
after-pass channel — the `data-eq-scroll` path and the `scroll` listener that reports through it —
exists because *"a windowed list is (offset, viewport) and neither is knowable before layout"*. The
server has no layout, so it writes neither.

Excluded by the **channel key** rather than by tag, and only there: a `scroll` handler anywhere else
still counts. Same rule as the text entry's client-only handlers — the server sends markup, the
client attaches what needs a live layout.

## Where the sweep stands

| | this morning | now |
|---|---|---|
| components | 12 | **44** |
| nodes compared | — | **1351** |
| driven cases (a press, then the tree again) | 0 | 2 |
| recorded divergences | 0 | 1 (`text-input`, waiting on a hydration decision) |

## Verification

Web 530, Compiler 802, Conformance 1114, vitest 910, tsc 0, eslint clean.