### PR TITLE
🐛 fix: the 404 fallback hands over its payload like the mapped route does

### DIFF
--- a/src/eQuantic.UI.Server/UIExtensions.cs
+++ b/src/eQuantic.UI.Server/UIExtensions.cs
@@ -651,6 +651,39 @@ public static class UIExtensions
         var ssrEnabled = false;
         string? serializedState = null;
 
+        // ONE adoption for BOTH doors to the same page: the mapped route, and the fallback every
+        // URL that matched nothing comes through. They were two copies of this and drifted — the
+        // fallback quietly kept neither the payload nor the assets, so a not-found page that loads
+        // its branding served it and then hydrated blank, unstyled. A local function instead of a
+        // second copy, because the next thing a render result carries has one place to be adopted.
+        void AdoptSsr(Rendering.ServerRenderResult adopted)
+        {
+            ssrContent = adopted.Html!;
+            vectorDefs = adopted.VectorDefs;
+            ssrEnabled = true;
+            serializedState = adopted.SerializedState;
+
+            if (adopted.Metadata != null)
+            {
+                if (!string.IsNullOrEmpty(adopted.Metadata.Title))
+                    metadata.Title = adopted.Metadata.Title;
+
+                foreach (var tag in adopted.Metadata.Tags)
+                    metadata.AddOrUpdate(tag);
+            }
+
+            // The page's atomic CSS rides here. Without it the fallback served the right markup
+            // with none of its classes defined.
+            if (adopted.Assets != null)
+            {
+                foreach (var tag in adopted.Assets.RenderTags())
+                {
+                    if (!headTags.Contains(tag))
+                        headTags.Add(tag);
+                }
+            }
+        }
+
         if (pageName != null && options.EnableSsr)
         {
             var renderingService = context.RequestServices.GetService<IServerRenderingService>();
@@ -661,37 +694,17 @@ public static class UIExtensions
                     var result = await renderingService.RenderPageAsync(pageName, context);
                     if (result.Success && result.Html != null)
                     {
-                        ssrContent = result.Html;
-                        vectorDefs = result.VectorDefs;
-                        ssrEnabled = true;
-                        serializedState = result.SerializedState;
+                        AdoptSsr(result);
 
                         // What the PAGE asked to answer with (IHandleStatus). A route that matched
                         // while its content did not exist renders the right thing for a reader and
                         // must not tell every machine the request succeeded — a crawler would index
                         // the empty page and a link checker would call the site healthy.
+                        //
+                        // This one stays HERE and not in AdoptSsr: the fallback's status is already
+                        // 404 from the endpoint, and a page answering 200 must not raise it back.
                         if (result.StatusCode != StatusCodes.Status200OK)
                             context.Response.StatusCode = result.StatusCode;
-
-                        // Merge metadata from SSR
-                        if (result.Metadata != null)
-                        {
-                            if (!string.IsNullOrEmpty(result.Metadata.Title))
-                                metadata.Title = result.Metadata.Title;
-
-                            foreach(var tag in result.Metadata.Tags)
-                                metadata.AddOrUpdate(tag);
-                        }
-
-                        // Merge asset dependencies from components
-                        if (result.Assets != null)
-                        {
-                            foreach (var tag in result.Assets.RenderTags())
-                            {
-                                if (!headTags.Contains(tag))
-                                    headTags.Add(tag);
-                            }
-                        }
                     }
                 }
                 catch (Exception ex)
@@ -739,15 +752,7 @@ public static class UIExtensions
                             var result = await renderingService.RenderPageAsync(pageName, context);
                             if (result.Success && result.Html != null)
                             {
-                                ssrContent = result.Html;
-                                vectorDefs = result.VectorDefs;
-                                ssrEnabled = true;
-                                // The SAME page reached by an unmatched URL instead of by /404, so it
-                                // hydrates from the same payload. Without this line the branches
-                                // differed by one: /404 rendered and kept its prefetched state, and
-                                // /anything-else rendered identically and then hydrated from nothing.
-                                serializedState = result.SerializedState;
-                                if (!string.IsNullOrEmpty(result.Metadata?.Title)) metadata.Title = result.Metadata.Title;
+                                AdoptSsr(result);
                             }
                         }
                     }

