### PR TITLE
🐛 fix: async that never ran — a lost `async`, an untranslated `Task.Yield`, and three more the sweep found

### DIFF
--- a/docs/COVERAGE-PLAN.md
+++ b/docs/COVERAGE-PLAN.md
@@ -94,15 +94,30 @@ A plan without a stop condition chases an ideal forever. Three numbers end it:
    async IIFE (conditional, so the other thousand cases keep their program byte for byte) and the
    .NET side imports `System.Threading.Tasks`.
 
-   The first run found a gap nobody had written down: **the TYPE of an awaited call does not reach
-   the value it produces.** `var s = await F();` over a `Task<string>` leaves `s` untyped, so a
-   member on it is name-guessed (`.toUpperInvariant()`, which exists nowhere) and a conversion on
-   it never fires (`l + 2` stays a BigInt beside a Number and throws). Both work the moment the
-   same call is synchronous, so it is the AWAIT that loses the type, not the local function. An
-   async local function is also not emitted `async`, so a body that awaits is a SyntaxError.
+   The first run reported three failures as a compiler gap — "the TYPE of an awaited call does not
+   reach the value it produces". **Two of the three were the instrument again.** The transpiler's
+   synthesized wrapper had no `using System.Threading.Tasks` and its `__Eval` was not `async`, so
+   `Task<string>` did not bind and `await` was not valid C# there. The tree came back full of
+   errors and eqc did exactly what it documents for a model that cannot answer: it guessed a name.
+   The compiler was right; the harness could not present it a program.
 
-   Held in `AsyncConformanceTests` as a ledger that fails when a case starts WORKING, since that is
-   the direction which otherwise goes unnoticed. This is the open thread of Fase 6.
+   **What was real, and what the hunt then found:**
+
+   - An async LOCAL FUNCTION, and `async delegate`, lost the `async` on the emitted arrow — so a
+     body that awaited became a SyntaxError and the module never parsed. Lambdas and component
+     methods already carried it; those two dropped it.
+   - `Task.Yield()` had no translation at all and emitted `Task.yield()`, a name that exists
+     nowhere. It is now `new Promise(resolve => setTimeout(resolve, 0))`: a resolved promise is a
+     microtask and would not yield the loop, which is the whole point of the call.
+
+   The second one almost escaped, and how is the part worth keeping. Its case had the yield inside
+   a `try/catch`, so it PASSED with the name broken — the catch swallowed the ReferenceError and
+   the fold still read the value the catch wrote. A green tick for the wrong reason. The case now
+   awaits outside any catch, and reverting the fix is what proved it bites.
+
+   **The score for this phase is now four instrument faults to two compiler bugs.** That ratio is
+   the finding: on a suite this size, the thing most likely to be wrong about a failure is the
+   thing doing the measuring.
 
 When the three hold, the compiler is finished in the sense that matters, and the effort moves to
 PERFORMANCE — which this whole arc has never once measured.

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -94,6 +94,7 @@ than pick for you, eqc asks.
 | `EQ2109` | `ToString(CultureInfo.CurrentCulture)` with no specifier — the general format is outside the tested `Intl` subset. | Name the format: `ToString("N2")`, `ToString("F1")`. |
 | `EQ2110` | A fractional number converted with no culture at all: C# follows the request's culture (a comma, in `pt`) and JavaScript is always invariant. | Say which you mean. |
 | `EQ2111` | `GetService` with no type argument to cross — the registry is keyed by the interface NAME, and there is nothing to key on. | Call the generic overload. |
+| `EQ2113` | `ConfigureAwait` is dropped — there is one context to resume on — and dropping it would discard a NON-CONSTANT argument without evaluating it. | Pass a constant, or evaluate the expression into a local first. |
 
 ## EQ3001–EQ3003 — the Photon app generator
 

--- a/src/eQuantic.UI.Compiler/CodeGen/Strategies/Async/TaskMethodStrategy.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Strategies/Async/TaskMethodStrategy.cs
@@ -23,7 +23,7 @@ public class TaskMethodStrategy : IConversionStrategy
         
         if (expr != "Task" && expr != "System.Threading.Tasks.Task") return false;
         
