### PR TITLE
📝 docs: add Track M — email rendering

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -291,6 +291,23 @@ culture-aware FORMATTING subset and 3+ form plurals) in `docs/I18N-PLAN.md`. 202
 now also covers the SDK's OWN component strings (D14/W8 — a11y announcements were hardcoded
 English), the `CurrentCulture`/`CurrentUICulture` pair, and `<html lang>` from the request culture.
 
+## Track M — Email rendering
+
+Added 2026-08-24 (Edgar's question): author an email in C# with the same components a page is
+written with, and get back HTML an email client will actually render. Email is a THIRD REALIZER
+beside web and Photon — a target whose engine is merely very restrictive, which is architecturally
+the same shape as a target with no DOM, so nothing in the authoring layer changes.
+
+Two pieces already exist: `WebRealizer.Lower(..., styles: null)` keeps styles INLINE instead of
+atomising them into classes, and `HtmlRenderer.RenderNode` turns the lowered tree into a string.
+What is missing is the medium — nested-table layout for Outlook's Word engine, literal colors
+instead of custom properties, absolute image URLs, a 600px shell, and a fence over everything an
+email cannot do (`ScrollView`, `Pressable`, hover, `position: absolute`).
+
+Full design, slices and fences: wiki **[Email Rendering](https://github.com/eQuantic/equantic-ui/wiki/EmailRealizer)**.
+M0 MEASURES what the two existing calls already survive in Gmail, Outlook and Apple Mail before M1
+builds anything — half a day, no new code, and it decides the size of the rest.
+
 ## Definition of "production-ready" (per pillar)
 - **0 JS**: any unsupported C# fails the build with a clear message; conformance suite green; C#
   debuggable in the browser.


### PR DESCRIPTION
Answers a question about whether eQuantic.UI could build email bodies from C# components. It can,
and the roadmap now says how.

**Email is a third realizer**, beside web and Photon — a target whose rendering engine is merely
very restrictive, which is architecturally the same shape as a target with no DOM. Nothing in the
authoring layer changes: the same `Column`, `Text`, `Image` and theme tokens, the same
`Build(context)`.

Two pieces already exist, and the plan says so rather than overstating the work:

- `WebRealizer.Lower(node, theme, typeScale, styles: null)` keeps styles **inline** instead of
  atomising them into deduplicated classes — inline style being email's hardest constraint.
- `HtmlRenderer.RenderNode(...)` turns the lowered tree into an HTML string.

What is missing is the medium: nested-table layout for Outlook's Word engine (`Row`/`Column` lower
to `FlexDirection` today), literal colors instead of `var(--eq-color-…)`, absolute image URLs, the
600px shell, and a fence over everything an email cannot do.

**M0 measures before M1 builds** — render an existing component through those two calls, open it in
Gmail, Outlook and Apple Mail, and record what survives. Half a day, no new code, and it decides how
large the rest is. It is written that way deliberately.

The design, the slices, the fences and the testing approach are in the wiki, EN and pt-BR in
[one commit](https://github.com/eQuantic/equantic-ui/wiki/EmailRealizer) — page, both sidebars, both
roadmaps. This PR is the repo-side pointer, which is all `ROADMAP.md` should carry for it.