### PR TITLE
🐛 fix: record discovery knows every shape Emit writes, and defaults come from the symbol

### DIFF
--- a/src/eQuantic.UI.Compiler/CodeGen/RecordTypeEmitter.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/RecordTypeEmitter.cs
@@ -290,8 +290,16 @@ public class RecordTypeEmitter
         foreach (var conversion in type.Members.OfType<ConversionOperatorDeclarationSyntax>())
         {
             var parameter = conversion.ParameterList.Parameters[0];
-            var toSelf = conversion.Type.ToString() == name;
-            var opName = ConversionMethodName(toSelf ? parameter.Type!.ToString() : conversion.Type.ToString(), from: toSelf);
+            // The NAME comes from the symbol wherever there is one, through the same function the
+            // call site uses. The two used to compute it apart — this side compared type SYNTAX
+            // (`conversion.Type.ToString() == name`) and the call site compared SYMBOLS — so a
+            // conversion written with a qualified name emitted `toMoney` and was called as
+            // `fromInt`. Undefined at runtime, with a green build.
+            var opName = ModelFor(conversion)?.GetDeclaredSymbol(conversion) is { } symbol
+                ? ConversionNameFor(symbol)
+                : ConversionMethodName(
+                    conversion.Type.ToString() == name ? parameter.Type!.ToString() : conversion.Type.ToString(),
+                    from: conversion.Type.ToString() == name);
             var par = tsTypeDeclarations
                 ? $"{parameter.Identifier.Text.ToJsIdentifier()}: {TsTypeOf(parameter.Type)}"
                 : parameter.Identifier.Text.ToJsIdentifier();
@@ -420,6 +428,21 @@ public class RecordTypeEmitter
     /// The static-method name an operator becomes. Named for the operation, not for the CLR's
     /// <c>op_Addition</c> mangling: the emitted class is read by people too.
     /// </summary>
+    /// <summary>
+    /// What a conversion is CALLED, from the symbol — the one place that decides it, so the emitted
+    /// method and every call site cannot drift apart. Direction is symbol equality against the
+    /// declaring type, and the other side's name uses the minimally-qualified display the call site
+    /// has always used.
+    /// </summary>
+    internal static string ConversionNameFor(IMethodSymbol conversion)
+    {
+        var toSelf = SymbolEqualityComparer.Default.Equals(
+            conversion.ReturnType, conversion.ContainingType);
+        var other = toSelf ? conversion.Parameters[0].Type : conversion.ReturnType;
+        return ConversionMethodName(
+            other.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat), from: toSelf);
+    }
+
     internal static string? OperatorMethodName(string token) => token switch
     {
         "+" => "opAdd",

--- a/src/eQuantic.UI.Compiler/CodeGen/RecordTypeEmitter.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/RecordTypeEmitter.cs
@@ -41,10 +41,18 @@ public class RecordTypeEmitter
                 x.IsKind(SyntaxKind.StaticKeyword) || x.IsKind(SyntaxKind.ConstKeyword)),
             PropertyDeclarationSyntax p => p.Modifiers.Any(SyntaxKind.StaticKeyword),
             MethodDeclarationSyntax me => me.Modifiers.Any(SyntaxKind.StaticKeyword),
-            // Emit writes both of these as static methods (`Money.opAdd`, `Money.fromInt`), and a
-            // call site lowers to them — so a type whose only surface is an operator or a conversion
-            // is one whose twin must exist.
-            OperatorDeclarationSyntax => true,
+            // Emit writes these as static methods (`Money.opAdd`, `Money.fromInt`), and a call site
+            // lowers to them — so a type whose only surface is one of them is a type whose twin must
+            // exist.
+            //
+            // The operator asks the SAME mapping Emit asks, because Emit skips the tokens it has no
+            // name for (`&`, `|`, `^`, shifts, `++`, `true`/`false`). Discovery answering yes where
+            // Emit writes nothing would produce an empty twin for a type that has no lowering
+            // either — a module standing in for an operator no call site can use.
+            OperatorDeclarationSyntax op => (op.ParameterList.Parameters.Count == 1
+                ? UnaryOperatorMethodName(op.OperatorToken.Text)
+                : OperatorMethodName(op.OperatorToken.Text)) is not null,
+            // Every conversion IS written — that loop has no such skip.
             ConversionOperatorDeclarationSyntax => true,
             _ => false,
         });