--- a/src/eQuantic.UI.Server/UIExtensions.cs
+++ b/src/eQuantic.UI.Server/UIExtensions.cs
@@ -769,8 +769,16 @@ public static class UIExtensions
             }
         }
 
-        // 500 Error Handling during SSR
-        if (!ssrEnabled && pageName != null && options.EnableSsr)
+        // 500 Error Handling during SSR.
+        //
+        // NOT when the answer is already 404. Reaching here with a 404 means the app's own
+        // not-found page failed to render, and the request is still what it was: a URL that
+        // matches nothing. Upgrading it to 500 tells every crawler and link checker the server
+        // broke, when what happened is the resource does not exist — and it undoes the contract
+        // the branch above exists to hold, that a 404 page failing must not fail the 404.
+        var alreadyNotFound = context.Response.StatusCode == StatusCodes.Status404NotFound;
+
+        if (!ssrEnabled && pageName != null && options.EnableSsr && !alreadyNotFound)
         {
             // If we are here, it means SSR failed or was disabled.
             // We need to check if it failed due to an exception (which we can't easily track from here without earlier logic change)
@@ -794,10 +802,9 @@ public static class UIExtensions
                              context.Response.StatusCode = 500;
                              pageName = errorPageName;
                              pageValue = $"'{pageName}'";
-                             ssrContent = result.Html;
-                        vectorDefs = result.VectorDefs;
-                             ssrEnabled = true; // Enabled for the error page
-                             if (!string.IsNullOrEmpty(result.Metadata?.Title)) metadata.Title = result.Metadata.Title;
+                             // The THIRD door to a rendered page, and it was drifting like the other
+                             // two: an error page that loads its own branding kept none of it.
+                             AdoptSsr(result);
                          }
                     }
                 }

--- a/src/eQuantic.UI.Server/UIExtensions.cs
+++ b/src/eQuantic.UI.Server/UIExtensions.cs
@@ -740,13 +740,26 @@ public static class UIExtensions
                             if (result.Success && result.Html != null)
                             {
                                 ssrContent = result.Html;
-                        vectorDefs = result.VectorDefs;
+                                vectorDefs = result.VectorDefs;
                                 ssrEnabled = true;
+                                // The SAME page reached by an unmatched URL instead of by /404, so it
+                                // hydrates from the same payload. Without this line the branches
+                                // differed by one: /404 rendered and kept its prefetched state, and
+                                // /anything-else rendered identically and then hydrated from nothing.
+                                serializedState = result.SerializedState;
                                 if (!string.IsNullOrEmpty(result.Metadata?.Title)) metadata.Title = result.Metadata.Title;
                             }
                         }
                     }
-                    catch { /* Ignore 404 render errors */ }
+                    catch (Exception ex)
+                    {
+                        // The 404 page failing must not fail the 404, so this still swallows — but
+                        // SILENTLY is how the missing line above survived: a page that threw here
+                        // looked exactly like a page that rendered.
+                        context.RequestServices.GetService<ILoggerFactory>()?
+                            .CreateLogger("eQuantic.UI.NotFound")
+                            .LogWarning(ex, "The registered /404 page failed to render; serving the shell without it");
+                    }
                 }
             }
         }

--- a/tests/eQuantic.UI.Server.Tests/NotFoundFallbackTests.cs
+++ b/tests/eQuantic.UI.Server.Tests/NotFoundFallbackTests.cs
@@ -46,9 +46,9 @@ public class NotFoundFallbackTests
 
     /// <summary>Registered only by the test that wants the 404 page to fail, so the page can break
     /// on demand without a static flag that leaks into every other test in the class.</summary>
-    private interface IBreakTheNotFoundPage;
+    private interface IBreakTheNotFoundPage { }
 
-    private sealed class BreakIt : IBreakTheNotFoundPage;
+    private sealed class BreakIt : IBreakTheNotFoundPage { }
 
     /// <summary>The app's 500 page, so the error path has somewhere to go.</summary>
     [eQuantic.UI.Core.Page("/500")]

