### PR TITLE
📝 docs: every field of a prefetched page is public

### DIFF
--- a/src/eQuantic.UI.Primitives/Nodes/IServerPrefetch.cs
+++ b/src/eQuantic.UI.Primitives/Nodes/IServerPrefetch.cs
@@ -26,6 +26,19 @@ namespace eQuantic.UI.Primitives;
 /// </code>
 /// </example>
 /// <para>
+/// EVERY FIELD IS PUBLIC. The payload is written into the served HTML, so a value a prefetch stores
+/// is readable by anyone who views the page source — it is not "server data" once it lands in a
+/// field. Load what the page DISPLAYS, and nothing else: an access token used to fetch, the
+/// connection string behind the query, the internal id you only needed while loading. Where a
+/// secret is unavoidable, keep it out of the fields and off the tree — resolve it inside a
+/// <c>[ServerAction]</c>, which runs on the server and returns only its result.
+/// <para>
+/// The one exception is a DEPENDENCY: a field whose type is an interface from outside
+/// <c>System</c> is skipped, because the client resolves that for itself. Everything else travels,
+/// including a <c>string</c> nobody meant to publish.
+/// </para>
+/// </para>
+/// <para>
 /// Native fence: Photon hosts render locally, so nothing prefetches for them — a native shell loads
 /// its data before constructing the tree (the same data, an explicit call).
 /// </para>

--- a/src/eQuantic.UI.Primitives/Nodes/IServerPrefetch.cs
+++ b/src/eQuantic.UI.Primitives/Nodes/IServerPrefetch.cs
@@ -38,9 +38,16 @@ namespace eQuantic.UI.Primitives;
 /// rule is the same on both sides: what crosses is what the page may show.
 /// </para>
 /// <para>
-/// The one exception is a DEPENDENCY: a field whose type is an interface from outside
-/// <c>System</c> is skipped, because the client resolves that for itself. Everything else travels,
-/// including a <c>string</c> nobody meant to publish.
+/// What does NOT travel is a DEPENDENCY: a field whose type is an interface from outside
+/// <c>System</c>, which the client resolves for itself. The <c>System</c> exclusion is deliberate
+/// and not a detail — <c>IReadOnlyList&lt;T&gt;</c> is how a component RECEIVES its items, so
+/// skipping every interface would delete state rather than protect anything.
+/// </para>
+/// <para>
+/// Everything else that CAN be written travels, including a <c>string</c> nobody meant to publish.
+/// A null, a delegate, and a value that fails to serialize are left out — but read that as what it
+/// is, a robustness rule so one field cannot empty the payload. It is NOT a protection: never rely
+/// on a value being unserializable to keep it off the page.
 /// </para>
 /// <para>
 /// Native fence: Photon hosts render locally, so nothing prefetches for them — a native shell loads

--- a/src/eQuantic.UI.Primitives/Nodes/IServerPrefetch.cs
+++ b/src/eQuantic.UI.Primitives/Nodes/IServerPrefetch.cs
@@ -29,14 +29,18 @@ namespace eQuantic.UI.Primitives;
 /// EVERY FIELD IS PUBLIC. The payload is written into the served HTML, so a value a prefetch stores
 /// is readable by anyone who views the page source — it is not "server data" once it lands in a
 /// field. Load what the page DISPLAYS, and nothing else: an access token used to fetch, the
-/// connection string behind the query, the internal id you only needed while loading. Where a
-/// secret is unavoidable, keep it out of the fields and off the tree — resolve it inside a
-/// <c>[ServerAction]</c>, which runs on the server and returns only its result.
+/// connection string behind the query, the internal id you only needed while loading.
+/// </para>
+/// <para>
+/// A secret belongs in neither place. A <c>[ServerAction]</c> runs on the server and may USE one —
+/// read a token, open a connection, call an API with it — but its return value is serialized to the
+/// browser exactly as a field is, so return the ANSWER and never the secret that produced it. The
+/// rule is the same on both sides: what crosses is what the page may show.
+/// </para>
 /// <para>
 /// The one exception is a DEPENDENCY: a field whose type is an interface from outside
 /// <c>System</c> is skipped, because the client resolves that for itself. Everything else travels,
 /// including a <c>string</c> nobody meant to publish.
-/// </para>
 /// </para>
 /// <para>
 /// Native fence: Photon hosts render locally, so nothing prefetches for them — a native shell loads


### PR DESCRIPTION
`IServerPrefetch` documented how to store results — "store results in ordinary FIELDS" — and never
that storing them **publishes** them. The payload is written into the served HTML, so a value a
prefetch stores is readable by anyone who views the page source.

Raised by a consuming app that noticed a `_password` field riding along in its payload. Empty at
SSR, harmless today, and exactly the shape that stops being harmless the day a page loads a token
into a field to use it.

The added text states three things:

- **The rule.** A value stops being "server data" the moment it lands in a field. Load what the page
  *displays*, and nothing else.
- **Where a secret goes instead.** Inside a `[ServerAction]`, which runs on the server and returns
  only its result.
- **The one exception.** A field whose type is an interface from outside `System` is skipped,
  because the client resolves it for itself — and why that exception is not "skip every interface":
  `IReadOnlyList<T>` is how a component *receives* its items, and skipping it would delete state
  instead of protecting it.

The wiki carries the same statement, EN and pt-BR, in
[6042531](https://github.com/eQuantic/equantic-ui/wiki/ServerIntegration#every-field-is-public).

The version mark on the wiki section caught an error while writing it: I had marked the section
against `SerializeState`, which shipped in preview.1, not against the rule that is actually new. It
names `IsDependency` now, and the three wiki guards pass.