--- a/src/eQuantic.UI.Compiler/CodeGen/RecordTypeEmitter.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/RecordTypeEmitter.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using eQuantic.UI.Compiler.CodeGen.Strategies;
 
 namespace eQuantic.UI.Compiler.CodeGen;
 
@@ -40,6 +41,11 @@ public class RecordTypeEmitter
                 x.IsKind(SyntaxKind.StaticKeyword) || x.IsKind(SyntaxKind.ConstKeyword)),
             PropertyDeclarationSyntax p => p.Modifiers.Any(SyntaxKind.StaticKeyword),
             MethodDeclarationSyntax me => me.Modifiers.Any(SyntaxKind.StaticKeyword),
+            // Emit writes both of these as static methods (`Money.opAdd`, `Money.fromInt`), and a
+            // call site lowers to them — so a type whose only surface is an operator or a conversion
+            // is one whose twin must exist.
+            OperatorDeclarationSyntax => true,
+            ConversionOperatorDeclarationSyntax => true,
             _ => false,
         });
 
@@ -54,6 +60,17 @@ public class RecordTypeEmitter
             ? model.Compilation.GetSemanticModel(node.SyntaxTree)
             : null;
     }
+
+    /// <summary>
+    /// The default of a declared type, asked of the SYMBOL where one is available. The syntax-only
+    /// fallback cannot see through a name: it answers <c>null</c> for <c>char</c> and for every
+    /// enum, where C# gives <c>'\0'</c> and the zero-valued member. A static of either type would
+    /// then hold a different value in the twin than on the server, silently.
+    /// </summary>
+    private string DefaultOf(TypeSyntax type) =>
+        ModelFor(type)?.GetTypeInfo(type).Type is { } symbol
+            ? DefaultValue.Of(symbol)
+            : TypeDeclarationExtensions.DefaultFor(type);
 
     /// <summary>Every accessor bodyless and no expression body — an auto-property and nothing else.</summary>
     private static bool IsPureAuto(PropertyDeclarationSyntax property) =>
@@ -299,7 +316,7 @@ public class RecordTypeEmitter
                     {
                         var fieldValue = variable.Initializer is { } init
                             ? _converter.ConvertExpression(init.Value, field.Declaration.Type.ToString())
-                            : TypeDeclarationExtensions.DefaultFor(field.Declaration.Type);
+                            : DefaultOf(field.Declaration.Type);
                         sb.Append($"static {variable.Identifier.Text.ToCamelCase()} = {fieldValue}; ");
                     }
                     break;
@@ -311,7 +328,7 @@ public class RecordTypeEmitter
                     when prop.Modifiers.Any(SyntaxKind.StaticKeyword) && IsPureAuto(prop):
                     var propValue = prop.Initializer is { } propInit
                         ? _converter.ConvertExpression(propInit.Value, prop.Type.ToString())
-                        : TypeDeclarationExtensions.DefaultFor(prop.Type);
+                        : DefaultOf(prop.Type);
                     sb.Append($"static {prop.Identifier.Text.ToCamelCase()} = {propValue}; ");
                     break;
             }

--- a/src/eQuantic.UI.Compiler/CodeGen/RecordTypeEmitter.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/RecordTypeEmitter.cs
@@ -481,8 +481,18 @@ public class RecordTypeEmitter
         var bare = typeText.Trim().TrimEnd('?');
         var dot = bare.LastIndexOf('.');
         if (dot >= 0) bare = bare[(dot + 1)..];