-        return name is "Delay" or "Run" or "WhenAll" or "WhenAny" or "FromResult";
+        return name is "Delay" or "Run" or "WhenAll" or "WhenAny" or "FromResult" or "Yield";
     }
 
     public string Convert(SyntaxNode node, ConversionContext context)
@@ -33,6 +33,16 @@ public class TaskMethodStrategy : IConversionStrategy
         var name = memberAccess.Name.Identifier.Text;
         var args = invocation.ArgumentList.Arguments;
         
+        if (name == "Yield")
+        {
+            // `Task.Yield()` gives the scheduler a turn: the continuation is GUARANTEED to run
+            // asynchronously. A resolved promise is a microtask and would not let anything else in
+            // — setTimeout(0) is the analogue that actually yields the loop, the same shape Delay
+            // already uses. Untranslated it emitted `Task.yield()`, a name that exists nowhere, and
+            // the module died at the first call.
+            return "new Promise(resolve => setTimeout(resolve, 0))";
+        }
+
         if (name == "Delay")
         {
             var ms = context.Converter.ConvertExpression(args[0].Expression);

--- a/src/eQuantic.UI.Compiler/CodeGen/Strategies/Async/TaskMethodStrategy.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Strategies/Async/TaskMethodStrategy.cs
@@ -34,11 +34,27 @@ public class TaskMethodStrategy : IConversionStrategy
         // it went out as `.configureAwait(false)` — a method that exists nowhere. JavaScript has no
         // synchronization context to opt out of, so the honest translation is to DROP it and keep
         // the receiver. It is everywhere in real async C#, and it broke the module at parse time.
-        if (name == "ConfigureAwait") return true;
+        //
+        // Gated on the SYMBOL, not the name. A name gate takes any method called ConfigureAwait,
+        // including one somebody wrote on their own type, and drops the call silently — which is
+        // the failure this whole strategy exists to stop. The name is consulted only where the
+        // model cannot answer, which is the rule everywhere else in here.
+        if (name == "ConfigureAwait")
+            return IsAwaitableConfigure(invocation, context) || context.CanGuess(invocation);
 
         if (!IsTaskType(expr)) return false;
 
         return name is "Delay" or "Run" or "WhenAll" or "WhenAny" or "FromResult" or "Yield";
+    }
+
+    /// <summary>Whether this <c>ConfigureAwait</c> is the BCL's, on a task or a value task.</summary>
+    private static bool IsAwaitableConfigure(InvocationExpressionSyntax invocation, ConversionContext context)
+    {
+        if (context.SemanticHelper.GetSymbol(invocation) is not IMethodSymbol method) return false;
+        var owner = method.ContainingType?.ConstructedFrom ?? method.ContainingType;
+        var name = owner?.ToDisplayString();
+        return name is "System.Threading.Tasks.Task" or "System.Threading.Tasks.Task<TResult>"
+            or "System.Threading.Tasks.ValueTask" or "System.Threading.Tasks.ValueTask<TResult>";
     }
 
     private static bool IsTaskType(string expression) =>
@@ -56,9 +72,25 @@ public class TaskMethodStrategy : IConversionStrategy
         var args = invocation.ArgumentList.Arguments;
 
         // `t.ConfigureAwait(false)` IS `t` here: the flag says which context to resume on, and
-        // there is only one.
+        // there is only one. Dropping the call drops its ARGUMENT too, which is only safe while
+        // the argument cannot do anything — a constant. Anything else is refused rather than
+        // silently discarded: a side effect that stops happening is the kind of defect that shows
+        // up nowhere near the line that caused it.
         if (name == "ConfigureAwait")