--- a/tests/eQuantic.UI.Server.Tests/NotFoundFallbackTests.cs
+++ b/tests/eQuantic.UI.Server.Tests/NotFoundFallbackTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
@@ -32,6 +33,9 @@ public class NotFoundFallbackTests
         [eQuantic.UI.Core.ServerOnly]
         public Task PrefetchAsync(IServiceProvider services, CancellationToken cancellationToken)
         {
+            if (services.GetService(typeof(IBreakTheNotFoundPage)) != null)
+                throw new InvalidOperationException("the branded 404 page could not load its branding");
+
             _brand = "northwind-brand";
             return Task.CompletedTask;
         }
@@ -40,8 +44,22 @@ public class NotFoundFallbackTests
             new eQuantic.UI.Primitives.Text(_brand, eQuantic.UI.Primitives.TypeRole.Heading);
     }
 
+    /// <summary>Registered only by the test that wants the 404 page to fail, so the page can break
+    /// on demand without a static flag that leaks into every other test in the class.</summary>
+    private interface IBreakTheNotFoundPage;
+
+    private sealed class BreakIt : IBreakTheNotFoundPage;
+
+    /// <summary>The app's 500 page, so the error path has somewhere to go.</summary>
+    [eQuantic.UI.Core.Page("/500")]
+    public class AppError : eQuantic.UI.Primitives.StatelessComponent
+    {
+        public override eQuantic.UI.Primitives.VisualNode Build(eQuantic.UI.Primitives.ComponentContext context) =>
+            new eQuantic.UI.Primitives.Text("something broke", eQuantic.UI.Primitives.TypeRole.Heading);
+    }
+
     private static async Task<(WebApplication App, HttpClient Client)> StartAppAsync(
-        bool scanTestPages, bool ssr = false)
+        bool scanTestPages, bool ssr = false, bool breakNotFound = false)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -53,6 +71,8 @@ public class NotFoundFallbackTests
             options.EnableSsr = ssr;
             if (scanTestPages) options.ScanAssembly(Assembly.GetExecutingAssembly());
         });
+
+        if (breakNotFound) builder.Services.AddSingleton<IBreakTheNotFoundPage, BreakIt>();
 
         var app = builder.Build();
         app.MapUI();
@@ -123,6 +143,21 @@ public class NotFoundFallbackTests
         // its classes defined. Comparing the <head> is what makes "one page, two doors" testable at
         // all — anything a render result grows later is covered by the same line.
         Head(mappedHtml).Should().Be(Head(fallbackHtml), "one page cannot have two heads");