-        var pascal = bare.Length == 0 ? bare : char.ToUpperInvariant(bare[0]) + bare[1..];
-        return (from ? "from" : "to") + pascal;
+
+        // A CONSTRUCTED type is not an identifier. `List<int>` reached here verbatim and produced
+        // `fromList<int>` — emitted as a method name and used as one by the call site, which no
+        // JavaScript parser accepts. Every segment of the type becomes part of the name instead, so
+        // `List<int>` is `fromListInt` and `Dictionary<string, int>` is `fromDictionaryStringInt`:
+        // still readable, still deterministic, and different constructed types stay different names.
+        var parts = bare.Split(new[] { '<', '>', ',', ' ', '[', ']', '.', '?' },
+            System.StringSplitOptions.RemoveEmptyEntries);
+        var identifier = string.Concat(parts.Select(part =>
+            part.Length == 0 ? part : char.ToUpperInvariant(part[0]) + part[1..]));
+
+        return (from ? "from" : "to") + identifier;
     }
 
     /// <summary>A converted block comes back braced; a method body wants its contents.</summary>

--- a/src/eQuantic.UI.Compiler/CodeGen/Strategies/UserDefinedOperators.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Strategies/UserDefinedOperators.cs
@@ -20,11 +20,10 @@ public static class UserDefinedOperators
     public static JsExpr? Conversion(IMethodSymbol method, string operand)
     {
         if (!IsInSource(method) || method.Parameters.Length != 1) return null;
-        var declaring = method.ContainingType;
-        var toSelf = SymbolEqualityComparer.Default.Equals(method.ReturnType, declaring);
-        var other = toSelf ? method.Parameters[0].Type : method.ReturnType;
-        var name = RecordTypeEmitter.ConversionMethodName(Display(other), from: toSelf);
-        return JsExpr.Callish($"{declaring.Name}.{name}({operand})");
+        // ONE function names a conversion, and the emitter calls the same one — they used to
+        // compute it apart, and a qualified declaration made them disagree in silence.
+        var name = RecordTypeEmitter.ConversionNameFor(method);
+        return JsExpr.Callish($"{method.ContainingType.Name}.{name}({operand})");
     }
 
     /// <summary>The unary operator called on its operand, or null.</summary>
@@ -42,6 +41,4 @@ public static class UserDefinedOperators
     }
 
     /// <summary>The keyword form a symbol displays (`int`, not Int32), the text the emitter read.</summary>
-    private static string Display(ITypeSymbol type) =>
-        type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 }

--- a/tests/eQuantic.UI.Compiler.Tests/RecordStaticMemberTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/RecordStaticMemberTests.cs
@@ -291,4 +291,39 @@ public class RecordStaticMemberTests
         new ComponentCompiler().CompileSource(source, "Flags.cs")
             .Should().NotContain(r => r.ComponentName == "Flags");
     }
