### PR TITLE
🐛 fix: two web-realizer defects the SSR suite could not see — chrome that ties, and a paragraph read from the wrong field

### DIFF
--- a/src/eQuantic.UI.Runtime/src/shared/lowering.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/lowering.ts
@@ -632,6 +632,17 @@ function revealCaret(path: string): void {
  * Chrome is TWO bands: a floating header and a pinned rail would otherwise tie on one number and
  * let document order decide, which is how a rail painted over an open mega menu.
  */
+/**
+ * The paragraph as PLAIN text: its content, or the runs joined — the C# `Text.PlainContent` twin.
+ * A Text built from runs carries an EMPTY content, so anything that asks the field directly gets
+ * nothing and silently decides as if the paragraph were empty.
+ */
+function plainContent(text: TextNode): string {
+  return text.spans && text.spans.length > 0
+    ? text.spans.map((run) => run.content).join('')
+    : text.content;
+}
+
 const PINNED_LAYER = '100';
 const FLOATING_CHROME_LAYER = '110';
 
@@ -2093,8 +2104,10 @@ function lowerText(text: TextNode, context: LoweringContext): HtmlNode {
     'text-align': text.align === 'center' ? 'center' : text.align === 'end' ? 'end' : undefined,
     // Authored \n is a HARD break (pre-line keeps normal wrapping between them) — C# twin.
     // Mono text is CODE (indentation survives); plain text only keeps its newlines.
+    // plainContent, not content: a paragraph built from RUNS has an empty content, so reading the
+    // field instead of what the node says lost the break entirely (C# twin's PlainContent).
     'white-space':
-      text.mono === true ? 'pre-wrap' : text.content.includes('\n') ? 'pre-line' : undefined,
+      text.mono === true ? 'pre-wrap' : plainContent(text).includes('\n') ? 'pre-line' : undefined,
     'font-family': text.mono === true ? MONO_STACK : undefined,
     'font-variant-numeric': text.tabular === true ? 'tabular-nums' : undefined,
     // The slant (C# twin): the node's own, or the ROLE's when the theme cuts that role italic.

--- a/src/eQuantic.UI.Runtime/src/shared/lowering.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/lowering.ts
@@ -628,8 +628,12 @@ function revealCaret(path: string): void {
  * CONTENT is elevation 1–5 — the design system's own scale, and the only one an author names.
  * CHROME is above all of it: a pinned header is not a raised card. Photon needs none of this, since
  * paint order IS child order there.
+ *
+ * Chrome is TWO bands: a floating header and a pinned rail would otherwise tie on one number and
+ * let document order decide, which is how a rail painted over an open mega menu.
  */
-const CHROME_LAYER = '100';
+const PINNED_LAYER = '100';
+const FLOATING_CHROME_LAYER = '110';
 
 /** The caret's width in px — the C# `PhotonRealizer.CaretWidth` twin. */
 const CARET_WIDTH = 2;
@@ -2954,11 +2958,11 @@ function lowerSticky(node: StickyNode, context: LoweringContext, path: string): 
     top: px(node.offset),
     left: float ? '0' : undefined,
     right: float ? '0' : undefined,
-    // CHROME, both of them — a band of its own, above anything the CONTENT can reach (C# twin's
-    // ChromeLayer). Plain sticky sat at 1, one step above nothing, which is a number competing with
-    // other numbers: a raised card (elevation carries 1–5) would out-stack the pinned header and
-    // scroll straight over it.
-    'z-index': CHROME_LAYER,
+    // CHROME, above anything the CONTENT can reach (C# twin's PinnedLayer). Plain sticky sat at 1,
+    // one step above nothing, which is a number competing with other numbers: a raised card
+    // (elevation carries 1–5) would out-stack the pinned header and scroll straight over it.
+    // FLOATING chrome is a band above PINNED chrome, so two of them on one page do not tie.
+    'z-index': float ? FLOATING_CHROME_LAYER : PINNED_LAYER,
     // Spec S6 (C# twin): the scrolled swap GLIDES instead of flipping in one frame.
     transition: node.transition ? transitionValue(node.transition) : undefined,
   });

--- a/src/eQuantic.UI.Runtime/src/shared/lowering.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/lowering.ts
@@ -623,7 +623,8 @@ function revealCaret(path: string): void {
 }
 
 /**
- * The stacking PLANES, because CSS gives you one number and a page needs three (C# `ChromeLayer`).
+ * The stacking PLANES, because CSS gives you one number and a page needs three (the C#
+ * `PinnedLayer` / `FloatingChromeLayer` twins).
  *
  * CONTENT is elevation 1–5 — the design system's own scale, and the only one an author names.
  * CHROME is above all of it: a pinned header is not a raised card. Photon needs none of this, since
@@ -2381,11 +2382,17 @@ function lowerFlexible(
  * invisible fixed scrim as a REAL pressable while dismissible, and the absolute panel positioned
  * ENTIRELY by the generated placement classes — the gap rides the margin as an atomic declaration.
  */
-/** The panel's visible text, flattened — the C# TextContentOf twin (the tooltip id hashes it). */
+/**
+ * The panel's visible text, flattened — the C# TextContentOf twin (the tooltip id hashes it).
+ *
+ * plainContent, not the content FIELD: a paragraph built from runs carries an empty content, so
+ * every styled panel hashed the same empty string and shared one id with all the others — and the
+ * aria-describedby pointing at one then named somebody else's panel.
+ */
 function visualTextOf(node: VisualNodeValue): string {
   switch (node.nodeKind) {
     case 'text':
-      return (node as TextNode).content ?? '';
+      return plainContent(node as TextNode);
     case 'box': {
       const child = (node as BoxNode).child;
       return child ? visualTextOf(child) : '';

--- a/src/eQuantic.UI.Runtime/src/shared/rich-text-plain-content.spec.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/rich-text-plain-content.spec.ts
@@ -39,3 +39,36 @@ describe('a paragraph built from runs (C# cross-pin)', () => {
     expect(effectiveStyle(lowerVisualNode(plain, ctx))).toContain('pre-line');
   });
 });
+
+/**
+ * The tooltip id hashes the panel's visible text, which is what makes it survive SSR → hydration.
+ * `visualTextOf` read the content FIELD, so every styled panel hashed the same empty string.
+ *
+ * This is the case that would have caught it: the C# side was fixed first and the client twin was
+ * missed, because the two functions do not share a name (`TextContentOf` / `visualTextOf`) and a
+ * search for the C# one found nothing here.
+ */
+describe('the tooltip id of a styled panel (C# cross-pin)', () => {
+  const tipId = (hint: string): string => {
+    const node = {
+      nodeKind: 'anchored',
+      anchor: { nodeKind: 'text', content: 'Save', role: 'label' },
+      panel: styled(hint),
+      open: true,
+      openOnHover: true,
+      describesAnchor: true,
+    } as unknown as VisualNodeValue;
+    const host = lowerVisualNode(node, ctx);
+    const panel = host.children[host.children.length - 1];
+    return panel.attributes['id'] ?? '';
+  };
+
+  it('differs when the styled text differs', () => {
+    expect(tipId('saves the draft')).not.toBe('');
+    expect(tipId('saves the draft')).not.toBe(tipId('discards the draft'));
+  });
+
+  it('is stable for the same styled text, which is what hydration depends on', () => {
+    expect(tipId('saves the draft')).toBe(tipId('saves the draft'));
+  });
+});

--- a/src/eQuantic.UI.Runtime/src/shared/rich-text-plain-content.spec.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/rich-text-plain-content.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { lowerVisualNode } from './lowering';
+import { effectiveStyle } from './style-atomizer';
+import { photonTheme } from './design-system.generated';
+import type { LoweringContext } from './lowering';
+import type { VisualNodeValue } from './nodes';
+
+const ctx: LoweringContext = { textPrimary: photonTheme.textPrimary };
+
+/** A paragraph built from RUNS: its `content` is empty and the text lives in `spans`. */
+const styled = (content: string): VisualNodeValue =>
+  ({
+    nodeKind: 'text',
+    content: '',
+    role: 'heading',
+    spans: [{ content }],
+  }) as unknown as VisualNodeValue;
+
+/**
+ * Cross-pinned with the C# RichTextPlainContentTests. Anything that reads a Text's `content` FIELD
+ * decides as if a styled paragraph were empty, because the paragraph is in `spans`.
+ *
+ * The parity fixture could never have caught this: the C# twin read the same wrong field, so the
+ * two sides agreed. Agreement is not correctness, and this is what that costs.
+ */
+describe('a paragraph built from runs (C# cross-pin)', () => {
+  it('keeps a hard break inside a run', () => {
+    expect(effectiveStyle(lowerVisualNode(styled('first\nsecond'), ctx))).toContain('pre-line');
+  });
+
+  it('asks for no white-space rule when no run has a break', () => {
+    const style = effectiveStyle(lowerVisualNode(styled('one line'), ctx));
+    expect(style).not.toContain('pre-line');
+    expect(style).not.toContain('pre-wrap');
+  });
+
+  it('still reads the plain content when there are no runs at all', () => {
+    const plain = { nodeKind: 'text', content: 'a\nb', role: 'heading' } as unknown as VisualNodeValue;
+    expect(effectiveStyle(lowerVisualNode(plain, ctx))).toContain('pre-line');
+  });
+});

--- a/src/eQuantic.UI.Runtime/src/shared/s7-scroll.spec.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/s7-scroll.spec.ts
@@ -28,6 +28,22 @@ describe('S7 scroll semantics (C# cross-pin)', () => {
     expect(style).toContain('z-index: 100');
   });
 
+  it('floating chrome outranks pinned chrome, so two of them do not tie', () => {
+    // The C# twin pins the same rule. Reported by the site: a rail pinned on one page painted over
+    // the header's open mega menu, because both are chrome and both were 100 — so document order
+    // decided. The header's panel could not climb out either: its z-index lives inside the
+    // header's own stacking context.
+    const layer = (node: VisualNodeValue) =>
+      Number(/z-index: (\d+)/.exec(effectiveStyle(lowerVisualNode(node, ctx)))?.[1]);
+
+    const floating = layer({ nodeKind: 'sticky', child: box(), offset: 0, float: true } as unknown as VisualNodeValue);
+    const pinned = layer({ nodeKind: 'sticky', child: box(), offset: 96 } as unknown as VisualNodeValue);
+
+    expect(floating).toBe(110);
+    expect(pinned).toBe(100);
+    expect(floating).toBeGreaterThan(pinned);
+  });
+
   it('positioned zIndex rides the anchor', () => {
     const stack = {
       nodeKind: 'stack',

--- a/src/eQuantic.UI.Web/WebRealizer.cs
+++ b/src/eQuantic.UI.Web/WebRealizer.cs
@@ -568,11 +568,23 @@ public static class WebRealizer
     /// by their own layer rather than by a number.
     /// </para>
     /// <para>
+    /// Chrome is TWO bands, not one. A floating header and a pinned rail are both chrome, and on
+    /// one number they TIE — so the winner is whichever comes later in the document, which is the
+    /// page's structure deciding a paint order nobody chose. Reported by the site: a rail pinned on
+    /// one page painted over the open mega menu of the header, and the header's own panel could not
+    /// climb out because its z-index lives inside the header's stacking context. Floating chrome
+    /// outranks pinned chrome by construction, because a header whose dropdown falls behind the
+    /// page is not a trade-off anybody wants to be offered.
+    /// </para>
+    /// <para>
     /// Photon needs none of this: paint order IS child order there, so a later sibling is on top and
     /// the question never comes up. This is the web realizer keeping that promise.
     /// </para>
     /// </summary>
-    private const string ChromeLayer = "100";
+    private const string PinnedLayer = "100";
+
+    /// <summary>Floating chrome — see <see cref="PinnedLayer"/> for why it is a band of its own.</summary>
+    private const string FloatingChromeLayer = "110";
 
     private static HtmlElement LowerSticky(Sticky sticky, ComponentContext context)
     {
@@ -586,13 +598,14 @@ public static class WebRealizer
                 Top = TokenCss.Px(sticky.Offset),
                 Left = sticky.Float ? "0" : null,
                 Right = sticky.Float ? "0" : null,
-                // CHROME, both of them — a band of its own, above anything the CONTENT can reach.
-                // Plain sticky used to sit at 1, one step above nothing, which is a number competing
-                // with other numbers: a raised card (elevation carries 1–5 now) or a deep enough
-                // stack cell would out-stack the pinned header and scroll straight over it. Chrome
-                // is not "slightly raised content", it is a different plane, and saying so here is
-                // what keeps the author out of the argument.
-                ZIndex = ChromeLayer,
+                // CHROME, above anything the CONTENT can reach. Plain sticky used to sit at 1, one
+                // step above nothing, which is a number competing with other numbers: a raised card
+                // (elevation carries 1–5 now) or a deep enough stack cell would out-stack the pinned
+                // header and scroll straight over it. Chrome is not "slightly raised content", it is
+                // a different plane, and saying so here is what keeps the author out of the argument.
+                // FLOATING chrome is a band above PINNED chrome, so a header and a rail on one page
+                // do not tie and let document order pick the winner.
+                ZIndex = sticky.Float ? FloatingChromeLayer : PinnedLayer,
                 // Spec S6: the scrolled swap GLIDES (the design's transparent-until-scrolled bar
                 // fades its veil in) instead of flipping in one frame.
                 Transition = sticky.Transition is { } transition ? TokenCss.Transition(transition) : null,

--- a/src/eQuantic.UI.Web/WebRealizer.cs
+++ b/src/eQuantic.UI.Web/WebRealizer.cs
@@ -455,10 +455,15 @@ public static class WebRealizer
     }
 
     /// <summary>The panel's visible text, flattened — what the tooltip id hashes. Walking the
-    /// VISUAL tree (not the lowered one) keeps the answer identical on both producers.</summary>
+    /// VISUAL tree (not the lowered one) keeps the answer identical on both producers.
+    /// <para>
+    /// PlainContent, not Content: a paragraph built from RUNS has an empty Content, so every
+    /// styled panel hashed the same empty string and shared one id with all the others — and the
+    /// aria-describedby pointing at it then named somebody else's panel.
+    /// </para></summary>
     private static string TextContentOf(VisualNode node) => node switch
     {
-        Text text => text.Content,
+        Text text => text.PlainContent,
         Box box => box.Child is { } child ? TextContentOf(child) : "",
         FlexNode flex => string.Concat(flex.Children.Select(TextContentOf)),
         Pressable pressable => TextContentOf(pressable.Child),
@@ -1837,8 +1842,11 @@ public static class WebRealizer
                 // Authored \n is a HARD break (the designed headline's line turns) — pre-line
                 // keeps normal wrapping between them.
                 // Mono text is CODE (indentation survives); plain text only keeps its newlines.
+                // PlainContent, not Content: a paragraph built from RUNS has an empty Content, so
+                // reading the field instead of what the node says lost the break entirely — the
+                // headline ran on in one line and nothing said why.
                 WhiteSpace = mono ? "pre-wrap"
-                    : text.Content.Contains('\n') ? "pre-line" : null,
+                    : text.PlainContent.Contains('\n') ? "pre-line" : null,
                 FontFamily = mono ? TokenCss.MonoStack : null,
                 FontVariantNumeric = text.Tabular ? "tabular-nums" : null,
                 FontStyle = italic ? "italic" : null,

--- a/tests/eQuantic.UI.Web.Tests/ElevationStackingTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/ElevationStackingTests.cs
@@ -63,7 +63,16 @@ public class ElevationStackingTests
         var raised = Layer(StyleOf(new Box(new BoxStyle { Elevation = 5, Width = 40, Height = 40 })));
 
         chrome.Should().BeGreaterThan(raised, "a pinned header is a plane, not a raised card");
-        floating.Should().Be(chrome, "both are chrome; they differ in whether they take space");
+        floating.Should().BeGreaterThan(raised, "and so is a floating one");
+        // This line used to read `floating.Should().Be(chrome)` — both are chrome, differing only
+        // in whether they take space. True right up until a page had BOTH, which the site then
+        // did: a pinned rail and a floating header tied on one number, so the winner was whichever
+        // came later in the document, and the rail painted over the header's open mega menu. The
+        // header's own panel could not climb out either — its z-index lives inside the header's
+        // stacking context and never rises above a sibling of the header. Two chrome elements on
+        // one plane is the page's structure deciding a paint order nobody chose.
+        floating.Should().BeGreaterThan(chrome,
+            "a header whose dropdown falls behind the page is not a trade-off to offer an author");
     }
 
     private static int Layer(string css) =>

--- a/tests/eQuantic.UI.Web.Tests/RichTextPlainContentTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/RichTextPlainContentTests.cs
@@ -1,0 +1,68 @@
+using eQuantic.UI.Primitives;
+using FluentAssertions;
+
+namespace eQuantic.UI.Web.Tests;
+
+/// <summary>
+/// A Text built from RUNS carries an empty <c>Content</c> — the paragraph lives in
+/// <c>Spans</c>, and <c>PlainContent</c> is what the node actually says. Anything that reads the
+/// FIELD instead decides as if the paragraph were empty, silently and only for styled text.
+/// <para>
+/// Found by the sibling session in the semantic walk, where a <c>Content.Length > 0</c> guard
+/// dropped every styled paragraph and screen readers heard nothing. It was not one site: the same
+/// read was in the web realizer twice, and the parity fixture could never catch either, because
+/// the TypeScript twin read the same wrong field and the two agreed.
+/// </para>
+/// </summary>
+public class RichTextPlainContentTests
+{
+    private static Text Styled(string content) =>
+        new("", TypeRole.Heading, null) { Spans = new[] { new TextRun(content) } };
+
+    /// <summary>An authored \n is a hard break. In a run it was dropped, so the designed
+    /// headline ran on in one line with nothing to say why.</summary>
+    [Fact]
+    public void AHardBreakInsideARun_StillTurnsTheLine()
+    {
+        var css = ((Core.HtmlElement)WebRealizer.Lower(Styled("first\nsecond"), PhotonTheme.Instance))
+            .Style!.ToCssString();
+
+        css.Should().Contain("pre-line");
+    }
+
+    /// <summary>And a run WITHOUT one still must not ask for it — the fix must not turn the
+    /// property on for every styled paragraph there is.</summary>
+    [Fact]
+    public void ARunWithoutABreak_AsksForNoWhiteSpaceRule()
+    {
+        var css = ((Core.HtmlElement)WebRealizer.Lower(Styled("one line"), PhotonTheme.Instance))
+            .Style!.ToCssString();
+
+        css.Should().NotContain("pre-line").And.NotContain("pre-wrap");
+    }
+
+    /// <summary>
+    /// The tooltip id hashes the panel's visible TEXT, which is what makes it deterministic across
+    /// SSR and hydration. Read from the field, every styled panel hashed the same empty string —
+    /// so two tooltips shared one id, and the aria-describedby pointing at one named the other.
+    /// </summary>
+    [Fact]
+    public void TwoTooltipsWithDifferentStyledText_DoNotShareOneId()
+    {
+        static string TooltipId(string hint)
+        {
+            var tooltip = new Anchored(
+                new Pressable(new Text("Save", TypeRole.Label), () => { }) { Label = "Save" },
+                Styled(hint))
+            {
+                OpenOnHover = true,
+                DescribesAnchor = true,
+            };
+            var element = WebRealizer.Lower(tooltip, PhotonTheme.Instance);
+            return ((Core.HtmlElement)element.Children[^1]).Id!;
+        }
+
+        TooltipId("saves the draft").Should().NotBe(TooltipId("discards the draft"),
+            "the id hashes the panel's visible text, and a styled paragraph keeps all of it in runs");
+    }
+}


### PR DESCRIPTION
## Why these two together

Both were reported from the running site, both are in the web realizer, and neither could be found
by the suite we have. One needed a real browser to see; the other was invisible to the parity
fixture *by construction*, because both sides made the same mistake and agreed with each other.

## Floating chrome outranked nothing

A page with a floating header and a pinned rail had **both on z-index 100** — chrome was one band.
So the winner was whichever came later in the document, and the rail painted over the header's open
mega menu. The header's own panel could not climb out: its z-index lives inside the header's
stacking context, so `1045` there never rises above a *sibling* of the header. The site removed the
`Sticky` from the rail and lost the pin, which was the only move an author had.

`ElevationStackingTests` asserted the tie **on purpose** — *"both are chrome; they differ in whether
they take space"*. That was true right up until a page had both. The claim was not careless, it was
untested: the case that distinguishes them had not happened yet. The test now says why the line
changed rather than quietly dropping it.

Deciding this in the realizer instead of exposing a `z` is the point. A z-index puts the author back
in the argument, every consumer has to pick numbers that agree, and the defect returns on the next
page that pins two things.

## A paragraph built from runs has an empty `Content`

The sibling session found this class in the semantic walk — a `Content.Length > 0` guard dropped
every styled paragraph, so screen readers heard nothing on all three targets. **It was not one
site.** The same read was in the web realizer twice:

| site | what it decided | what happened |
|---|---|---|
| `WhiteSpace` | `text.Content.Contains('\n')` → `pre-line` | an authored newline inside a run was dropped, so the designed headline ran on in one line |
| `TextContentOf` | hashes the tooltip panel's visible text | every styled panel hashed the same empty string — verified by reverting, where two different tooltips both came out `eq-tip-ztntfp` |

Two panels sharing one id means the `aria-describedby` pointing at one names the other.

**Why the parity fixture was never going to catch it:** the TypeScript twin read the same wrong
field, so the two sides agreed. Agreement is not correctness — that is what a cross-pin costs, and
it is worth writing down.

Both fixed on both sides, each with its negative case beside it: a run *without* a break must still
ask for no white-space rule, or the fix just turns the property on for every styled paragraph there
is.

## Method note, from the site and worth keeping

Neither defect appears in an SSR suite. The first showed up under `getBoundingClientRect` and
`elementFromPoint` in a real browser, and only because someone opened the page and looked. Layout
and stacking are the class of defect that neither the C# tests nor the vitest twins can see.

Web 533 · vitest 914 · tsc 0.