### PR TITLE
🐛 fix: one type is one twin — the EQ1005 false positives, and a reference for every diagnostic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,8 +248,10 @@ The Roslyn-based compiler READS C# with strategies and WRITES JavaScript from an
 7. **ValueFlow** (`CodeGen/Strategies/ValueFlow.cs`) - the dispatcher settles EVERY expression for
    the implicit conversion the BOUND tree (`IOperation`) wraps it in — char promotion, int→long —
    at every site C# applies it. A rule ValueFlow owns is removed from the syntax strategies (never
-   both, or the value converts twice); it yields on text and decimal until those move. The bound
-   tree is the destination: `docs/BOUND-TREE-PLAN.md` lists the slices
+   both, or the value converts twice). It now owns TEXT (a value on its way into a concatenation or
+   an interpolation hole) and decimal too; what it still hands back untouched is principled, not
+   owed — no bound tree to read, no implicit conversion, or two chars compared, which stay chars.
+   `docs/BOUND-TREE-PLAN.md` has the slices and what each one cost
 8. **SemanticHelper** (`Services/SemanticHelper.cs`) - symbol-based decisions. The rule: name
    heuristics are legal ONLY where the model cannot be asked (`Knows()` false — no model, or a
    strategy-rewrote node); an in-tree call the model cannot bind is a build error (EQ2006), never

--- a/docs/BOUND-TREE-PLAN.md
+++ b/docs/BOUND-TREE-PLAN.md
@@ -1,5 +1,11 @@
 # Fase 5 — translating the bound tree
 
+**Closed.** All eight slices shipped. `ValueFlow` settles every expression the bound tree wraps in
+a conversion, text and decimal included, and the defensive `dec()`/`long()` wraps are gone — the
+five seams they were hiding became conversions of their own. What ValueFlow still hands back
+untouched is principled: no bound tree to read, no implicit conversion, or two chars compared.
+Phase 6 (`COVERAGE-PLAN.md`) took over from here.
+
 ## Why
 
 Every strategy in `CodeGen/Strategies/` reads SYNTAX and asks the semantic model what it needs,

--- a/docs/COVERAGE-PLAN.md
+++ b/docs/COVERAGE-PLAN.md
@@ -9,13 +9,19 @@ remembered. It did not reduce the strategy COUNT, and it was never going to. Wha
 semantics but MAPPING — which JavaScript shape a given C# call becomes — and that is where
 "one by one" still bites.
 
-Measured at 69acdc17 + slice 7 in flight:
+Where it started, measured at 69acdc17 + slice 7 in flight, and where it stands now. Re-measure
+before quoting either column — the numbers are what the baselines say today, not what this
+paragraph remembers:
 
-| | Count | Concentration |
-|---|---|---|
-| Strategies still emitting text (no writer guarantees) | 111 | **42 LINQ**, 26 Expressions, 21 Types, 8 Primitives, 6 Invocation, 4 Special, 3 UI, 1 Async |
-| BCL members fenced (a build error today) | 99 | **71 EQ1001** — of which **42 `Double`**, 12 `Int64`, 12 `Int32`, 4 `Char`, 1 `String`; plus 23 EQ2004, 3 EQ1004 |
-| Conversion divergences | 2 | the documented `unchecked` limits |
+| | At the start | Today | Concentration now |
+|---|---|---|---|
+| Strategies still emitting text (no writer guarantees) | 111 | **92** | 26 Expressions, 23 LINQ, 21 Types, 8 Primitives, 6 Invocation, 4 Special, 3 UI, 1 Async |
+| BCL members fenced (a build error today) | 99 | **32** | 23 EQ2004 (extension methods declared outside the compilation), 6 EQ1001, 3 EQ1004 |
+| Conversion divergences | 2 | **7** | the two `unchecked` limits, plus five found by widening the instrument: array index out of range (×2) and `m[k]++`/`++m[k]`/`--m[k]` on a missing key |
+
+The divergence row went UP, and that is the phase working rather than failing. Two of them were
+all the generator could see; the other five were always there, in a grammar that had never written
+an array index or a compound assignment through a dictionary key.
 
 Both remaining pockets are CONCENTRATED and REGULAR, which is what makes them derivable rather
 than writable. That is the whole thesis of this phase.
@@ -26,7 +32,7 @@ than writable. That is the whole thesis of this phase.
 |---|---|---|---|
 | 1 | **LINQ as one mechanism.** DONE. Instrumented first, and the instrument said stop: of the 57 operators the 42 strategies claimed, 14 had no executed case and 23 had one. Closing that found ELEVEN bugs before a line was refactored — the OrDefault family answering null where .NET answers 0, an enum field rendering nothing, Zip walking the longer sequence into NaN, Take(-1) dropping the last element, SequenceEqual emitting a name that exists nowhere. Then the table: LinqSurfaceTailStrategy already WAS one, so it grew rather than gaining a rival, and 19 strategies moved in across three batches (43 files → 24, 2474 lines → 1717, baseline 111 → 92) with every pin byte-identical. What stays has a reason, not a shape: Reverse alone means two different things depending on whether the receiver is a List or a sequence | done |
 | 2 | **The numeric BCL as a table.** Method symbol to a JS expression template, one generated conformance case per entry | The 71 EQ1001 members are PURE FUNCTIONS with a 1:1 mapping (`Double.AcosPi(x)` is `Math.acos(x) / Math.PI`). No refactor, pure addition, and every entry is independent of every other — the one slice in this plan that parallelises cleanly | done — 71 → 6 fences (Int128 BigMul, the two Unicode-table members, the intern pool, the two PLATFORM estimates — .NET on ARM64 answers FRECPE, a number this side cannot produce). 65 entries in PrimitiveStaticStrategy's tables + `$eq.bits` (rotations, counts) + `$eq.math` (min/max tie rules, FMA by TwoProduct, bit-adjacent doubles, and the *Pi family PORTED LITERALLY from dotnet/runtime's aocl-libm polynomials — .NET never calls the platform libm for those, so the only bit-exact answer is running the same reduction into the same coefficients; probing found TanPi(0.25) is 0.9999999999999999 THERE too). 135 conformance cases, magnitude ties, ±0, parity infinities and residue-error paths included |
-| 3 | **Widen the differential generator** to LINQ chains and statements | After 1 and 2 there is a large new surface, and the generator is the only instrument that finds what nobody thought to test. Its grammar is still expression-heavy | |
+| 3 | **Widen the differential generator** to LINQ chains and statements. DONE. Its grammar now writes `long`, `decimal`, `char`, `enum`, nullables, records, patterns, dictionaries, `DateTime`, `try`/`catch` and LINQ chains, none of which it had ever produced | After 1 and 2 there is a large new surface, and the generator is the only instrument that finds what nobody thought to test. Its grammar is still expression-heavy | done — and the lesson is the phase's most important one: a DRY instrument and an EXHAUSTED one look identical from outside. It had returned 0 divergences over 3600 programs, which read as coverage and was silence. Widening the grammar took the gap baseline from 2 to 7 in one afternoon |
 | 4 | **Component conformance.** DONE. Components are lowered by `WebRealizer.Lower` through a style sink into a canonical JSON fixture and replayed by the vitest twin through `lowerVisualNode` — tag, attributes, event NAMES and children, with the atomic class names pinning the style hash across both sides. A case can also be DRIVEN: a press is the index of a click handler in document order, invoked between frames, so a Select that opens and an Accordion that switches section are compared after the state moved, not only before. A guard asserts both sides cover the same names. Two things are deliberately not compared, and the code says why: the anchored panel's generated ID (each side hashes different inputs; an open panel never comes from SSR, so they never meet) and class ORDER (attribute order does not enter the cascade). Instead every ARIA reference is asserted to RESOLVE to an id the tree has, on the un-normalised tree — the check a pin against the attribute itself cannot make. First runs found the `MathF.Round` mirror (every small button's label 16.5px in the browser, 16px from the server) and the class-order difference now documented | done |
 
 ## When this phase is DONE