+        {
+            var flag = args.Count > 0 ? args[0].Expression : null;
+            if (flag is not null && !context.SemanticHelper.TryGetConstantValue(flag, out _))
+            {
+                context.Report(node, ConversionSeverity.Error, "EQ2113",
+                    "'ConfigureAwait' has no JavaScript translation — there is one context to "
+                    + "resume on — so the call is dropped, and dropping it would discard this "
+                    + "argument without evaluating it. Pass a constant, or evaluate the expression "
+                    + "into a local first.");
+                return context.Converter.ConvertExpression(memberAccess.Expression);
+            }
+
             return context.Converter.ConvertExpression(memberAccess.Expression);
+        }
 
         if (name == "Yield")
         {

--- a/src/eQuantic.UI.Compiler/CodeGen/Strategies/Async/TaskMethodStrategy.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Strategies/Async/TaskMethodStrategy.cs
@@ -14,6 +14,15 @@ public class TaskMethodStrategy : IConversionStrategy
 {
     public bool CanConvert(SyntaxNode node, ConversionContext context)
     {
+        // `Task.CompletedTask` is a PROPERTY, so the invocation gate below never saw it and it went
+        // out as `Task.completedTask`. The guard on Parent is what keeps this from also matching
+        // the callee of every call: `Task.Delay(1)` has a member access inside it too, and it is
+        // the invocation that owns the translation.
+        if (node is MemberAccessExpressionSyntax property)
+            return property.Parent is not InvocationExpressionSyntax
+                && IsTaskType(property.Expression.ToString())
+                && property.Name.Identifier.Text == "CompletedTask";
+
         if (node is not InvocationExpressionSyntax invocation) return false;
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return false;
 
@@ -21,18 +30,36 @@ public class TaskMethodStrategy : IConversionStrategy
         var expr = memberAccess.Expression.ToString();
         var name = memberAccess.Name.Identifier.Text;
         
-        if (expr != "Task" && expr != "System.Threading.Tasks.Task") return false;
-        
+        // ConfigureAwait is an INSTANCE call on a task, so the `Task.` gate below never saw it and
+        // it went out as `.configureAwait(false)` — a method that exists nowhere. JavaScript has no
+        // synchronization context to opt out of, so the honest translation is to DROP it and keep
+        // the receiver. It is everywhere in real async C#, and it broke the module at parse time.
+        if (name == "ConfigureAwait") return true;
+
+        if (!IsTaskType(expr)) return false;
+
         return name is "Delay" or "Run" or "WhenAll" or "WhenAny" or "FromResult" or "Yield";
     }
 
+    private static bool IsTaskType(string expression) =>
+        expression is "Task" or "System.Threading.Tasks.Task";
+
     public string Convert(SyntaxNode node, ConversionContext context)
     {
+        // An already-completed task is a resolved promise: awaiting it yields immediately, which
+        // is what `await Task.CompletedTask` means on the other side too.
+        if (node is MemberAccessExpressionSyntax) return "Promise.resolve()";
+
         var invocation = (InvocationExpressionSyntax)node;
         var memberAccess = (MemberAccessExpressionSyntax)invocation.Expression;
         var name = memberAccess.Name.Identifier.Text;
         var args = invocation.ArgumentList.Arguments;
-        
+
+        // `t.ConfigureAwait(false)` IS `t` here: the flag says which context to resume on, and
+        // there is only one.
+        if (name == "ConfigureAwait")
+            return context.Converter.ConvertExpression(memberAccess.Expression);
+
         if (name == "Yield")
         {
             // `Task.Yield()` gives the scheduler a turn: the continuation is GUARANTEED to run
@@ -59,27 +86,10 @@ public class TaskMethodStrategy : IConversionStrategy
         }
         
         if (name == "WhenAll")
-        {
-            var arg = context.Converter.ConvertExpression(args[0].Expression);
-            // If variadic args? Task.WhenAll(t1, t2) -> Promise.all([t1, t2])
-            if (args.Count > 1) 
-            {
-                 var allArgs = string.Join(", ", args.Select(a => context.Converter.ConvertExpression(a.Expression)));
-                 return $"Promise.all([{allArgs}])";
-            }
-            return $"Promise.all({arg})";
-        }
+            return Combinator("Promise.all", invocation, args, context);
         
         if (name == "WhenAny")
-        {
-            var arg = context.Converter.ConvertExpression(args[0].Expression);
-            if (args.Count > 1) 
-            {
-                 var allArgs = string.Join(", ", args.Select(a => context.Converter.ConvertExpression(a.Expression)));
-                 return $"Promise.race([{allArgs}])";
-            }
-            return $"Promise.race({arg})";
-        }
+            return Combinator("Promise.race", invocation, args, context);
         
         if (name == "FromResult")
         {
@@ -88,6 +98,35 @@ public class TaskMethodStrategy : IConversionStrategy
         }
 
         return context.Unhandled(node, "Task");
+    }
+
+    /// <summary>
+    /// <c>Promise.all</c> / <c>Promise.race</c>, which take an ITERABLE. Several arguments are a
+    /// list of tasks and become an array; ONE argument is ambiguous — <c>WhenAll(t)</c> passes a
+    /// single task and <c>WhenAll(list)</c> passes the sequence, and the old code assumed the
+    /// second. <c>Promise.race(aPromise)</c> throws, because a promise is not iterable, so
+    /// <c>await Task.WhenAny(F(1))</c> died at runtime.
+    /// <para>
+    /// The MODEL decides which it is, since the shapes are indistinguishable in syntax. Where it
+    /// cannot answer, the argument is wrapped: a single task is the common form by far, and an
+    /// array of one sequence is at least a value <c>Promise.all</c> accepts rather than a throw.
+    /// </para>
+    /// </summary>
+    private static string Combinator(
+        string js,
+        InvocationExpressionSyntax invocation,
+        SeparatedSyntaxList<ArgumentSyntax> args,
+        ConversionContext context)
+    {
+        var translated = args.Select(a => context.Converter.ConvertExpression(a.Expression)).ToList();
+        if (translated.Count != 1) return $"{js}([{string.Join(", ", translated)}])";
+
+        var type = context.SemanticHelper.GetType(args[0].Expression);
+        var isSequence = type is not null
+            && type.SpecialType != SpecialType.System_String
+            && type.AllInterfaces.Any(i => i.SpecialType == SpecialType.System_Collections_IEnumerable);
+
+        return isSequence ? $"{js}({translated[0]})" : $"{js}([{translated[0]}])";
     }
 
     public int Priority => 10;

--- a/src/eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/AnonymousMethodExpressionStrategy.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/AnonymousMethodExpressionStrategy.cs
@@ -18,7 +18,11 @@ public class AnonymousMethodExpressionStrategy : IExpressionIrStrategy
         var parameters = anon.ParameterList is null
             ? ""
             : string.Join(", ", anon.ParameterList.Parameters.Select(p => p.Identifier.Text));
-        return JsExpr.ArrowBlock(parameters, context.Converter.ConvertBlock(anon.Block));
+        // `async delegate { … }` keeps its async, for the same reason the local function does:
+        // an arrow that is not async makes `await` in its body a SyntaxError, and the module then
+        // fails to parse rather than misbehaving somewhere visible.
+        var isAsync = anon.Modifiers.Any(Microsoft.CodeAnalysis.CSharp.SyntaxKind.AsyncKeyword);
+        return JsExpr.ArrowBlock(parameters, context.Converter.ConvertBlock(anon.Block), isAsync);
     }
 
     public int Priority => 10;

--- a/src/eQuantic.UI.Compiler/CodeGen/Strategies/Statements/LocalFunctionStatementStrategy.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Strategies/Statements/LocalFunctionStatementStrategy.cs
@@ -41,7 +41,13 @@ public class LocalFunctionStatementStrategy : IStatementStrategy
                 }),
                 context.Layout, context.Depth);
 
