### PR TITLE
✅ test: guarding the class that cost four bugs, and the harness learns to await

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,11 +45,14 @@ npm-debug.log*
 # Test results
 TestResults/
 coverage/
-# …but the compiler's coverage INSTRUMENTS are source, not tool output: the generic rule above
-# silently swallowed the whole folder — two test files and the committed BCL baseline shipped in
-# no commit while their commit message said otherwise.
-!tests/eQuantic.UI.Compiler.Tests/Coverage/
-!tests/eQuantic.UI.Compiler.Tests/Coverage/**
+# …but a test project's Coverage/ folder holds INSTRUMENTS, which are source and not tool output.
+# The rule above is case-insensitive on macOS and on Windows, so it swallows `Coverage/` whole: two
+# test files and a committed BCL baseline once shipped in no commit while the commit message said
+# otherwise. That was patched for ONE project, which left the mine armed everywhere else — and it
+# went off again the next time somebody added a Coverage folder to another test project. Negated
+# for every test project, so the next one does not have to discover it a third time.
+!tests/**/Coverage/
+!tests/**/Coverage/**
 
 **/wwwroot/_equantic/*
 # Embedded bun: only the .zip is tracked; the extracted binary is produced at build time.

--- a/docs/COVERAGE-PLAN.md
+++ b/docs/COVERAGE-PLAN.md
@@ -86,7 +86,23 @@ A plan without a stop condition chases an ideal forever. Three numbers end it:
 
    All three are now guarded rather than remembered: `TheGrammarWrites_EveryConstructItClaimsToCover`
    (does the grammar still reach it), `NoGeneratedProgram_DeclaresOneNameTwice` (is the input
-   valid), and bounding at the point values are consumed. Async is what remains unwritten.
+   valid), and bounding at the point values are consumed.
+
+   **Async, the last axis, and the one that DID find something.** It could not be reached at all
+   before: the harness wrapped every block in a plain arrow, where `await` is a SyntaxError, so bun
+   exited before printing and the failure read as a translation bug. An awaiting block now gets an
+   async IIFE (conditional, so the other thousand cases keep their program byte for byte) and the
+   .NET side imports `System.Threading.Tasks`.
+
+   The first run found a gap nobody had written down: **the TYPE of an awaited call does not reach
+   the value it produces.** `var s = await F();` over a `Task<string>` leaves `s` untyped, so a
+   member on it is name-guessed (`.toUpperInvariant()`, which exists nowhere) and a conversion on
+   it never fires (`l + 2` stays a BigInt beside a Number and throws). Both work the moment the
+   same call is synchronous, so it is the AWAIT that loses the type, not the local function. An
+   async local function is also not emitted `async`, so a body that awaits is a SyntaxError.
+
+   Held in `AsyncConformanceTests` as a ledger that fails when a case starts WORKING, since that is
+   the direction which otherwise goes unnoticed. This is the open thread of Fase 6.
 
 When the three hold, the compiler is finished in the sense that matters, and the effort moves to
 PERFORMANCE — which this whole arc has never once measured.

--- a/tests/eQuantic.UI.Conformance.Tests/AsyncConformanceTests.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/AsyncConformanceTests.cs
@@ -1,0 +1,66 @@
+using eQuantic.UI.Conformance.Tests.Infrastructure;
+using Xunit;
+
+namespace eQuantic.UI.Conformance.Tests;
+
+/// <summary>
+/// A Task is a Promise on the other side and `await` is `await`, but until now the harness could
+/// not RUN either: it wrapped every block in a plain arrow, where `await` is a SyntaxError, so bun
+/// exited before printing and the failure read as a translation bug. These are the first executed
+/// async cases in the suite, and the first run found a gap nobody had written down.
+/// </summary>
+public class AsyncConformanceTests
+{
+    [SkippableTheory]
+    [InlineData("async Task<int> F(int v) => v * 2; var r = await F(21); return $\"{r}\";")]
+    [InlineData("async Task<int> F(int v) => v + 1; var a = await F(1); var b = await F(a); return $\"{a}{b}\";")]
+    [InlineData("var r = await Task.FromResult(7); return $\"{r}\";")]
+    [InlineData("async Task<int> F(int v) => v * 3; var xs = await Task.WhenAll(F(1), F(2)); return $\"{xs[0]}{xs[1]}\";")]
+    [InlineData("async Task<int> F(int v) => v; var t = 0; for (var i = 0; i < 3; i++) t += await F(i); return $\"{t}\";")]
+    public void AsyncPrograms_MatchDotNet(string program)
+    {
+        Skip.IfNot(JsExecutor.IsAvailable, "No JS engine available.");
+        ConformanceRunner.AssertStatementsSameAsDotNet(program);
+    }
+
+    /// <summary>
+    /// The gap the first async run found: the TYPE of an awaited call does not reach the value it
+    /// produces. `var s = await F();` where F returns a Task&lt;string&gt; leaves `s` untyped, so a
+    /// member on it is name-guessed (`.toUpperInvariant()`, which exists nowhere) and a conversion
+    /// on it never fires (`l + 2` stays a BigInt beside a Number, which throws). Both work the
+    /// moment the same call is synchronous, so it is the await that loses the type and not the
+    /// local function. An async local function is also not emitted `async`, so a body that awaits
+    /// is a SyntaxError in its own right.
+    /// <para>
+    /// Held as a LEDGER rather than a skip: this fails when one of them starts working, which is
+    /// the direction that would otherwise go unnoticed. Move the case up to the theory above and
+    /// delete it here.
+    /// </para>
+    /// </summary>
+    [SkippableFact]
+    public void TheAwaitedValueLosesItsType_AndTheseAreTheCasesThatProveIt()
+    {
+        Skip.IfNot(JsExecutor.IsAvailable, "No JS engine available.");
+
+        string[] known =
+        [
+            // a member lookup on an awaited string
+            "async Task<string> F() => \"ok\"; var s = await F(); return s.ToUpperInvariant();",
+            // a conversion onto an awaited long
+            "async Task<long> F() => 40L; var l = await F(); return (l + 2).ToString();",
+            // an async local function whose body awaits is not marked async
+            "async Task<int> F() { await Task.Yield(); throw new InvalidOperationException(\"x\"); } "
+            + "var r = 0; try { r = await F(); } catch { r = -1; } return $\"{r}\";",
+        ];
+
+        var nowWorking = known.Where(program =>
+        {
+            try { ConformanceRunner.AssertStatementsSameAsDotNet(program); return true; }
+            catch { return false; }
+        }).ToList();
+
+        Assert.True(nowWorking.Count == 0,
+            "these async cases now match .NET — move them into AsyncPrograms_MatchDotNet and delete "
+            + "them here, so the suite records that the gap closed:\n  " + string.Join("\n  ", nowWorking));
+    }
+}

--- a/tests/eQuantic.UI.Conformance.Tests/Infrastructure/ConformanceRunner.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/Infrastructure/ConformanceRunner.cs
@@ -34,7 +34,7 @@ public static class ConformanceRunner
         var types = Transpiler.EmitDeclaredRecordTypes(prelude);
         // Top-level undefined canonicalizes to null: the transpiled world treats them as ONE
         // (the `== null` doctrine), and C#'s side of a guarded chain answers null.
-        var program = $"{BuildHelperImport(jsBlock + types)}{types}console.log(JSON.stringify(((v) => v === undefined ? null : v)((() => {jsBlock})())))";
+        var program = $"{BuildHelperImport(jsBlock + types)}{types}{Log(jsBlock)}";
 
         var actual = JsExecutor.Run(program);
         var expected = DotNetEvaluator.EvaluateToJson(csharpStatements, prelude);
@@ -66,6 +66,28 @@ public static class ConformanceRunner
     /// If the emitted JS references runtime helpers (e.g. `format`), import exactly those from the
     /// real bundled runtime.js. Helper-free output (the common case) gets no import at all.
     /// </summary>
+    /// <summary>
+    /// The line that runs the block and prints its result.
+    /// <para>
+    /// A block that AWAITS cannot run inside a plain arrow — `await` there is a SyntaxError and bun
+    /// exits before printing anything, which reads as a translation failure and is not one. So the
+    /// awaiting shape gets an async IIFE and prints from inside it, rather than a top-level await:
+    /// the harness writes a bare script, and top-level await needs a module.
+    /// </para>
+    /// <para>
+    /// Conditional ON PURPOSE. Every non-awaiting case keeps the exact program it had, byte for
+    /// byte, so a thousand green conformance cases are not quietly re-run through a new shape.
+    /// </para>
+    /// </summary>
+    private static string Log(string jsBlock)
+    {
+        const string canonical = "((v) => v === undefined ? null : v)";
+        return Regex.IsMatch(jsBlock, @"\bawait\b")
+            ? $"(async () => {{ const $r = await (async () => {jsBlock})(); "
+              + $"console.log(JSON.stringify({canonical}($r))); }})()"
+            : $"console.log(JSON.stringify({canonical}((() => {jsBlock})())))";
+    }
+
     private static string BuildHelperImport(string js)
     {
         var used = RuntimeHelpers.Where(h => Regex.IsMatch(js, $@"\b{h}[(.]")).ToList();

--- a/tests/eQuantic.UI.Conformance.Tests/Infrastructure/ConformanceRunner.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/Infrastructure/ConformanceRunner.cs
@@ -63,10 +63,6 @@ public static class ConformanceRunner
     }
 
     /// <summary>
-    /// If the emitted JS references runtime helpers (e.g. `format`), import exactly those from the
-    /// real bundled runtime.js. Helper-free output (the common case) gets no import at all.
-    /// </summary>
-    /// <summary>
     /// The line that runs the block and prints its result.
     /// <para>
     /// A block that AWAITS cannot run inside a plain arrow — `await` there is a SyntaxError and bun
@@ -88,6 +84,10 @@ public static class ConformanceRunner
             : $"console.log(JSON.stringify({canonical}((() => {jsBlock})())))";
     }
 
+    /// <summary>
+    /// If the emitted JS references runtime helpers (e.g. `format`), import exactly those from the
+    /// real bundled runtime.js. Helper-free output (the common case) gets no import at all.
+    /// </summary>
     private static string BuildHelperImport(string js)
     {
         var used = RuntimeHelpers.Where(h => Regex.IsMatch(js, $@"\b{h}[(.]")).ToList();

--- a/tests/eQuantic.UI.Conformance.Tests/Infrastructure/DotNetEvaluator.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/Infrastructure/DotNetEvaluator.cs
@@ -23,7 +23,10 @@ public static class DotNetEvaluator
             typeof(System.Collections.Generic.List<>).Assembly,
             typeof(System.Collections.Generic.Stack<>).Assembly,
             typeof(System.DateOnly).Assembly)
-        .AddImports("System", "System.Linq", "System.Collections.Generic", "System.Text");
+        // System.Threading.Tasks so an async case can NAME a Task: without it the .NET side fails
+        // to compile while the JS side runs fine, which compares a compiler error to a value.
+        .AddImports("System", "System.Linq", "System.Collections.Generic", "System.Text",
+            "System.Threading.Tasks");
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/tests/eQuantic.UI.Web.Tests/Coverage/DerivedPropertyReadersTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/Coverage/DerivedPropertyReadersTests.cs
@@ -1,0 +1,125 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+
+namespace eQuantic.UI.Web.Tests.Coverage;
+
+/// <summary>
+/// A derived property exists because the raw field is the WRONG answer somewhere. Nothing stops a
+/// caller reading the field anyway, and when they do it is silent: the value is a real value, just
+/// not the one the node means.
+/// <para>
+/// It cost four bugs in one day. A Text built from runs carries an empty <c>Content</c> — the words
+/// are in <c>Spans</c>, and <c>PlainContent</c> exists for exactly that. Read from the field: a
+/// styled paragraph produced no accessibility node at all, a control with a styled label reached
+/// the platform with NO NAME, an authored newline inside a run stopped turning the line, and every
+/// styled tooltip hashed the same empty string so two of them shared one id.
+/// </para>
+/// <para>
+/// None of it was visible to the parity fixture, because the TypeScript twin read the same wrong
+/// field and the two sides agreed. Agreement is not correctness — so the guard is on the SOURCE,
+/// which is the only place the mistake is visible at all.
+/// </para>
+/// </summary>
+public class DerivedPropertyReadersTests
+{
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "eQuantic.UI.sln")))
+            directory = directory.Parent;
+        return directory?.FullName ?? throw new InvalidOperationException("repository root not found");
+    }
+
+    private static IEnumerable<(string Path, string Text)> Sources(params string[] roots)
+    {
+        foreach (var root in roots)
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(RepoRoot(), root), "*.cs",
+                     SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") ||
+                file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+                continue;
+            yield return (Path.GetRelativePath(RepoRoot(), file).Replace(Path.DirectorySeparatorChar, '/'),
+                File.ReadAllText(file));
+        }
+    }
+
+    private static string Baseline(string name) => Path.Combine(
+        RepoRoot(), "tests", "eQuantic.UI.Web.Tests", "Coverage", name);
+
+    // A read of a Text's Content FIELD, in the three spellings the tree uses.
+    private static readonly Regex RawRead = new(
+        @"\btext\s*\.\s*Content\b|\bText\s*\{\s*Content\b|\bText\s+\w+\s+when\s+\w+\.Content\b",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Who still reads the raw field. This list may only SHRINK — every entry has to be a place
+    /// where the field genuinely IS the answer, and the entry says so. A new one is a bug waiting
+    /// for the shape of text that makes it visible, which is the shape nobody tests with.
+    /// Regenerate with EQ_UPDATE_RAW_READ_BASELINE=1 after REMOVING one.
+    /// </summary>
+    [Fact]
+    public void NoNewReaderOfTheRawContentField()
+    {
+        var current = Sources("src")
+            .SelectMany(source => source.Text.Split('\n')
+                .Select((line, index) => (source.Path, Number: index + 1, Line: line.Trim()))
+                .Where(entry => RawRead.IsMatch(entry.Line)))
+            .Select(entry => $"{entry.Path}  {entry.Line}")
+            .OrderBy(entry => entry, StringComparer.Ordinal)
+            .ToList();
+
+        var path = Baseline("raw-content-readers.baseline.txt");
+        if (Environment.GetEnvironmentVariable("EQ_UPDATE_RAW_READ_BASELINE") == "1")
+        {
+            File.WriteAllText(path, string.Join("\n", current) + "\n");
+            return;
+        }
+
+        var committed = File.ReadAllLines(path)
+            .Where(line => line.Length > 0 && !line.StartsWith('#'))
+            .ToList();
+
+        current.Except(committed).Should().BeEmpty(
+            "a new read of the raw Content field. A Text built from runs has an EMPTY Content — if "
+            + "this site is not guarded by a Spans check, it wants PlainContent. If it genuinely is "
+            + "guarded, add it to the baseline with the reason.");
+    }
+
+    /// <summary>
+    /// The other half, and it has the OPPOSITE rule: the set of derived-with-fallback properties may
+    /// legitimately GROW, so this fails when one is ADDED rather than when one is removed. A second
+    /// property of this shape is the moment somebody has to decide whether its readers are right —
+    /// which is much cheaper than deciding it four call sites later.
+    /// </summary>
+    [Fact]
+    public void PlainContentIsStillTheOnlyDerivedPropertyWithARawTwin()
+    {
+        var property = new Regex(@"public\s+[\w<>?\[\]]+\s+(\w+)\s*=>\s*([^;]{5,200});", RegexOptions.Compiled);
+        var member = new Regex(@"^\s*(?:public|internal)\s+(?:readonly\s+)?[\w<>?\[\],\s]+?\s(\w+)\s*(?:\{\s*get|;)",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+        // The FALLBACK arm only: what the property answers when its condition does not hold. That
+        // arm being a bare sibling member is what makes the raw read tempting AND wrong.
+        var fallback = new Regex(@"(?::|\?\?)\s*([A-Za-z_]\w*)\s*$", RegexOptions.Compiled);
+
+        var found = new List<string>();
+        foreach (var (path, text) in Sources("src/eQuantic.UI.Primitives", "src/eQuantic.UI.Components"))
+        {
+            var members = member.Matches(text).Select(m => m.Groups[1].Value).ToHashSet(StringComparer.Ordinal);
+            foreach (Match match in property.Matches(text))
+            {
+                var name = match.Groups[1].Value;
+                var body = Regex.Replace(match.Groups[2].Value, @"\s+", " ");
+                foreach (Match arm in fallback.Matches(body))
+                    if (arm.Groups[1].Value != name && members.Contains(arm.Groups[1].Value))
+                        found.Add($"{path}  {name} -> {arm.Groups[1].Value}");
+            }
+        }
+
+        found.Should().ContainSingle().Which.Should().EndWith("PlainContent -> Content",
+            "a second derived property with a raw twin is a decision point, not a detail: every "
+            + "reader of the raw field has to be checked before it ships, because getting it wrong "
+            + "is silent and only shows for the shape of data nobody writes tests with. Add it here "
+            + "deliberately once its readers are verified.");
+    }
+}

--- a/tests/eQuantic.UI.Web.Tests/Coverage/DerivedPropertyReadersTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/Coverage/DerivedPropertyReadersTests.cs
@@ -22,7 +22,11 @@ namespace eQuantic.UI.Web.Tests.Coverage;
 /// </summary>
 public class DerivedPropertyReadersTests
 {
-    private static string RepoRoot()
+    /// <summary>Walked ONCE. The scan visits hundreds of files, and re-walking the parents for
+    /// each one is filesystem IO to answer a question whose answer cannot change.</summary>
+    private static readonly string Root = FindRoot();
+
+    private static string FindRoot()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
         while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "eQuantic.UI.sln")))
@@ -33,19 +37,19 @@ public class DerivedPropertyReadersTests
     private static IEnumerable<(string Path, string Text)> Sources(params string[] roots)
     {
         foreach (var root in roots)
-        foreach (var file in Directory.EnumerateFiles(Path.Combine(RepoRoot(), root), "*.cs",
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(Root, root), "*.cs",
                      SearchOption.AllDirectories))
         {
             if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") ||
                 file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
                 continue;
-            yield return (Path.GetRelativePath(RepoRoot(), file).Replace(Path.DirectorySeparatorChar, '/'),
+            yield return (Path.GetRelativePath(Root, file).Replace(Path.DirectorySeparatorChar, '/'),
                 File.ReadAllText(file));
         }
     }
 
     private static string Baseline(string name) => Path.Combine(
-        RepoRoot(), "tests", "eQuantic.UI.Web.Tests", "Coverage", name);
+        Root, "tests", "eQuantic.UI.Web.Tests", "Coverage", name);
 
     // A read of a Text's Content FIELD, in the three spellings the tree uses.
     private static readonly Regex RawRead = new(

--- a/tests/eQuantic.UI.Web.Tests/Coverage/raw-content-readers.baseline.txt
+++ b/tests/eQuantic.UI.Web.Tests/Coverage/raw-content-readers.baseline.txt
@@ -1,0 +1,6 @@
+# Sites that read a Text's Content FIELD rather than PlainContent, and why each is correct.
+# This list may ONLY SHRINK. See DerivedPropertyReadersTests for what it cost.
+#
+# GUARDED by `Spans is null`, so Content is genuinely the whole paragraph here: the runs branch
+# renders the spans as child elements instead, and there is no inner HTML to set.
+src/eQuantic.UI.Web/WebRealizer.cs  InnerHtml = text.Spans is null ? text.Content : null,


### PR DESCRIPTION
## Three things, all about making the instruments say what they mean

### 1. The `Coverage/` folder was being silently ignored

`.gitignore` has `coverage/` for tool output. It is **case-insensitive on macOS and Windows**, so
it also swallows `Coverage/` — the folder a test project keeps its instruments in, which is source.

This already happened once, and the file records it: *"two test files and a committed BCL baseline
shipped in no commit while their commit message said otherwise."* The patch then was a negation for
**one** project, which left the mine armed everywhere else. It went off again the moment I added a
`Coverage/` folder to a second test project — files written, tests green locally, `git status`
showing nothing. Negated for every test project now, rather than one at a time.

### 2. A guard for the `Content` / `PlainContent` class

Agreed with the session that found the first of the four. A `Text` built from runs carries an
**empty `Content`** — the words are in `Spans`. Nothing stopped a caller reading the field, and
when they did it was silent: a real value, just not the one the node means.

Two artefacts, because the halves have **opposite rules** and one file would have killed the rule
for half of it:

| artefact | rule | today |
|---|---|---|
| `raw-content-readers.baseline.txt` | may only **shrink** | one entry, genuinely correct — guarded by `Spans is null`, where Content really is the whole paragraph |
| `PlainContentIsStillTheOnlyDerivedPropertyWithARawTwin` | fails when one is **added** | a second property of this shape is a decision point: every reader of its raw field must be checked before it ships |

The second needed a *precise* definition rather than an impression. "Any ternary" finds seven
properties across Primitives and Components, most harmless. What actually bit is narrower: a
derived property whose **fallback arm is a bare sibling member** — that is what makes the naive
read both tempting and wrong. On that definition there is exactly one, which confirms the sibling
session's sweep with a rule instead of a reading.

Both halves verified by breaking them. The decoy caught a mistake of my own on the way: the first
one landed in the wrong class and only produced a build error, which is not the same as the guard
firing.

### 3. The harness could not run `await` at all — and the first run that could, found a gap

Async was the last axis the generator had never walked, and it turned out it *could not be*: every
block was wrapped in a plain arrow, where `await` is a SyntaxError. bun exited before printing, so
the failure read as a translation bug. The .NET side had always handled await via
`CSharpScript.EvaluateAsync`, but did not import `System.Threading.Tasks` — so a case that names a
Task failed to compile there while the JS side ran, comparing a compiler error to a value.

An awaiting block now gets an async IIFE that prints from inside it (not a top-level await — the
harness writes a bare script, and top-level await needs a module). **Conditional on purpose**: every
non-awaiting case keeps its exact program, byte for byte, so a thousand green cases are not quietly
re-run through a new shape.

Five async cases pass. Three do not, and they are **one finding**:

> The TYPE of an awaited call does not reach the value it produces.

`var s = await F();` over a `Task<string>` leaves `s` untyped, so a member on it is name-guessed
(`.toUpperInvariant()`, which exists nowhere) and a conversion on it never fires (`l + 2` stays a
BigInt beside a Number and throws). Both work the moment the same call is **synchronous** — triaged
before reporting — so it is the `await` that loses the type, not the local function. An async local
function is also not emitted `async`, so a body that awaits is a SyntaxError in its own right.

Held as a ledger that **fails when one of them starts working**, not as a skip: a skip rots
silently in exactly the direction nobody watches. This is the open thread of Fase 6, and it is
written down in `COVERAGE-PLAN.md` rather than left in a commit message.

Conformance 1126 · Web 547.