+
+    [Fact]
+    public void AConversionFromAConstructedTypeIsNamedWithAValidIdentifier()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using eQuantic.UI.Core;
+            using eQuantic.UI.Primitives;
+
+            public sealed record Bag
+            {
+                public static implicit operator Bag(List<int> v) => new();
+            }
+
+            [Page("/bag")]
+            public sealed class BagPage : StatelessComponent
+            {
+                public override VisualNode Build(ComponentContext context)
+                {
+                    Bag b = new List<int>();
+                    return new Text("x", TypeRole.BodyM);
+                }
+            }
+            """;
+
+        var emitted = new ComponentCompiler().CompileSource(source, "Bag.cs").ToList();
+        var twin = emitted.Single(r => r.ComponentName == "Bag").TypeScript;
+        var page = emitted.Single(r => r.ComponentName == "BagPage").TypeScript;
+
+        // `List<int>` reached the namer verbatim and produced `fromList<int>` — written as a method
+        // name and called as one, which no JavaScript parser accepts. Both sides go through the one
+        // namer, so both had it, and the page simply did not run.
+        twin.Should().Contain("static fromListInt(").And.NotContain("fromList<");
+        page.Should().Contain("Bag.fromListInt(").And.NotContain("fromList<");
+    }
 }

--- a/tests/eQuantic.UI.Compiler.Tests/RecordStaticMemberTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/RecordStaticMemberTests.cs
@@ -166,32 +166,71 @@ public class RecordStaticMemberTests
         ShapesTwin().Should().NotContain("static half = ");
     }
 
+    /// <summary>One SHAPE per fixture: a fixture carrying both an operator and a conversion proves
+    /// neither arm, because either one alone keeps the type discoverable.</summary>
+    private static string OnlySurface(string member) => $$"""
+        using eQuantic.UI.Core;
+        using eQuantic.UI.Primitives;
+
+        public sealed record Money
+        {
+            {{member}}
+        }
+
+        [Page("/money")]
+        public sealed class MoneyPage : StatelessComponent
+        {
+            public override VisualNode Build(ComponentContext context)
+                => new Text("x", TypeRole.BodyM);
+        }
+        """;
+
     [Fact]
-    public void ARecordWhoseOnlySurfaceIsAnOperatorStillGetsATwin()
+    public void ARecordWhoseOnlySurfaceIsAnOPERATORStillGetsATwin()
+    {
+        // Emit writes an operator as a static method and a call site lowers to it, so a type whose
+        // only surface is one still needs its twin.
+        var twin = new ComponentCompiler()
+            .CompileSource(OnlySurface("public static Money operator +(Money a, Money b) => a;"), "Money.cs")
+            .Single(r => r.ComponentName == "Money").TypeScript;
+
+        twin.Should().Contain("static opAdd(");
+    }
+
+    [Fact]
+    public void ARecordWhoseOnlySurfaceIsA_CONVERSION_StillGetsATwin()
+    {
+        var twin = new ComponentCompiler()
+            .CompileSource(OnlySurface("public static implicit operator Money(int v) => new();"), "Money.cs")
+            .Single(r => r.ComponentName == "Money").TypeScript;
+
+        // And under the name the CALL SITE will use: both sides go through ConversionNameFor now,
+        // so a qualified declaration cannot make the emitted method and the call disagree.
+        twin.Should().Contain("static fromInt(");
+    }
+
+    [Fact]
+    public void AQualifiedConversionIsNamedTheWayItIsCalled()
     {
         const string source = """
             using eQuantic.UI.Core;
             using eQuantic.UI.Primitives;
 