-        return JsStatement.Const(name, JsExpr.ArrowBlock(parameters, block));
+        // The `async` has to cross. A C# local function that awaits becomes a JS arrow that
+        // awaits, and an arrow that is not `async` makes `await` in its body a SyntaxError — the
+        // module then fails to parse, which is a build that succeeds and a page that never runs.
+        // Lambdas already carry it (LambdaExpressionStrategy) and so do component methods; this
+        // one dropped it, so the shape only broke where somebody wrote a local async helper.
+        var isAsync = localFn.Modifiers.Any(SyntaxKind.AsyncKeyword);
+        return JsStatement.Const(name, JsExpr.ArrowBlock(parameters, block, isAsync));
     }
 
     /// <summary>

--- a/tests/eQuantic.UI.Compiler.Tests/Coverage/diagnostics.baseline.txt
+++ b/tests/eQuantic.UI.Compiler.Tests/Coverage/diagnostics.baseline.txt
@@ -29,6 +29,7 @@ EQ2109 eQuantic.UI.Compiler/CodeGen/Strategies/Invocation/ToStringStrategy.cs
 EQ2110 eQuantic.UI.Compiler/CodeGen/Strategies/Invocation/ToStringStrategy.cs
 EQ2111 eQuantic.UI.Compiler/CodeGen/Strategies/Invocation/ServiceProviderStrategy.cs
 EQ2112 eQuantic.UI.Compiler/Services/SemanticValidator.cs