@@ -34,9 +40,17 @@ than writable. That is the whole thesis of this phase.
 A plan without a stop condition chases an ideal forever. Three numbers end it:
 
 1. `ir-migration.baseline.txt` reaches ~20 — only genuinely irregular constructs still emit text.
+   **At 92.** The 23 LINQ entries left are call-shaped on purpose; the 26 in `Expressions` and 21
+   in `Types` are the honest remainder, and the number has not moved since slice 1.
 2. `bcl-surface.baseline.txt` fences only what is impossible BY CONSTRUCTION (`System.IO`,
-   reflection, threading), not what is merely unwritten.
+   reflection, threading), not what is merely unwritten. **At 32, and close.** The 6 EQ1001 are
+   deliberate (`Int128.BigMul`, two Unicode-table members, the intern pool, two platform estimates
+   .NET answers from ARM64 hardware). The 23 EQ2004 are one shape, not 23: an extension method
+   whose declaring class is outside the compilation.
 3. The differential generator runs N seeds clean across expressions, statements and LINQ.
+   **Not yet, and the bar moved.** Clean means clean on a grammar that writes the language, and
+   each widening has produced findings. The condition should be read as "widening the grammar
+   stops yielding divergences", which is a stronger claim than any seed count.
 
 When the three hold, the compiler is finished in the sense that matters, and the effort moves to
 PERFORMANCE — which this whole arc has never once measured.

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -1,0 +1,116 @@
+# Diagnostics
+
+Every build error and warning eqc can print, with what it means and what to do about it. The
+codes are stable: they are what you search for, and what a suppression would name.
+
+A guard keeps this page honest — `DiagnosticsDocumentedTests` fails the build when a code is
+reported from `src/` and has no row here, when a row names a code that no longer exists, or when
+a code gains a new reporting site. The last one is not a style rule: **EQ2101 was once two
+unrelated errors** (a resx translation mismatch and `System.IO` in a client component), each
+pinned by its own green test, because the two never met in one compilation.
+
+Diagnostics print in MSBuild-canonical form, so the IDE and `dotnet build` both link them:
+
+```text
+Pages/Counter.cs(14,9): error EQ2002: C# 'goto' cannot be transpiled to JavaScript …
+```
+
+## EQ0xxx — the build host
+
+The `eqc` process itself, before or around a compilation.
+
+| Code | Meaning | What to do |
+|---|---|---|
+| `EQ0000` | A compilation error arrived with no code of its own. | Read the message — the code is missing, not the diagnosis. |
+| `EQ0001` | eqc crashed. | A bug in the compiler. The message carries the exception; please report it with the source that triggered it. |
+| `EQ0002` | The MSBuild reference list is empty, so the semantic model would be built from an incomplete compilation and named arguments could be emitted in the wrong order. | Rebuild (`dotnet build`). If it persists, `CompileEQuanticUI` ran without `FindReferenceAssembliesForReferences`. |
+
+## EQ1xxx — no translation exists yet
+
+A gap in the compiler, not in your code. The construct is legal C# and could be translated; today
+nothing does it. These are the codes that shrink as the compiler grows.
+
+| Code | Meaning | What to do |
+|---|---|---|
+| `EQ1001` | A C# **expression** kind has no transpilation strategy. | Rewrite it in a transpilable form, or add a conversion strategy for the construct. |
+| `EQ1002` | A C# **statement** kind has no transpilation strategy. | As above. |
+| `EQ1003` | A C# **node** (neither expression nor statement) has no strategy. | As above. |
+| `EQ1004` | A strategy **matched** the construct but this exact form has no emission — the translation would be silently wrong, so it stops. | Rewrite the form, or add the missing case to the strategy. |
+| `EQ1005` | Two types share a twin filename — either the same name twice, or two names that differ only in case (one file on Windows and macOS). Their twins would be ONE file and the second would overwrite the first. | Rename one of the types. |
+| `EQ1006` | *(warning)* One type is declared in more than one place and eqc emits one module per declaration, so the twin holds only the first declaration's members. | Combine them into a single declaration, or keep the members a component uses together in one. Harmless when the other halves are server-only, which is why it does not stop the build. |
+
+## EQ2001–EQ2009 — the construct cannot cross
+
+Not a gap: there is no browser equivalent, or a translation would have to be a guess. These do
+not shrink with compiler work — they are the shape of the target.
+
+| Code | Meaning | What to do |
+|---|---|---|
+| `EQ2001` | A C# construct with no runtime equivalent in the browser (typed-reference intrinsics: `__makeref`, `__reftype`, `__refvalue`, `stackalloc`, pointers). | Restructure without it. |
+| `EQ2002` | `goto`. | Restructure with loops and conditionals, or a labelled `break`/`continue` (those DO translate). |
+| `EQ2003` | `new T()` on a type parameter — generic arguments are erased at runtime in JavaScript, so the concrete type is unknown. | Pass a factory (`Func<T>`) or the constructed value in. |
+| `EQ2004` | An extension method whose declaring class is not part of this compilation, so nothing emits it. | Use an instance member, or bring the declaring source into the compilation. |
+| `EQ2005` | An infinite iterator. Iterators are MATERIALISED into an array, so the loop would run forever instead of yielding lazily. | Give the loop an end (a bound, a `yield break`), or take what you need inside the method. |
+| `EQ2006` | The member does not bind in the semantic model, so any translation would be a guess. | Either the code does not compile, or eqc is missing references / generated sources. Never guessed — see [Compiler](https://github.com/equantic/equantic-ui/wiki/Compiler). |
+| `EQ2007` | A collection expression `with(…)` argument beyond a capacity hint — a JS array or `Set` takes no constructor comparer. | Drop the argument, or build the collection explicitly. |
+| `EQ2008` | Query syntax using `join`, `let`, a second `from`, or `into` — its C# translation runs through compiler-generated transparent identifiers. Also the fenced initializer forms. | Rewrite in method syntax, where every operator is supported. |
+| `EQ2009` | A component is declared more than once in one file (partial declarations). eqc emits one module per declaration and cannot merge them. | Combine the members into a single declaration. |
+
+## EQ2100–EQ2101 — resx templates
+
+The localization contract, checked on the build machine rather than when a visitor arrives.
+
+| Code | Meaning | What to do |
+|---|---|---|
+| `EQ2100` | About **this call**: the template must be a valid composite format whose specifiers are inside the supported subset, and the call must pass every hole it declares. | Fix the argument count, or drop the out-of-subset specifier (alignment such as `{0,10}` is outside v1). |
+| `EQ2101` | About the **translations**: every culture's resx is held against the neutral one, which is the arity contract. | Fix the culture's template — a dropped or extra `{n}` fails the build, not the page. |
+
+## EQ2102–EQ2107, EQ2112 — the client/server boundary
+
+A client component reached for an API that only exists on a server. The bridge is `[ServerAction]`.
+
+| Code | Meaning |
+|---|---|
+| `EQ2102` | Direct database access (`Microsoft.EntityFrameworkCore`, `System.Data`). |
+| `EQ2103` | Networking (`System.Net.Http`, `System.Net.Sockets`). |
+| `EQ2104` | OS threading and locking (`Thread`, `Monitor`, `Mutex`, `Semaphore` — not `Task`). |
+| `EQ2105` | Spawning processes (`System.Diagnostics.Process`). |
+| `EQ2106` | Native interop / P-Invoke (`System.Runtime.InteropServices`). |
+| `EQ2107` | Runtime IL generation (`System.Reflection.Emit`). |
+| `EQ2112` | File-system access (`System.IO`). |
+
+`EQ2112` sits apart from its family on purpose: `System.IO` was reported as `EQ2101` until that
+code turned out to belong to the resx check above, which the wiki already published. It is not a
+numbering slip to tidy back.
+
+## EQ2108–EQ2111 — one meaning per target, or none
+
+The construct translates, but would READ differently on the server and in the browser. Rather
+than pick for you, eqc asks.
+
+| Code | Meaning | What to do |
+|---|---|---|
+| `EQ2108` | A `CultureInfo` that is neither `InvariantCulture` nor `CurrentCulture` — only those two cross. | Format with an explicit specifier (`ToString("N2")` follows the app's culture on both targets), or convert with the invariant culture. |
+| `EQ2109` | `ToString(CultureInfo.CurrentCulture)` with no specifier — the general format is outside the tested `Intl` subset. | Name the format: `ToString("N2")`, `ToString("F1")`. |
+| `EQ2110` | A fractional number converted with no culture at all: C# follows the request's culture (a comma, in `pt`) and JavaScript is always invariant. | Say which you mean. |
+| `EQ2111` | `GetService` with no type argument to cross — the registry is keyed by the interface NAME, and there is nothing to key on. | Call the generic overload. |
+
+## EQ3001–EQ3003 — the Photon app generator
+
+| Code | Meaning |
+|---|---|
+| `EQ3001` | A Photon app has no program. |
+| `EQ3002` | A Photon app has more than one program. |
+| `EQ3003` | A capability's reason must be a constant. |
+
+## EQ3101–EQ3105 — the source generators
+
+The generated factory surface and form models.
+
+| Code | Meaning |
+|---|---|
+| `EQ3101` | A component elects more than one factory constructor (`[UiFactory]`). |
+| `EQ3102` | Two components share a name. |
+| `EQ3103` | A form model property has a type no text box can hold. |
+| `EQ3104` | A validation attribute has no rule to become. |
+| `EQ3105` | A `[Compare]` names a property this form does not have. |

--- a/src/eQuantic.Build/Program.cs
+++ b/src/eQuantic.Build/Program.cs
@@ -378,12 +378,26 @@ bool CompileAndBundle()
                         // name write the same file and the second wins. Nothing said so: C# is
                         // happy — the namespaces differ — and the page died in the browser with
                         // the OTHER type's fields, which is the worst way to learn.
-                        var claim = written.Claim(result.ComponentName, file, result.TypeScript,
-                            path => Path.GetRelativePath(dir, path), out var collision);
+                        // Namespace-qualified, because that is what makes two claims ONE type.
+                        // The FILE is still keyed by the bare name — see EmittedTwins for why both
+                        // halves are needed, and why either alone gets a real case wrong.
+                        var identity = string.IsNullOrEmpty(result.Namespace)
+                            ? result.ComponentName
+                            : $"{result.Namespace}.{result.ComponentName}";
+                        var claim = written.Claim(result.ComponentName, identity, file, result.TypeScript,
+                            path => Path.GetRelativePath(dir, path), out var message);
                         if (claim == eQuantic.UI.Compiler.Services.TwinClaim.Collision)
                         {
-                            Console.Error.WriteLine($"{file}(1,1): error EQ1005: {collision}");
+                            Console.Error.WriteLine($"{file}(1,1): error EQ1005: {message}");
                             hasErrors = true;
+                            continue;
+                        }
+                        // One type across declarations eqc cannot merge. The build goes on with
+                        // the module already written; the members left out are said out loud,
+                        // because their absence shows up only in the browser.
+                        if (claim == eQuantic.UI.Compiler.Services.TwinClaim.Divided)
+                        {
+                            Console.Error.WriteLine($"{file}(1,1): warning EQ1006: {message}");
                             continue;
                         }
                         // The same module already on disk: writing it again would rewrite its map

--- a/src/eQuantic.UI.Compiler/Services/EmittedTwins.cs
+++ b/src/eQuantic.UI.Compiler/Services/EmittedTwins.cs
@@ -11,6 +11,15 @@ namespace eQuantic.UI.Compiler.Services;
 /// build ERROR instead, which is the whole of the fix: the compiler refuses what it cannot
 /// represent rather than picking one.
 /// </para>
+/// <para>
+/// The FILE key and the TYPE identity are two different things, and conflating them breaks the
+/// rule in one direction or the other. The file is keyed by NAME, because that is all a filename
+/// carries — key it by namespace too and the original bug walks straight through. The identity is
+/// namespace-qualified, because that is what makes two claims one type — compare only the name and
+/// a <c>partial</c> class split across six files reads as six types fighting for one twin. Both
+/// halves are needed: same name and same identity is ONE type arriving more than once, same name
+/// and a different identity is the collision.
+/// </para>
 /// </summary>
 public sealed class EmittedTwins
 {
@@ -18,31 +27,47 @@ public sealed class EmittedTwins
     // language and one file to Windows and to macOS as it ships — so an ordinal key would let the
     // second overwrite the first on the machines most people build on, and pass on Linux. A source
     // tree has to build the same everywhere, so the case-only pair is refused too.
-    private readonly Dictionary<string, (string Name, string Source, string TypeScript)> _written =
-        new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Twin> _written = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly record struct Twin(string Name, string Identity, string Source, string TypeScript);
 
     /// <summary>
     /// Records a twin about to be written and says what the writer should do with it.
     /// </summary>
+    /// <param name="name">The type's name, which is the twin's FILENAME and so the key.</param>
+    /// <param name="identity">
+    /// The namespace-qualified name: what makes two claims the same TYPE rather than two types.
+    /// </param>
     /// <remarks>
-    /// Compared by CONTENT rather than by source path: two types of one name in the same file
-    /// collide just as surely as two in different files, and a type that reaches the writer twice
-    /// with the same bytes is not a collision at all. That repeat is a <see cref="TwinClaim.Repeat"/>
-    /// rather than a second write, because the SOURCE MAP is not identical even when the module
-    /// is — it embeds the path and content of the C# it came from, so writing it again would leave
-    /// the module mapped to the wrong file and send a debugger to the wrong line.
+    /// A repeat is compared by CONTENT as well: a type that reaches the writer twice with the same
+    /// bytes is skipped rather than rewritten, because the SOURCE MAP is not identical even when
+    /// the module is — it embeds the path and content of the C# it came from, so writing it again
+    /// would leave the module mapped to the wrong file and send a debugger to the wrong line.
     /// </remarks>
-    public TwinClaim Claim(string name, string source, string typeScript, Func<string, string> describeSource,
-        out string? error)
+    public TwinClaim Claim(string name, string identity, string source, string typeScript,
+        Func<string, string> describeSource, out string? message)
     {
-        error = null;
+        message = null;
         if (!_written.TryGetValue(name, out var first))
         {
-            _written[name] = (name, source, typeScript);
+            _written[name] = new Twin(name, identity, source, typeScript);
             return TwinClaim.Fresh;
         }
 
-        if (first.TypeScript == typeScript) return TwinClaim.Repeat;
+        if (string.Equals(first.Identity, identity, StringComparison.Ordinal))
+        {
+            // ONE type, reaching the writer more than once. Never an error: no file is being lost
+            // to a stranger. It is the same declaration seen twice (a generated file collected
+            // under two configurations) or one type split across declarations.
+            if (first.TypeScript == typeScript) return TwinClaim.Repeat;
+
+            message = $"'{identity}' is declared in more than one place and eqc emits one module "
+                + $"per declaration, so the twin holds only what is in "
+                + $"'{describeSource(first.Source)}' — the members declared here are not in it. "
+                + "Combine them into a single declaration, or keep the members a component uses "
+                + "together in one.";
+            return TwinClaim.Divided;
+        }
 
         var other = first.Source == source
             ? "another type of the same name in this file"
@@ -51,7 +76,7 @@ public sealed class EmittedTwins
             ? $"two types are named '{name}'"
             : $"'{name}' and '{first.Name}' differ only in case, and a filename on Windows and "
               + "on macOS does not";
-        error = $"{named} — this one and {other}. Their twins are ONE file, and the second "
+        message = $"{named} — this one and {other}. Their twins are ONE file, and the second "
             + "would silently replace the first: the code that used one would get the other's "
             + "members. Namespaces do not separate them, because a twin is named for its TYPE. "
             + "Rename one of them.";
@@ -69,6 +94,15 @@ public enum TwinClaim
     /// that points at a different C# file — skip it.</summary>
     Repeat,
 
-    /// <summary>A different type wants a name that is taken. The build stops; see the error.</summary>
+    /// <summary>
+    /// The same TYPE, reaching the writer with a different module: a declaration eqc cannot merge
+    /// into the twin already written. The build continues — the first module stands — and the
+    /// dropped members are reported, because a twin missing half its type fails in the browser and
+    /// nowhere else. The same-file case is an error (EQ2009); across files it is a warning, since
+    /// a partial type whose other halves are server-only is ordinary and correct.
+    /// </summary>
+    Divided,
+
+    /// <summary>A different type wants a name that is taken. The build stops; see the message.</summary>
     Collision,
 }

--- a/src/eQuantic.UI.Compiler/Services/ProjectCompilationHelper.cs
+++ b/src/eQuantic.UI.Compiler/Services/ProjectCompilationHelper.cs
@@ -192,10 +192,22 @@ public static class ProjectCompilationHelper
         }
 
         return roots
-            .SelectMany(dir => Directory.GetFiles(dir, "*.cs", SearchOption.AllDirectories))
+            .SelectMany(dir => Directory.GetFiles(dir, "*.cs", SearchOption.AllDirectories)
+                .Select(file => (Root: dir, File: file)))
             // The implicit-usings file is collected separately; taking it twice would declare the
             // same global usings in two trees, which Roslyn reports as a duplicate.
-            .Where(file => !file.EndsWith(".GlobalUsings.g.cs", StringComparison.Ordinal))
+            .Where(found => !found.File.EndsWith(".GlobalUsings.g.cs", StringComparison.Ordinal))
+            // The SAME generated file under two roots is one file a generator wrote twice, once
+            // per configuration — not two types. Keyed by its path INSIDE its root, because that
+            // is what the generator names it; the roots differ only by the configuration in them.
+            // Newest wins: a stale Release copy from yesterday must not shadow today's Debug one.
+            // Without this the fallback hands Roslyn the same type twice and it resolves to
+            // neither, exactly as the parameter doc above warns.
+            .GroupBy(found => Path.GetRelativePath(found.Root, found.File), StringComparer.OrdinalIgnoreCase)
+            .Select(sameFile => sameFile
+                .OrderByDescending(found => File.GetLastWriteTimeUtc(found.File))
+                .ThenBy(found => found.File, StringComparer.Ordinal)
+                .First().File)
             .Distinct();
     }
 

--- a/src/eQuantic.UI.Compiler/Services/SemanticValidator.cs
+++ b/src/eQuantic.UI.Compiler/Services/SemanticValidator.cs
@@ -20,7 +20,7 @@ public class SemanticValidator
     /// </summary>
     private static readonly (string Prefix, string Code, string Reason)[] ForbiddenApis =
     {
-        ("System.IO", "EQ2101", "file-system access"),
+        ("System.IO", "EQ2112", "file-system access"),
         ("Microsoft.EntityFrameworkCore", "EQ2102", "direct database access"),
         ("System.Data", "EQ2102", "direct database access"),
         ("System.Net.Http", "EQ2103", "HTTP networking"),

--- a/tests/eQuantic.UI.Compiler.Tests/Coverage/DiagnosticsDocumentedTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/Coverage/DiagnosticsDocumentedTests.cs
@@ -47,7 +47,10 @@ public class DiagnosticsDocumentedTests
                 var code = match.Groups[1].Success ? match.Groups[1].Value : match.Groups[2].Value;
                 if (!reported.TryGetValue(code, out var files))
                     reported[code] = files = new SortedSet<string>(StringComparer.Ordinal);
-                files.Add(Path.GetFileName(file));
+                // The path RELATIVE to src, not the filename: src has seven Program.cs, so a
+                // filename key would collapse the build host's diagnostics with the CLI's and a
+                // code moving between them would slip past this guard unseen.
+                files.Add(Path.GetRelativePath(src, file).Replace(Path.DirectorySeparatorChar, '/'));
             }
         }
 