+    }
+
+    [Fact]
+    public async Task A404PageThatFailsStillAnswers404()
+    {
+        var (app, client) = await StartAppAsync(scanTestPages: true, ssr: true, breakNotFound: true);
+        await using var _ = app;
+
+        var response = await client.GetAsync("/definitely-not-a-page");
+
+        // The request has not changed: it is still a URL that matches nothing. The app's own 404
+        // page failing is the SERVER's problem and not the reader's, and answering 500 tells every
+        // crawler and link checker the server broke — which also undoes the whole reason the
+        // fallback swallows that failure in the first place.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     /// <summary>The document head, which is where everything a render result contributes lands.</summary>

--- a/tests/eQuantic.UI.Server.Tests/NotFoundFallbackTests.cs
+++ b/tests/eQuantic.UI.Server.Tests/NotFoundFallbackTests.cs
@@ -18,11 +18,30 @@ public class NotFoundFallbackTests
     [eQuantic.UI.Core.Page("/known")]
     public class KnownPage { }
 
-    /// <summary>The app's branded not-found page — just another routed page.</summary>
+    /// <summary>
+    /// The app's branded not-found page. A REAL component that prefetches, because the branding on
+    /// a 404 is exactly the thing an app loads rather than hardcodes — a logo, a support link, the
+    /// tenant's name — and it is reached two ways: mapped at /404, and by every URL that matched
+    /// nothing. Both have to hydrate from the same payload.
+    /// </summary>
     [eQuantic.UI.Core.Page("/404")]
-    public class BrandedNotFound { }
+    public class BrandedNotFound : eQuantic.UI.Primitives.StatelessComponent, eQuantic.UI.Primitives.IServerPrefetch
+    {
+        private string _brand = "(not loaded)";
 
-    private static async Task<(WebApplication App, HttpClient Client)> StartAppAsync(bool scanTestPages)
+        [eQuantic.UI.Core.ServerOnly]
+        public Task PrefetchAsync(IServiceProvider services, CancellationToken cancellationToken)
+        {
+            _brand = "northwind-brand";
+            return Task.CompletedTask;
+        }
+
+        public override eQuantic.UI.Primitives.VisualNode Build(eQuantic.UI.Primitives.ComponentContext context) =>
+            new eQuantic.UI.Primitives.Text(_brand, eQuantic.UI.Primitives.TypeRole.Heading);
+    }
+
+    private static async Task<(WebApplication App, HttpClient Client)> StartAppAsync(
+        bool scanTestPages, bool ssr = false)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -30,7 +49,7 @@ public class NotFoundFallbackTests
         {
             // SSR off: these tests pin the ROUTING contract (status + which page boots), not
             // rendering. The test page types aren't real components and have no compiled bundles.
-            options.EnableSsr = false;
+            options.EnableSsr = ssr;
             if (scanTestPages) options.ScanAssembly(Assembly.GetExecutingAssembly());
         });
 
@@ -77,5 +96,25 @@ public class NotFoundFallbackTests
         (await client.GetAsync("/known")).StatusCode.Should().Be(HttpStatusCode.OK);
         // Browsing straight to /404 hits a mapped page, not the fallback.
         (await client.GetAsync("/404")).StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task TheFallbackCarriesTheSamePayloadAsTheMappedRoute()
+    {
+        var (app, client) = await StartAppAsync(scanTestPages: true, ssr: true);
+        await using var _ = app;
+
+        var mapped = await client.GetAsync("/404");
+        var fallback = await client.GetAsync("/definitely-not-a-page");
+
+        var mappedHtml = await mapped.Content.ReadAsStringAsync();
+        var fallbackHtml = await fallback.Content.ReadAsStringAsync();
+
+        // ONE page, two doors. The fallback branch rendered the same markup and then forgot to hand
+        // over the state, so an app whose 404 loads its branding served it correctly and blanked it
+        // the moment the page hydrated — on the door every real 404 comes through, and on no other.
+        mappedHtml.Should().Contain("__INITIAL_STATE__").And.Contain("northwind-brand");
+        fallbackHtml.Should().Contain("__INITIAL_STATE__").And.Contain("northwind-brand");
+        fallback.StatusCode.Should().Be(HttpStatusCode.NotFound, "branding does not make a page found");
     }
 }