+EQ2113 eQuantic.UI.Compiler/CodeGen/Strategies/Async/TaskMethodStrategy.cs
 EQ3001 eQuantic.UI.Native.Generators/PhotonProgramGenerator.cs
 EQ3002 eQuantic.UI.Native.Generators/PhotonProgramGenerator.cs
 EQ3003 eQuantic.UI.Native.Generators/CapabilityDeclarations.cs

--- a/tests/eQuantic.UI.Conformance.Tests/AsyncConformanceTests.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/AsyncConformanceTests.cs
@@ -4,10 +4,21 @@ using Xunit;
 namespace eQuantic.UI.Conformance.Tests;
 
 /// <summary>
-/// A Task is a Promise on the other side and `await` is `await`, but until now the harness could
-/// not RUN either: it wrapped every block in a plain arrow, where `await` is a SyntaxError, so bun
-/// exited before printing and the failure read as a translation bug. These are the first executed
-/// async cases in the suite, and the first run found a gap nobody had written down.
+/// A Task is a Promise on the other side and `await` is `await`, but until recently the harness
+/// could not RUN either, so none of this had ever executed.
+/// <para>
+/// The first run reported three failures as a compiler gap — "the TYPE of an awaited call does not
+/// reach the value it produces". **Two of the three were the harness**, not the compiler: its
+/// synthesized wrapper had no `using System.Threading.Tasks` and its `__Eval` was not `async`, so
+/// `Task&lt;string&gt;` did not bind and `await` was not even valid C# there. The tree came back
+/// full of errors and eqc did what it says it does when the model cannot answer — guessed a name.
+/// The compiler was right and the instrument was wrong, which is the third time in one day.
+/// </para>
+/// <para>
+/// The third was real: an async LOCAL FUNCTION (and `async delegate`) lost its `async`, so a body
+/// that awaited became a SyntaxError and the module failed to parse. Lambdas and component methods
+/// already carried it; those two dropped it.
+/// </para>
 /// </summary>
 public class AsyncConformanceTests
 {
@@ -17,50 +28,27 @@ public class AsyncConformanceTests
     [InlineData("var r = await Task.FromResult(7); return $\"{r}\";")]
     [InlineData("async Task<int> F(int v) => v * 3; var xs = await Task.WhenAll(F(1), F(2)); return $\"{xs[0]}{xs[1]}\";")]
     [InlineData("async Task<int> F(int v) => v; var t = 0; for (var i = 0; i < 3; i++) t += await F(i); return $\"{t}\";")]
+    // The awaited value keeps its TYPE: a member on it resolves rather than being name-guessed,
+    // and a conversion onto it fires. Both were reported as broken and were the harness.
+    [InlineData("async Task<string> F() => \"ok\"; var s = await F(); return s.ToUpperInvariant();")]
+    [InlineData("async Task<long> F() => 40L; var l = await F(); return (l + 2).ToString();")]
+    // The one that WAS a compiler bug: an async local function whose body awaits. Without `async`
+    // on the emitted arrow this is a SyntaxError and the whole module fails to parse.
+    //
+    // The yield is awaited OUTSIDE any catch on purpose. Written with the throw inside a
+    // try/catch, this case passed while `Task.Yield()` emitted `Task.yield()` — a name that
+    // exists nowhere — because the catch swallowed the ReferenceError and the fold still read
+    // -1. A green tick for the wrong reason is worse than a red one.
+    [InlineData("async Task<int> F(int v) { await Task.Yield(); return v * 4; } "
+        + "var a = await F(5); return $\"{a}\";")]
+    [InlineData("async Task<int> F() { await Task.Yield(); throw new InvalidOperationException(\"x\"); } "
+        + "var r = 0; try { r = await F(); } catch { r = -1; } return $\"{r}\";")]
+    // `async delegate` is the same shape, and dropped it the same way.
+    [InlineData("Func<Task<int>> f = async delegate { await Task.Yield(); return 9; }; "
+        + "var r = await f(); return $\"{r}\";")]
     public void AsyncPrograms_MatchDotNet(string program)
     {
         Skip.IfNot(JsExecutor.IsAvailable, "No JS engine available.");
         ConformanceRunner.AssertStatementsSameAsDotNet(program);
-    }
-
-    /// <summary>
-    /// The gap the first async run found: the TYPE of an awaited call does not reach the value it
-    /// produces. `var s = await F();` where F returns a Task&lt;string&gt; leaves `s` untyped, so a
-    /// member on it is name-guessed (`.toUpperInvariant()`, which exists nowhere) and a conversion
-    /// on it never fires (`l + 2` stays a BigInt beside a Number, which throws). Both work the
-    /// moment the same call is synchronous, so it is the await that loses the type and not the
-    /// local function. An async local function is also not emitted `async`, so a body that awaits
-    /// is a SyntaxError in its own right.
-    /// <para>
-    /// Held as a LEDGER rather than a skip: this fails when one of them starts working, which is
-    /// the direction that would otherwise go unnoticed. Move the case up to the theory above and
-    /// delete it here.
-    /// </para>
-    /// </summary>
-    [SkippableFact]
-    public void TheAwaitedValueLosesItsType_AndTheseAreTheCasesThatProveIt()
-    {
-        Skip.IfNot(JsExecutor.IsAvailable, "No JS engine available.");
-
-        string[] known =
-        [
-            // a member lookup on an awaited string
-            "async Task<string> F() => \"ok\"; var s = await F(); return s.ToUpperInvariant();",
-            // a conversion onto an awaited long
-            "async Task<long> F() => 40L; var l = await F(); return (l + 2).ToString();",
-            // an async local function whose body awaits is not marked async
-            "async Task<int> F() { await Task.Yield(); throw new InvalidOperationException(\"x\"); } "
-            + "var r = 0; try { r = await F(); } catch { r = -1; } return $\"{r}\";",
-        ];
-
-        var nowWorking = known.Where(program =>
-        {
-            try { ConformanceRunner.AssertStatementsSameAsDotNet(program); return true; }
-            catch { return false; }
-        }).ToList();
-
-        Assert.True(nowWorking.Count == 0,
-            "these async cases now match .NET — move them into AsyncPrograms_MatchDotNet and delete "
-            + "them here, so the suite records that the gap closed:\n  " + string.Join("\n  ", nowWorking));
     }
 }

