### PR TITLE
🔧 chore: 0.2.0-preview.44

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.43</Version>
+        <Version>0.2.0-preview.44</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
Cuts `0.2.0-preview.44`. One line in `Directory.Build.props`; the tag `v0.2.0-preview.44` follows
once this lands, and that is what publishes to nuget.org.

## What the version carries since preview.43

**#41 — the 404 fallback is no longer a second-class door.** One page reached two ways, and only the
mapped route handed anything over. Every URL that matched nothing rendered identical markup and then
hydrated from nothing, and shipped without the page's assets — so an app whose not-found page loads
its branding served it correctly and blanked it, unstyled, a moment later. Both doors go through one
adoption now: html, vector defs, payload, metadata title, metadata tags, assets.

Beside it: a 404 page that *failed* to render used to answer **500** in Production, telling every
crawler and link checker the server broke when the resource simply does not exist. And the 500 path
turned out to be a third door with the same drift, so it adopts through the same place.

**#40 — every field of a prefetched page is public.** `IServerPrefetch` documented how to store
results and never that storing them publishes them: the payload is written into the served HTML.
States the rule, where a secret goes instead (a `[ServerAction]` may **use** one and returns the
answer, never the secret), and the one exception — a dependency the client resolves for itself. The
wiki carries the same statement in EN and pt-BR.

## Known, and NOT in this version

Two defects in `RecordTypeEmitter`, verified in a real build and left open deliberately — both have
a one-word workaround and neither blocks anyone:

- A `record` loses a `static T P { get; } = new(…)` in its twin. Build green, SSR perfect, and only
  the browser throws. Workaround: `public static readonly T P = new(…)`, which does cross.
- A `const` inside a record is counted as a **value** member: it enters the positional constructor,
  `equals`, `with` and `toString`, so the twin takes two parameters where C# takes one.

They are two different rules about what counts as a value member — one lets too little through, the
other too much — and they are tracked for a later version.