+            namespace App;
+
             public sealed record Money
             {
-                public static Money operator +(Money a, Money b) => a;
-                public static implicit operator Money(int v) => new();
-            }
-
-            [Page("/money")]
-            public sealed class MoneyPage : StatelessComponent
-            {
-                public override VisualNode Build(ComponentContext context)
-                    => new Text("x", TypeRole.BodyM);
+                public static implicit operator global::App.Money(int v) => new();
             }
             """;
 
-        // Emit writes an operator as a static method and a call site lowers to it, so a type whose
-        // only surface is one still needs its twin. Discovery has to know every shape Emit writes,
-        // or it deletes a type the emitted code goes on referencing.
+        // Written with a qualified name, the syntax says "global::App.Money" and the simple name
+        // says "Money" — the emitter used to read that as a conversion AWAY from the type and emit
+        // the wrong method, while the call site read the symbol and called fromInt. Undefined, with
+        // a green build.
         new ComponentCompiler().CompileSource(source, "Money.cs")
-            .Should().Contain(r => r.ComponentName == "Money");
+            .Single(r => r.ComponentName == "Money").TypeScript
+            .Should().Contain("static fromInt(");
     }
 
     [Fact]

--- a/tests/eQuantic.UI.Compiler.Tests/RecordStaticMemberTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/RecordStaticMemberTests.cs
@@ -225,4 +225,31 @@ public class RecordStaticMemberTests
         twin.Should().Contain(@"static sep = '\0'");
         twin.Should().Contain("static level = 'low'");
     }
+
+    [Fact]
+    public void AnOperatorEmitCannotWriteDoesNotConjureATwin()
+    {
+        const string source = """
+            using eQuantic.UI.Core;
+            using eQuantic.UI.Primitives;
+
+            public sealed record Flags
+            {
+                public static Flags operator &(Flags a, Flags b) => a;
+            }
+
+            [Page("/flags")]
+            public sealed class FlagsPage : StatelessComponent
+            {
+                public override VisualNode Build(ComponentContext context)
+                    => new Text("x", TypeRole.BodyM);
+            }
+            """;
+
+        // Emit has no method name for `&`, so it writes nothing for this operator and no call site
+        // can lower it either. Discovery must answer the same question Emit does — saying yes here
+        // would emit an empty module standing in for an operator nobody can use.
+        new ComponentCompiler().CompileSource(source, "Flags.cs")
+            .Should().NotContain(r => r.ComponentName == "Flags");
+    }
 }

--- a/tests/eQuantic.UI.Compiler.Tests/RecordStaticMemberTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/RecordStaticMemberTests.cs
@@ -165,4 +165,64 @@ public class RecordStaticMemberTests
         // and silently drop the halving — the worst kind of wrong, because it looks like it works.
         ShapesTwin().Should().NotContain("static half = ");
     }
+
+    [Fact]
+    public void ARecordWhoseOnlySurfaceIsAnOperatorStillGetsATwin()
+    {
+        const string source = """
+            using eQuantic.UI.Core;
+            using eQuantic.UI.Primitives;
+
+            public sealed record Money
+            {
+                public static Money operator +(Money a, Money b) => a;
+                public static implicit operator Money(int v) => new();
+            }
+
+            [Page("/money")]
+            public sealed class MoneyPage : StatelessComponent
+            {
+                public override VisualNode Build(ComponentContext context)
+                    => new Text("x", TypeRole.BodyM);
+            }
+            """;
+
+        // Emit writes an operator as a static method and a call site lowers to it, so a type whose
+        // only surface is one still needs its twin. Discovery has to know every shape Emit writes,
+        // or it deletes a type the emitted code goes on referencing.
+        new ComponentCompiler().CompileSource(source, "Money.cs")
+            .Should().Contain(r => r.ComponentName == "Money");
+    }
+
+    [Fact]
+    public void AStaticCharOrEnumTakesTheDefaultDOTNETGivesIt()
+    {
+        const string source = """
+            using eQuantic.UI.Core;
+            using eQuantic.UI.Primitives;
+
+            public enum Kind { Low, High }
+
+            public sealed record Marks(string Tag)
+            {
+                public static char Sep { get; set; }
+                public static Kind Level { get; set; }
+            }
+
+            [Page("/marks")]
+            public sealed class MarksPage : StatelessComponent
+            {
+                public override VisualNode Build(ComponentContext context)
+                    => new Text(Marks.Sep.ToString(), TypeRole.BodyM);
+            }
+            """;
+
+        var twin = new ComponentCompiler().CompileSource(source, "Marks.cs")
+            .Single(r => r.ComponentName == "Marks").TypeScript;
+
+        // A syntax-only default cannot see through a NAME: it answers null for both, where .NET
+        // gives '\0' and the zero-valued member. The symbol can, and the server would have said so.
+        twin.Should().Contain(@"static sep = '\0'");
+        twin.Should().Contain("static level = 'low'");
+    }
 }


### PR DESCRIPTION
The last two findings from the review of #43, which merged without them — see below for why, because
the reason is worth recording.

**Discovery missed operators.** `Emit` writes `operator +` and an implicit conversion as static
methods (`Money.opAdd`, `Money.fromInt`) and a call site lowers to them, so a record whose only
surface is one still needs its twin. `HasStaticSurface` never looked at either syntax kind.

This was invisible before #43 too — `ValueMembers` counted none of it either — so it is not a
regression, but adding a discovery predicate is the moment to make it complete rather than half.

**Defaults were syntax-only.** `DefaultFor` reads syntax, so it cannot see through a name: it
answers `null` for `char` and for every enum, where .NET gives `'\0'` and the zero-valued member. A
static of either type held a different value in the twin than the server had, silently. It asks the
**symbol** now, through the same `DefaultValue.Of` the rest of the compiler uses, keeping the syntax
answer as the fallback for when no model is available. Both call sites — static field and static
auto-property — go through one helper so they cannot diverge.

Two tests, each A/B'd: one compiles a record whose only members are `operator +` and an implicit
conversion and asserts the twin exists; the other pins `static sep = '\0'` and `static level = 'low'`.

## Why this is a separate PR

I branched the Track M docs work off the record branch instead of off `main`, so this commit landed
on the docs branch and #43 merged without it — while its review threads were already answered as
fixed. Caught because the compiler suite went from 821 on the branch to **819** on `main` right after
the merge, which is the only signal there was.

`dotnet test tests/eQuantic.UI.Compiler.Tests` → 821.