--- a/tests/eQuantic.UI.Conformance.Tests/AsyncConformanceTests.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/AsyncConformanceTests.cs
@@ -51,4 +51,39 @@ public class AsyncConformanceTests
         Skip.IfNot(JsExecutor.IsAvailable, "No JS engine available.");
         ConformanceRunner.AssertStatementsSameAsDotNet(program);
     }
+
+    /// <summary>
+    /// The rest of the Task surface, swept after the first two bugs rather than waiting for the
+    /// third to be reported. Three more were broken, and all three are everyday async C#:
+    /// <list type="bullet">
+    /// <item><c>ConfigureAwait</c> is an INSTANCE call, so the strategy's `Task.` gate never saw it
+    /// and it emitted `.configureAwait(false)` — a method that exists nowhere.</item>
+    /// <item><c>Task.CompletedTask</c> is a PROPERTY, so the invocation gate never saw it
+    /// either.</item>
+    /// <item><c>WhenAll</c>/<c>WhenAny</c> with ONE argument passed it to `Promise.all`/`race`
+    /// unwrapped. A promise is not iterable, so a single-task call threw — and the model is what
+    /// tells a lone task from a sequence, since the two are the same syntax.</item>
+    /// </list>
+    /// </summary>
+    [SkippableTheory]
+    [InlineData("async Task<int> F() => 7; var r = await F().ConfigureAwait(false); return $\"{r}\";")]
+    [InlineData("async Task F() { await Task.CompletedTask; } await F(); return \"ok\";")]
+    [InlineData("await Task.Delay(1); return \"ok\";")]
+    [InlineData("var r = await Task.Run(() => 6 * 7); return $\"{r}\";")]
+    // ONE task, not a sequence: the shape that threw.
+    [InlineData("async Task<int> F(int v) => v; var t = await Task.WhenAny(F(1)); return $\"{await t}\";")]
+    [InlineData("async Task<int> F(int v) => v * 2; var xs = await Task.WhenAll(F(3)); return $\"{xs[0]}\";")]
+    // …and a SEQUENCE, which must still go through unwrapped.
+    [InlineData("async Task<int> F(int v) => v; var ts = new[] { F(1), F(2) }.ToList(); "
+        + "var xs = await Task.WhenAll(ts); return $\"{xs[0]}{xs[1]}\";")]
+    [InlineData("var r = 0; try { await Task.FromException(new InvalidOperationException(\"x\")); } "
+        + "catch { r = -1; } var ok = 5; return $\"{r}{ok}\";")]
+    [InlineData("async ValueTask<int> F() => 3; var r = await F(); return $\"{r}\";")]
+    [InlineData("async Task F(int v) { var _ = v; } await F(2); return \"done\";")]
+    [InlineData("Func<Task<int>> f = async () => { await Task.Yield(); return 11; }; return $\"{await f()}\";")]
+    public void TheTaskSurface_MatchesDotNet(string program)
+    {
+        Skip.IfNot(JsExecutor.IsAvailable, "No JS engine available.");
+        ConformanceRunner.AssertStatementsSameAsDotNet(program);
+    }
 }