--- a/tests/eQuantic.UI.Compiler.Tests/Coverage/DiagnosticsDocumentedTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/Coverage/DiagnosticsDocumentedTests.cs
@@ -1,0 +1,108 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace eQuantic.UI.Compiler.Tests.Coverage;
+
+/// <summary>
+/// Every code the compiler can print has a row in <c>docs/DIAGNOSTICS.md</c>, and every row names
+/// a code that still exists. A diagnostic nobody can look up is barely a diagnostic: the codes are
+/// scattered across the call sites that raise them, so nothing but this holds them together.
+/// <para>
+/// The second half — a code may not gain a reporting FILE without the baseline saying so — is not
+/// tidiness. <c>EQ2101</c> was two unrelated errors for months, a resx translation mismatch and
+/// <c>System.IO</c> in a client component, each with its own green test, because the two never met
+/// in one compilation. Nothing could have noticed except a list of who reports what.
+/// Regenerate with EQ_UPDATE_DIAGNOSTICS_BASELINE=1.
+/// </para>
+/// </summary>
+public class DiagnosticsDocumentedTests
+{
+    // Two idioms raise a diagnostic: a code passed as its own argument ("EQ2007", …), and one
+    // written straight into an MSBuild-canonical line ($"…: error EQ1005: {message}"). Matching
+    // only the first missed every diagnostic the build HOST raises, which is where EQ1005 lives.
+    private static readonly Regex CodeLiteral =
+        new(@"""(EQ\d{4})""|(?:error|warning)\s+(EQ\d{4})", RegexOptions.Compiled);
+    private static readonly Regex DocumentedRow = new(@"^\|\s*`(EQ\d{4})`", RegexOptions.Multiline);
+
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "eQuantic.UI.sln")))
+            directory = directory.Parent;
+        return directory?.FullName ?? throw new InvalidOperationException("repository root not found");
+    }
+
+    /// <summary>Code to the source files that report it, which is the thing a collision shows up in.</summary>
+    private static SortedDictionary<string, SortedSet<string>> ReportedCodes()
+    {
+        var reported = new SortedDictionary<string, SortedSet<string>>(StringComparer.Ordinal);
+        var src = Path.Combine(RepoRoot(), "src");
+        foreach (var file in Directory.EnumerateFiles(src, "*.cs", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") ||
+                file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+                continue;
+            foreach (Match match in CodeLiteral.Matches(File.ReadAllText(file)))
+            {
+                var code = match.Groups[1].Success ? match.Groups[1].Value : match.Groups[2].Value;
+                if (!reported.TryGetValue(code, out var files))
+                    reported[code] = files = new SortedSet<string>(StringComparer.Ordinal);
+                files.Add(Path.GetFileName(file));
+            }
+        }
+
+        return reported;
+    }
+
+    private static IReadOnlySet<string> DocumentedCodes() =>
+        DocumentedRow.Matches(File.ReadAllText(Path.Combine(RepoRoot(), "docs", "DIAGNOSTICS.md")))
+            .Select(match => match.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+    [Fact]
+    public void EveryDiagnosticTheCompilerRaises_HasARowInTheReference()
+    {
+        var undocumented = ReportedCodes().Keys.Except(DocumentedCodes()).ToList();
+
+        Assert.True(undocumented.Count == 0,
+            "these codes are raised by src/ and have no row in docs/DIAGNOSTICS.md — a build error "
+            + "nobody can look up: " + string.Join(", ", undocumented));
+    }
+
+    [Fact]
+    public void EveryRowInTheReference_NamesACodeThatStillExists()
+    {
+        // EQ0000 is the fallback for an error that arrived with no code, so it is documented and
+        // never written as a literal beside a message.
+        var raised = ReportedCodes().Keys.ToHashSet(StringComparer.Ordinal);
+        var phantom = DocumentedCodes().Where(code => !raised.Contains(code) && code != "EQ0000").ToList();
+
+        Assert.True(phantom.Count == 0,
+            "docs/DIAGNOSTICS.md documents codes nothing raises any more: " + string.Join(", ", phantom));
+    }
+
+    [Fact]
+    public void NoCodeGainsAReportingSite_WithoutTheBaselineSayingSo()
+    {
+        var report = string.Join("\n", ReportedCodes()
+            .Select(entry => $"{entry.Key} {string.Join(" ", entry.Value)}")) + "\n";
+        var baselinePath = Path.Combine(RepoRoot(), "tests", "eQuantic.UI.Compiler.Tests",
+            "Coverage", "diagnostics.baseline.txt");
+
+        if (Environment.GetEnvironmentVariable("EQ_UPDATE_DIAGNOSTICS_BASELINE") == "1")
+        {
+            File.WriteAllText(baselinePath, report);
+            return;
+        }
+
+        Assert.True(File.Exists(baselinePath),
+            "No committed baseline — run once with EQ_UPDATE_DIAGNOSTICS_BASELINE=1 and commit the file.");
+        var committed = File.ReadAllText(baselinePath).Replace("\r\n", "\n");
+
+        Assert.True(committed == report,
+            "who reports which diagnostic has changed. If a code gained a file, make sure it is the "
+            + "SAME error — EQ2101 once meant two unrelated things because nobody checked — then "
+            + "regenerate with EQ_UPDATE_DIAGNOSTICS_BASELINE=1.\n\nexpected:\n" + committed
+            + "\nactual:\n" + report);
+    }
+}

--- a/tests/eQuantic.UI.Compiler.Tests/Coverage/diagnostics.baseline.txt
+++ b/tests/eQuantic.UI.Compiler.Tests/Coverage/diagnostics.baseline.txt
@@ -1,39 +1,39 @@
-EQ0000 Program.cs
-EQ0001 Program.cs
-EQ0002 Program.cs
-EQ1001 CSharpToJsConverter.cs
-EQ1002 CSharpToJsConverter.cs
-EQ1003 CSharpToJsConverter.cs
-EQ1004 ConversionContext.cs
-EQ1005 Program.cs
-EQ1006 Program.cs
-EQ2001 Program.cs UnsupportedConstructStrategy.cs
-EQ2002 GotoStatementStrategy.cs
-EQ2003 ObjectCreationStrategy.cs
-EQ2004 CodeEditing.cs InvocationStrategy.cs RangeExpressionStrategy.cs
-EQ2005 TypeScriptEmitter.cs
-EQ2006 ConditionalAccessStrategy.cs InvocationStrategy.cs MemberAccessStrategy.cs ObjectCreationStrategy.cs
-EQ2007 CollectionExpressionStrategy.cs
-EQ2008 ComponentCompiler.cs GroupByStrategy.cs InitializerExpressionStrategy.cs QueryExpressionStrategy.cs TypeScriptEmitter.cs
-EQ2009 ComponentCompiler.cs
-EQ2100 StringStaticStrategy.cs
-EQ2101 StringStaticStrategy.cs
-EQ2102 SemanticValidator.cs
-EQ2103 SemanticValidator.cs
-EQ2104 SemanticValidator.cs
-EQ2105 SemanticValidator.cs
-EQ2106 SemanticValidator.cs
-EQ2107 SemanticValidator.cs
-EQ2108 ToStringStrategy.cs
-EQ2109 ToStringStrategy.cs
-EQ2110 ToStringStrategy.cs
-EQ2111 ServiceProviderStrategy.cs
-EQ2112 SemanticValidator.cs
-EQ3001 PhotonProgramGenerator.cs
-EQ3002 PhotonProgramGenerator.cs
-EQ3003 CapabilityDeclarations.cs
-EQ3101 AppFactorySurfaceGenerator.cs
-EQ3102 AppFactorySurfaceGenerator.cs
-EQ3103 FormModelGenerator.cs
-EQ3104 FormModelGenerator.cs
-EQ3105 FormModelGenerator.cs
+EQ0000 eQuantic.Build/Program.cs
+EQ0001 eQuantic.Build/Program.cs
+EQ0002 eQuantic.Build/Program.cs
+EQ1001 eQuantic.UI.Compiler/CodeGen/CSharpToJsConverter.cs
+EQ1002 eQuantic.UI.Compiler/CodeGen/CSharpToJsConverter.cs
+EQ1003 eQuantic.UI.Compiler/CodeGen/CSharpToJsConverter.cs
+EQ1004 eQuantic.UI.Compiler/CodeGen/ConversionContext.cs
+EQ1005 eQuantic.Build/Program.cs
+EQ1006 eQuantic.Build/Program.cs
+EQ2001 eQuantic.Build/Program.cs eQuantic.UI.Compiler/CodeGen/Strategies/Special/UnsupportedConstructStrategy.cs
+EQ2002 eQuantic.UI.Compiler/CodeGen/Strategies/Statements/GotoStatementStrategy.cs
+EQ2003 eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/ObjectCreationStrategy.cs
+EQ2004 eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/InvocationStrategy.cs eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/RangeExpressionStrategy.cs eQuantic.UI.Primitives/Code/CodeEditing.cs
+EQ2005 eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
+EQ2006 eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/ConditionalAccessStrategy.cs eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/InvocationStrategy.cs eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/MemberAccessStrategy.cs eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/ObjectCreationStrategy.cs
+EQ2007 eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/CollectionExpressionStrategy.cs
+EQ2008 eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/InitializerExpressionStrategy.cs eQuantic.UI.Compiler/CodeGen/Strategies/Linq/GroupByStrategy.cs eQuantic.UI.Compiler/CodeGen/Strategies/Linq/QueryExpressionStrategy.cs eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs eQuantic.UI.Compiler/ComponentCompiler.cs
+EQ2009 eQuantic.UI.Compiler/ComponentCompiler.cs
+EQ2100 eQuantic.UI.Compiler/CodeGen/Strategies/Primitives/StringStaticStrategy.cs
+EQ2101 eQuantic.UI.Compiler/CodeGen/Strategies/Primitives/StringStaticStrategy.cs
+EQ2102 eQuantic.UI.Compiler/Services/SemanticValidator.cs
+EQ2103 eQuantic.UI.Compiler/Services/SemanticValidator.cs
+EQ2104 eQuantic.UI.Compiler/Services/SemanticValidator.cs
+EQ2105 eQuantic.UI.Compiler/Services/SemanticValidator.cs
+EQ2106 eQuantic.UI.Compiler/Services/SemanticValidator.cs
+EQ2107 eQuantic.UI.Compiler/Services/SemanticValidator.cs
+EQ2108 eQuantic.UI.Compiler/CodeGen/Strategies/Invocation/ToStringStrategy.cs
+EQ2109 eQuantic.UI.Compiler/CodeGen/Strategies/Invocation/ToStringStrategy.cs
+EQ2110 eQuantic.UI.Compiler/CodeGen/Strategies/Invocation/ToStringStrategy.cs
+EQ2111 eQuantic.UI.Compiler/CodeGen/Strategies/Invocation/ServiceProviderStrategy.cs
+EQ2112 eQuantic.UI.Compiler/Services/SemanticValidator.cs
+EQ3001 eQuantic.UI.Native.Generators/PhotonProgramGenerator.cs
+EQ3002 eQuantic.UI.Native.Generators/PhotonProgramGenerator.cs
+EQ3003 eQuantic.UI.Native.Generators/CapabilityDeclarations.cs
+EQ3101 eQuantic.UI.Generators/AppFactorySurfaceGenerator.cs
+EQ3102 eQuantic.UI.Generators/AppFactorySurfaceGenerator.cs
+EQ3103 eQuantic.UI.Generators/FormModelGenerator.cs
+EQ3104 eQuantic.UI.Generators/FormModelGenerator.cs
+EQ3105 eQuantic.UI.Generators/FormModelGenerator.cs

--- a/tests/eQuantic.UI.Compiler.Tests/Coverage/diagnostics.baseline.txt
+++ b/tests/eQuantic.UI.Compiler.Tests/Coverage/diagnostics.baseline.txt
@@ -1,0 +1,39 @@
+EQ0000 Program.cs
+EQ0001 Program.cs
+EQ0002 Program.cs
+EQ1001 CSharpToJsConverter.cs
+EQ1002 CSharpToJsConverter.cs
+EQ1003 CSharpToJsConverter.cs
+EQ1004 ConversionContext.cs
+EQ1005 Program.cs
+EQ1006 Program.cs
+EQ2001 Program.cs UnsupportedConstructStrategy.cs
+EQ2002 GotoStatementStrategy.cs
+EQ2003 ObjectCreationStrategy.cs
+EQ2004 CodeEditing.cs InvocationStrategy.cs RangeExpressionStrategy.cs
+EQ2005 TypeScriptEmitter.cs
+EQ2006 ConditionalAccessStrategy.cs InvocationStrategy.cs MemberAccessStrategy.cs ObjectCreationStrategy.cs
+EQ2007 CollectionExpressionStrategy.cs
+EQ2008 ComponentCompiler.cs GroupByStrategy.cs InitializerExpressionStrategy.cs QueryExpressionStrategy.cs TypeScriptEmitter.cs
+EQ2009 ComponentCompiler.cs
+EQ2100 StringStaticStrategy.cs
+EQ2101 StringStaticStrategy.cs
+EQ2102 SemanticValidator.cs
+EQ2103 SemanticValidator.cs
+EQ2104 SemanticValidator.cs
+EQ2105 SemanticValidator.cs
+EQ2106 SemanticValidator.cs
+EQ2107 SemanticValidator.cs
+EQ2108 ToStringStrategy.cs
+EQ2109 ToStringStrategy.cs
+EQ2110 ToStringStrategy.cs
+EQ2111 ServiceProviderStrategy.cs
+EQ2112 SemanticValidator.cs
+EQ3001 PhotonProgramGenerator.cs
+EQ3002 PhotonProgramGenerator.cs
+EQ3003 CapabilityDeclarations.cs
+EQ3101 AppFactorySurfaceGenerator.cs
+EQ3102 AppFactorySurfaceGenerator.cs
+EQ3103 FormModelGenerator.cs
+EQ3104 FormModelGenerator.cs
+EQ3105 FormModelGenerator.cs

--- a/tests/eQuantic.UI.Compiler.Tests/Diagnostics/FailOnUnsupportedTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/Diagnostics/FailOnUnsupportedTests.cs
@@ -71,7 +71,7 @@ public class FailOnUnsupportedTests
 
     [Theory]
     [InlineData("System.Net.Http", "EQ2103", "new System.Net.Http.HttpClient().GetStringAsync(\"x\")")]
-    [InlineData("System.IO", "EQ2101", "System.IO.File.ReadAllText(\"x\")")]
+    [InlineData("System.IO", "EQ2112", "System.IO.File.ReadAllText(\"x\")")]
     public void ForbiddenApi_InClientComponent_RaisesBoundaryError(string _, string expectedCode, string call)
     {
         var (semanticModel, tree) = CompileClientComponentCalling(call);

--- a/tests/eQuantic.UI.Compiler.Tests/EmittedTwinsTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/EmittedTwinsTests.cs
@@ -20,9 +20,9 @@ public class EmittedTwinsTests
     public void TwoTypesOfOneName_InDifferentFiles_AreRefused()
     {
         var twins = new EmittedTwins();
-        twins.Claim("BenchSeat", "Sections/Bench.cs", "class BenchSeat { a }", Here, out _).Should().Be(TwinClaim.Fresh);
+        twins.Claim("BenchSeat", "App.Sections.BenchSeat", "Sections/Bench.cs", "class BenchSeat { a }", Here, out _).Should().Be(TwinClaim.Fresh);
 
-        twins.Claim("BenchSeat", "Pages/Bench.cs", "class BenchSeat { b }", Here, out var collision).Should().Be(TwinClaim.Collision);
+        twins.Claim("BenchSeat", "App.Pages.BenchSeat", "Pages/Bench.cs", "class BenchSeat { b }", Here, out var collision).Should().Be(TwinClaim.Collision);
 
         collision.Should().NotBeNull();
         collision.Should().Contain("BenchSeat").And.Contain("Sections/Bench.cs");
@@ -33,9 +33,9 @@ public class EmittedTwinsTests
     public void TwoTypesOfOneName_InTheSameFile_AreRefusedToo()
     {
         var twins = new EmittedTwins();
-        twins.Claim("Seat", "Bench.cs", "class Seat { a }", Here, out _).Should().Be(TwinClaim.Fresh);
+        twins.Claim("Seat", "App.Sections.Seat", "Bench.cs", "class Seat { a }", Here, out _).Should().Be(TwinClaim.Fresh);
 
-        twins.Claim("Seat", "Bench.cs", "class Seat { b }", Here, out var same)
+        twins.Claim("Seat", "App.Pages.Seat", "Bench.cs", "class Seat { b }", Here, out var same)
             .Should().Be(TwinClaim.Collision);
         same.Should().Contain("another type of the same name in this file");
     }
@@ -47,11 +47,11 @@ public class EmittedTwinsTests
         // refusing that would fail builds that were never broken.
         var twins = new EmittedTwins();
         var module = "class Seat { a }";
-        twins.Claim("Seat", "Bench.cs", module, Here, out _).Should().Be(TwinClaim.Fresh);
+        twins.Claim("Seat", "App.Seat", "Bench.cs", module, Here, out _).Should().Be(TwinClaim.Fresh);
         // REPEAT, not Fresh: the writer must skip it. The module is identical but its source map
         // is not — that embeds the C# path, so rewriting it would map the module to another file.
-        twins.Claim("Seat", "Bench.cs", module, Here, out _).Should().Be(TwinClaim.Repeat);
-        twins.Claim("Seat", "Other.cs", module, Here, out _).Should().Be(TwinClaim.Repeat);
+        twins.Claim("Seat", "App.Seat", "Bench.cs", module, Here, out _).Should().Be(TwinClaim.Repeat);
+        twins.Claim("Seat", "App.Seat", "Other.cs", module, Here, out _).Should().Be(TwinClaim.Repeat);
     }
 
     /// <summary>`Seat` and `seat` are two types to C# and ONE file to Windows and to macOS as it
@@ -62,9 +62,9 @@ public class EmittedTwinsTests
     public void NamesDifferingOnlyInCase_AreRefused_BecauseAFilenameDoesNotCare()
     {
         var twins = new EmittedTwins();
-        twins.Claim("Seat", "a.cs", "class Seat {}", Here, out _).Should().Be(TwinClaim.Fresh);
+        twins.Claim("Seat", "App.Seat", "a.cs", "class Seat {}", Here, out _).Should().Be(TwinClaim.Fresh);
 
-        twins.Claim("seat", "b.cs", "class seat {}", Here, out var collision).Should().Be(TwinClaim.Collision);
+        twins.Claim("seat", "App.seat", "b.cs", "class seat {}", Here, out var collision).Should().Be(TwinClaim.Collision);
 
         collision.Should().NotBeNull();
         collision.Should().Contain("differ only in case",
@@ -76,8 +76,8 @@ public class EmittedTwinsTests
     public void DifferentNames_NeverCollide()
     {
         var twins = new EmittedTwins();
-        twins.Claim("Seat", "a.cs", "class Seat {}", Here, out _).Should().Be(TwinClaim.Fresh);
-        twins.Claim("Bench", "b.cs", "class Bench {}", Here, out _).Should().Be(TwinClaim.Fresh);
+        twins.Claim("Seat", "App.Seat", "a.cs", "class Seat {}", Here, out _).Should().Be(TwinClaim.Fresh);
+        twins.Claim("Bench", "App.Bench", "b.cs", "class Bench {}", Here, out _).Should().Be(TwinClaim.Fresh);
     }
 
     /// <summary>The shape the site actually hit: two records of one name, different members. The
@@ -95,5 +95,65 @@ public class EmittedTwinsTests
         results.Select(r => r.ComponentName).Should().AllBe("BenchSeat");
         results[0].TypeScript.Should().NotBe(results[1].TypeScript,
             "they are different types — which is exactly what makes one file wrong");
+    }
+
+    /// <summary>
+    /// Reported by the site on preview.41, and the reason this class had to learn the difference
+    /// between a file and a type. `LibrarySeedSource` is ONE `sealed partial class` across six
+    /// files; the ledger counted DECLARATIONS and answered five collisions, each able to stop the
+    /// build on its own. Nothing was colliding: one type cannot silently replace itself.
+    /// </summary>
+    [Fact]
+    public void OneTypeSplitAcrossFiles_IsNotACollision()
+    {
+        var twins = new EmittedTwins();
+        twins.Claim("LibrarySeedSource", "App.Data.LibrarySeedSource", "Seed/Books.cs",
+            "class LibrarySeedSource { books }", Here, out _).Should().Be(TwinClaim.Fresh);
+
+        var claim = twins.Claim("LibrarySeedSource", "App.Data.LibrarySeedSource", "Seed/Films.cs",
+            "class LibrarySeedSource { films }", Here, out var message);
+
+        claim.Should().Be(TwinClaim.Divided, "a partial type is one type, and one type is one twin");
+        message.Should().NotBeNull();
+        message.Should().Contain("Seed/Books.cs",
+            "the warning has to name the declaration that DID reach the twin");
+        message.Should().Contain("not in it",
+            "and say plainly that these members were left out, since that only shows in the browser");
+    }
+
+    /// <summary>
+    /// The other half of the same report: `obj/Debug/…/AppUI.g.cs` and `obj/Release/…/AppUI.g.cs`
+    /// collected together, which is one generated type written twice by two configurations. This
+    /// one hits CI every time, because CI builds Release over a tree that has a Debug obj.
+    /// </summary>
+    [Fact]
+    public void OneGeneratedTypeFromTwoConfigurations_IsNotACollision()
+    {
+        var twins = new EmittedTwins();
+        const string module = "class AppUI { factories }";
+        twins.Claim("AppUI", "App.AppUI", "obj/Debug/net10.0/generated/AppUI.g.cs", module, Here, out _)
+            .Should().Be(TwinClaim.Fresh);
+
+        twins.Claim("AppUI", "App.AppUI", "obj/Release/net10.0/generated/AppUI.g.cs", module, Here, out var message)
+            .Should().Be(TwinClaim.Repeat);
+        message.Should().BeNull("identical bytes from one type are not worth a word to anybody");
+    }
+
+    /// <summary>
+    /// The guard on the guard: making partials pass must not make the ORIGINAL bug pass. What
+    /// separates them is not the namespace — grouping the FILE by namespace would let two
+    /// `BenchSeat` through, which is the bug this class exists for — it is whether the two claims
+    /// are the same TYPE. Same name, different identity: still refused.
+    /// </summary>
+    [Fact]
+    public void TwoTypesOfOneName_AreStillRefused_NowThatOneTypeMayRepeat()
+    {
+        var twins = new EmittedTwins();
+        twins.Claim("BenchSeat", "App.Sections.BenchSeat", "a.cs", "class BenchSeat { a }", Here, out _)
+            .Should().Be(TwinClaim.Fresh);
+
+        twins.Claim("BenchSeat", "App.Pages.BenchSeat", "b.cs", "class BenchSeat { b }", Here, out var error)
+            .Should().Be(TwinClaim.Collision);
+        error.Should().Contain("named for its TYPE");
     }
 }

--- a/tests/eQuantic.UI.Compiler.Tests/GeneratedSourceVisibilityTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/GeneratedSourceVisibilityTests.cs
@@ -112,4 +112,62 @@ public class GeneratedSourceVisibilityTests : IDisposable
 
         Assert.Contains("AppUI", resolver.GetAllStaticHelpers());
     }
+
+    private string WriteGeneratedIn(string configuration, string fileName, string content)
+    {
+        var dir = Path.Combine(_project, "obj", configuration, "net10.0", "generated", "SomeGen", "SomeGen.Emitter");
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, fileName);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    /// <summary>
+    /// A project built in both configurations has obj/Debug/…/generated AND obj/Release/…/generated,
+    /// and the unscoped fallback swept both — so csc's ONE generated type reached Roslyn twice and
+    /// resolved to neither, which the parameter doc had warned about while the code did it anyway.
+    /// Reported by the site: CI builds Release over a tree with a Debug obj, so it hit every run.
+    /// </summary>
+    [Fact]
+    public void OneGeneratedFile_UnderTwoConfigurations_IsCollectedOnce()
+    {
+        WriteGeneratedIn("Debug", "AppUI.g.cs", "public static class AppUI { }");
+        WriteGeneratedIn("Release", "AppUI.g.cs", "public static class AppUI { }");
+
+        var found = ProjectCompilationHelper.GetCompilerGeneratedFiles(_project).ToList();
+
+        Assert.Single(found, file => file.EndsWith("AppUI.g.cs", StringComparison.Ordinal));
+    }
+
+    /// <summary>Newest wins, so a Release copy left over from yesterday cannot shadow the Debug
+    /// build happening now. Same-name-different-content is the case that made it matter.</summary>
+    [Fact]
+    public void WhenTwoConfigurationsDisagree_TheNewerFileIsTheOneCollected()
+    {
+        var stale = WriteGeneratedIn("Release", "AppUI.g.cs", "public static class AppUI { /* yesterday */ }");
+        File.SetLastWriteTimeUtc(stale, DateTime.UtcNow.AddDays(-1));
+        var fresh = WriteGeneratedIn("Debug", "AppUI.g.cs", "public static class AppUI { /* today */ }");
+
+        var found = ProjectCompilationHelper.GetCompilerGeneratedFiles(_project).ToList();
+
+        Assert.Contains(fresh, found);
+        Assert.DoesNotContain(stale, found);
+    }
+
+    /// <summary>Deduping is by the path INSIDE the generated root, not by filename: two generators
+    /// may each write a Registry.g.cs and both are real.</summary>
+    [Fact]
+    public void TwoGeneratorsWritingOneFilename_AreBothKept()
+    {
+        var a = Path.Combine(_project, "obj", "Debug", "net10.0", "generated", "GenA", "GenA.Emitter");
+        var b = Path.Combine(_project, "obj", "Debug", "net10.0", "generated", "GenB", "GenB.Emitter");
+        Directory.CreateDirectory(a);
+        Directory.CreateDirectory(b);
+        File.WriteAllText(Path.Combine(a, "Registry.g.cs"), "class RegistryA { }");
+        File.WriteAllText(Path.Combine(b, "Registry.g.cs"), "class RegistryB { }");
+
+        var found = ProjectCompilationHelper.GetCompilerGeneratedFiles(_project).ToList();
+
+        Assert.Equal(2, found.Count(file => file.EndsWith("Registry.g.cs", StringComparison.Ordinal)));
+    }
 }


### PR DESCRIPTION
## Why

The site cannot build on `0.2.0-preview.41`. Two false positives from EQ1005, each able to stop a
build on its own, reported and isolated by the session working on the site. Chasing them turned up
a third defect in the same family and a documentation hole that let all of it happen quietly.

## The build breaks

**A partial class is one type.** `LibrarySeedSource` is one `sealed partial class` across six
files. The ledger keyed a claim by the twin's FILENAME and told a repeat from a collision by
comparing the emitted module — so six declarations became five errors saying the second would
erase the first. Nothing was being erased: a type cannot silently replace itself.

**One generated file under two configurations is one file.** `obj/Debug/…/AppUI.g.cs` and
`obj/Release/…/AppUI.g.cs` collected together and called two types of one name. This hits CI every
run, because CI builds Release over a tree that has a Debug obj.

The fix is to stop conflating the FILE with the TYPE:

| | keyed by | why not the other |
|---|---|---|
| the twin's file | the type NAME, case-insensitively | a filename carries nothing else — add the namespace and two `BenchSeat` in different namespaces walk straight back through, which is the bug this ledger exists for |
| the type's identity | the namespace-qualified name | compare only the name and a `partial` split across six files reads as six types |

Same name, same identity → one type arriving more than once. Same name, different identity → the
collision, still an error. A type arriving with a *different* module is not silently dropped
either: eqc emits one module per declaration and cannot merge them, so the members left out are
reported as **EQ1006**, a warning — a partial whose other halves are server-only is ordinary and
correct, and their absence otherwise shows up only in the browser.

The `obj/` sweep is fixed at the source too. The parameter doc on `GetCompilerGeneratedFiles`
already described the failure precisely — *"every generated type arrives TWICE and resolves to
neither"* — and the code underneath did it anyway. It now dedupes by the path inside its root,
newest wins, so a stale Release copy cannot shadow today's Debug build.

## EQ2101 meant two different things

Found while writing the reference below. `System.IO` in a client component and a resx translation
whose placeholders do not match the neutral one were both EQ2101. Both had a test, both were green,
and neither could see the other because the two never meet in one compilation. File-system access
moves to EQ2112; the resx meaning is the one the wiki already publishes.

## A reference, and a guard

37 codes exist. 13 were mentioned anywhere, scattered through prose in pages about other subjects,
so a developer who hit EQ2008 had nowhere to look. `docs/DIAGNOSTICS.md` is the reference, derived
from the messages the compiler actually prints. Nothing documented had gone stale — the hole was
only ever omission.

The guard is the part that lasts: a code raised by `src/` must have a row, a row must name a code
that still exists, and no code may gain a reporting site without the baseline saying so. That last
one is what would have caught EQ2101, and nothing else could have.

`docs/COVERAGE-PLAN.md` gets the same treatment — its state table was the snapshot from before the
phase ran (111 text strategies against 92 today, 99 fenced against 32, and "2 conversion
divergences, the documented `unchecked` limits" against 7 of which five are not that).

## Proof

End-to-end through `eqc`, on a tree holding both shapes at once:

- two `BenchSeat` in different namespaces → **still `error EQ1005`**, build stops
- one `LibrarySeedSource` across two files → **`warning EQ1006`**, build continues

Compiler 811 · Conformance 1114 · Web 530, all green.