### PR TITLE
🔧 chore: 0.2.0-preview.43

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.42</Version>
+        <Version>0.2.0-preview.43</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
Cuts `0.2.0-preview.43`. One line in `Directory.Build.props`; the tag `v0.2.0-preview.43` follows
once this lands, and that is what publishes to nuget.org.

## What the version carries since preview.42

**#38 — the client stops making the page worse than the server made it.** Three bugs with one
shape, all invisible to `curl`:

- A constructor dependency silenced the page's *entire* hydration payload. The server rendered
  correctly, hydration rebuilt from nothing, and what the page had prefetched vanished in front of
  the reader. Dependencies (an interface from outside `System`, the rule `CapabilityRule` states)
  are skipped because the client resolves them itself; everything else is written field by field so
  one bad value cannot take the rest.
- `GetService<T>()` returned null inside a server action — the renderer arms `CapabilityScope` for
  a request, the action middleware never did. With the above, this closes a dilemma that had no way
  out: constructor injection was the only route to the container, and it was exactly what killed the
  prefetch.
- A page bundle that failed to load replaced a correctly-rendered page with "404 — This page could
  not be found." Measured on the sample in a production build, chunk answering a real 404: 1802
  chars of intact page with the guard, 56 without. Dev keeps the loud page.

**#37 — window-relative sizing.** `SizeValue.WindowMinus(dp)` for a cap no constant can express,
plus the default that needs none: a panel refuses to outgrow the window.

**#36, #34, #33** — contracts read off the served document; a transparent layout node is not a hit
target.

## Release-relevant

The dependency-vs-state rule matters immediately for a consumer building a consent screen: a
`IReadOnlyList<ScopeItem>` of scopes rendered on the server and hydrated empty means a user
approving a permission list the page no longer shows. Verified covered, both directions.

Validated independently against this code by a consuming app: payload survives three constructor
dependencies, carries none of them, and its configuration no longer disappears at hydration.