--- a/tests/eQuantic.UI.Conformance.Tests/ConfigureAwaitGateTests.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/ConfigureAwaitGateTests.cs
@@ -1,0 +1,50 @@
+using eQuantic.UI.Conformance.Tests.Infrastructure;
+using Xunit;
+
+namespace eQuantic.UI.Conformance.Tests;
+
+/// <summary>
+/// `ConfigureAwait` is dropped, because JavaScript has one context to resume on. Two things have
+/// to be true for that to be safe, and neither was when the drop was first written:
+/// the call must actually BE the BCL's (a name gate takes anybody's method of that name and
+/// silently discards it), and its argument must not be able to do anything (dropping the call
+/// drops the argument, and a side effect that stops happening surfaces nowhere near its cause).
+/// </summary>
+public class ConfigureAwaitGateTests
+{
+    [SkippableTheory]
+    [InlineData("async Task<int> F() => 7; var r = await F().ConfigureAwait(false); return $\"{r}\";")]
+    [InlineData("async Task<int> F() => 7; var r = await F().ConfigureAwait(true); return $\"{r}\";")]
+    [InlineData("async ValueTask<int> F() => 8; var r = await F().ConfigureAwait(false); return $\"{r}\";")]
+    // A constant that is not a literal is still a constant: nothing to evaluate.
+    [InlineData("const bool Ctx = false; async Task<int> F() => 9; var r = await F().ConfigureAwait(Ctx); return $\"{r}\";")]
+    public void TheBclConfigureAwait_IsDroppedAndTheValueSurvives(string program)
+    {
+        Skip.IfNot(JsExecutor.IsAvailable, "No JS engine available.");
+        ConformanceRunner.AssertStatementsSameAsDotNet(program);
+    }
+
+    /// <summary>
+    /// Somebody else's `ConfigureAwait` is a real method and has to KEEP running. Under the old
+    /// name gate this returned the receiver and the method never ran at all — silently, since the
+    /// emitted code is perfectly valid JavaScript that simply does less.
+    /// </summary>
+    [SkippableFact]
+    public void AConfigureAwaitOnSomebodyElsesType_IsNotDropped()
+    {
+        Skip.IfNot(JsExecutor.IsAvailable, "No JS engine available.");
+
+        // A RECORD, because the harness emits those to the other side and a plain class it does
+        // not — the type has to exist over there for the call to be observable at all.
+        const string prelude = """
+            public sealed record Meter(int Reads)
+            {
+                public Meter ConfigureAwait(bool flag) => new Meter(Reads + (flag ? 2 : 1));
+            }
+            """;
+
+        ConformanceRunner.AssertStatementsSameAsDotNet(
+            "var m = new Meter(0).ConfigureAwait(false).ConfigureAwait(true); return $\"{m.Reads}\";",
+            prelude);
+    }
+}