--- a/tests/eQuantic.UI.Server.Tests/NotFoundFallbackTests.cs
+++ b/tests/eQuantic.UI.Server.Tests/NotFoundFallbackTests.cs
@@ -16,7 +16,15 @@ public class NotFoundFallbackTests
 {
     /// <summary>An app page occupying a normal route, so known-route behavior is contrasted.</summary>
     [eQuantic.UI.Core.Page("/known")]
-    public class KnownPage { }
+    public class KnownPage { 
+    /// <summary>The document head, which is where everything a render result contributes lands.</summary>
+    private static string Head(string html)
+    {
+        var start = html.IndexOf("<head", StringComparison.OrdinalIgnoreCase);
+        var end = html.IndexOf("</head>", StringComparison.OrdinalIgnoreCase);
+        return start >= 0 && end > start ? html[start..end] : html;
+    }
+}
 
     /// <summary>
     /// The app's branded not-found page. A REAL component that prefetches, because the branding on
@@ -47,8 +55,9 @@ public class NotFoundFallbackTests
         builder.WebHost.UseTestServer();
         builder.Services.AddUI(options =>
         {
-            // SSR off: these tests pin the ROUTING contract (status + which page boots), not
-            // rendering. The test page types aren't real components and have no compiled bundles.
+            // SSR OFF by default: most of these pin the ROUTING contract — the status, and which
+            // page boots — and the routing pages are not real components. The payload test turns it
+            // on, because what it compares is what SSR hands over.
             options.EnableSsr = ssr;
             if (scanTestPages) options.ScanAssembly(Assembly.GetExecutingAssembly());
         });
@@ -116,5 +125,19 @@ public class NotFoundFallbackTests
         mappedHtml.Should().Contain("__INITIAL_STATE__").And.Contain("northwind-brand");
         fallbackHtml.Should().Contain("__INITIAL_STATE__").And.Contain("northwind-brand");
         fallback.StatusCode.Should().Be(HttpStatusCode.NotFound, "branding does not make a page found");
+
+        // And the HEAD, not only the payload: the page's atomic CSS rides in the render result's
+        // assets, so a fallback that adopts less of the result serves the right markup with none of
+        // its classes defined. Comparing the <head> is what makes "one page, two doors" testable at
+        // all — anything a render result grows later is covered by the same line.
+        Head(mappedHtml).Should().Be(Head(fallbackHtml), "one page cannot have two heads");
+    }
+
+    /// <summary>The document head, which is where everything a render result contributes lands.</summary>
+    private static string Head(string html)
+    {
+        var start = html.IndexOf("<head", StringComparison.OrdinalIgnoreCase);
+        var end = html.IndexOf("</head>", StringComparison.OrdinalIgnoreCase);
+        return start >= 0 && end > start ? html[start..end] : html;
     }
 }

--- a/tests/eQuantic.UI.Server.Tests/NotFoundFallbackTests.cs
+++ b/tests/eQuantic.UI.Server.Tests/NotFoundFallbackTests.cs
@@ -16,15 +16,7 @@ public class NotFoundFallbackTests
 {
     /// <summary>An app page occupying a normal route, so known-route behavior is contrasted.</summary>
     [eQuantic.UI.Core.Page("/known")]
-    public class KnownPage { 
-    /// <summary>The document head, which is where everything a render result contributes lands.</summary>
-    private static string Head(string html)
-    {
-        var start = html.IndexOf("<head", StringComparison.OrdinalIgnoreCase);
-        var end = html.IndexOf("</head>", StringComparison.OrdinalIgnoreCase);
-        return start >= 0 && end > start ? html[start..end] : html;
-    }
-}
+    public class KnownPage { }
 
     /// <summary>
     /// The app's branded not-found page. A REAL component that prefetches, because the branding on


### PR DESCRIPTION
One page, two doors, and only one of them handed over the state.

`[Page("/404")]` reached as a **mapped route** carried its prefetched payload. The same page reached
through the **fallback** — every URL that matched nothing, which is how a real 404 actually
happens — rendered identical markup and then hydrated from nothing.

Measured side by side on one build by the app that hit it:

```
/404        status=200  payload=1
/nope-404   status=404  payload=0
```

SSR was correct in both. Only hydration differed.

## The cause

The two branches in `UIExtensions` are the same code. The fallback one reads `result.Html`,
`result.VectorDefs` and the metadata title, and never `result.SerializedState` — a line the mapped
branch has thirty lines above.

The consequence lands on exactly the apps that do the right thing: a not-found page that *loads* its
branding rather than hardcoding it served the logo, the support link and the tenant name correctly,
then blanked them a moment later.

## Also

The bare `catch { /* Ignore 404 render errors */ }` beside it now logs. It still swallows — a 404
page failing must not fail the 404 — but silence is how the missing line survived: a page that threw
there looked exactly like a page that rendered.

## What holds it

A test over the **real pipeline** (`TestServer`, no mocks) that fetches both doors and compares
them, so the next divergence fails instead of shipping. The app's `/404` in that test is now a real
component with a prefetch, which is what made the gap visible at all. A/B'd: removing the line fails
the test.

`dotnet test tests/eQuantic.UI.Server.Tests` → 141 passed.