--- a/tests/eQuantic.UI.Conformance.Tests/Infrastructure/Transpiler.cs
+++ b/tests/eQuantic.UI.Conformance.Tests/Infrastructure/Transpiler.cs
@@ -121,12 +121,13 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 {prelude}
 
 public class __Conformance
 {{
-    public object? __Eval()
+    public async Task<object?> __Eval()
     {{
         {evalBody}
     }}


### PR DESCRIPTION
## Why this exists

Async is advertised as supported and had **never been executed** by the conformance suite: the
harness wrapped every block in a plain arrow, where `await` is a SyntaxError, so bun exited before
printing and the failure read as a translation bug. Once it could run, five things were broken.

## The correction first, because I got the diagnosis wrong

I reported three failures as one compiler gap — *"the type of an awaited call does not reach the
value it produces"*. **Two of the three were the harness.** Its synthesized wrapper had no
`using System.Threading.Tasks` and its `__Eval` was not `async`, so `Task<string>` never bound and
`await` was not valid C# there. The tree came back full of errors and eqc did exactly what it
documents for a model that cannot answer: it guessed a name.

The compiler was right and the instrument was wrong — the fourth time in this phase. `COVERAGE-PLAN.md`
now records the score as **four instrument faults to two compiler bugs**, because on a suite this
size the thing most likely to be wrong about a failure is the thing doing the measuring.

## What was actually broken

| | |
|---|---|
| an async **local function** (and `async delegate`) | lost the `async` on the emitted arrow, so a body that awaited was a SyntaxError and the module never parsed. Lambdas and component methods already carried it |
| `Task.Yield()` | had no translation at all and emitted `Task.yield()`. Now `new Promise(resolve => setTimeout(resolve, 0))` — a resolved promise is a microtask and would not yield the loop, which is the whole point |
| `ConfigureAwait` | is an **instance** call, so the `Task.` gate never saw it → `.configureAwait(false)`, a method that exists nowhere |
| `Task.CompletedTask` | is a **property**, so the invocation gate never saw it either → `Task.completedTask` |
| `WhenAll`/`WhenAny` with **one** argument | handed it to `Promise.all`/`race` unwrapped, and a promise is not iterable. Two arguments were fine, which is why nothing had noticed |

The last three came from asking what else has the same shape, rather than waiting for each to be
reported.

## Two things worth keeping

**`WhenAll(t)` and `WhenAll(list)` are the same syntax**, so only the model can tell a lone task
from a sequence. Where it cannot answer the argument is wrapped: a single task is far the commoner
form, and an array holding one sequence is at least a value `Promise.all` accepts rather than a
throw. Both branches are pinned — a fix that only handles the case that broke is how the other one
starts failing later.

**One of my own cases passed for the wrong reason.** The `Task.Yield()` case had the yield inside a
`try/catch`, so it went green while the name was broken: the catch swallowed the ReferenceError and
the fold read the value the catch wrote. It now awaits outside any catch, and reverting the fix is
what proved it bites.

Conformance **1141** · Compiler **811** · Web **556** · Server **133**.