### PR TITLE
🐛 fix: a plain class carries its operators into the twin

### DIFF
--- a/src/eQuantic.UI.Compiler/CodeGen/RecordTypeEmitter.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/RecordTypeEmitter.cs
@@ -277,9 +277,12 @@ public class RecordTypeEmitter
                 .Select(p => tsTypeDeclarations
                     ? $"{p.Identifier.Text.ToJsIdentifier()}: {TsTypeOf(p.Type)}"
                     : p.Identifier.Text.ToJsIdentifier()));
-            var body = op.ExpressionBody is { } expr
-                ? $"return {_converter.ConvertExpression(expr.Expression)};"
-                : op.Body is { } block ? Unwrap(_converter.Convert(block)) : "";
+            // Hoisted locals first — `out var` inside an operator emits an assignment with nothing
+            // declaring the name, and an ES module is strict.
+            var body = OutParameters.HoistedLocals(op.Body ?? (SyntaxNode?)op.ExpressionBody)
+                + (op.ExpressionBody is { } expr
+                    ? $"return {_converter.ConvertExpression(expr.Expression)};"
+                    : op.Body is { } block ? Unwrap(_converter.Convert(block)) : "");
             sb.Append($"static {opName}({pars}) {{ {body} }} ");
         }
 
@@ -303,9 +306,10 @@ public class RecordTypeEmitter
             var par = tsTypeDeclarations
                 ? $"{parameter.Identifier.Text.ToJsIdentifier()}: {TsTypeOf(parameter.Type)}"
                 : parameter.Identifier.Text.ToJsIdentifier();
-            var body = conversion.ExpressionBody is { } expr
-                ? $"return {_converter.ConvertExpression(expr.Expression)};"
-                : conversion.Body is { } block ? Unwrap(_converter.Convert(block)) : "";
+            var body = OutParameters.HoistedLocals(conversion.Body ?? (SyntaxNode?)conversion.ExpressionBody)
+                + (conversion.ExpressionBody is { } expr
+                    ? $"return {_converter.ConvertExpression(expr.Expression)};"
+                    : conversion.Body is { } block ? Unwrap(_converter.Convert(block)) : "");
             sb.Append($"static {opName}({par}) {{ {body} }} ");
         }
 

--- a/src/eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
@@ -1617,8 +1617,8 @@ public class TypeScriptEmitter
     }
 
     /// <summary>
-    /// An operator's body in either spelling, or null where it has neither (a partial declaration)
-    /// and there is nothing to write.
+    /// An operator's body in either spelling, or null where it has neither — `extern`, or a
+    /// declaration in an interface — and there is nothing to write.
     /// <para>
     /// The hoisted locals come first, as they do for an ordinary method: `int.TryParse(s, out var n)`
     /// inside an operator emits `n = …` with nothing declaring `n`, and an ES module is strict, so

--- a/src/eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
@@ -1616,12 +1616,24 @@ public class TypeScriptEmitter
             EmitExtensionBlocks(cls, c);
     }
 
-    /// <summary>An operator's body in either spelling, or null where it has neither (a partial
-    /// declaration) and there is nothing to write.</summary>
-    private string? OperatorBody(BaseMethodDeclarationSyntax op) =>
-        op.ExpressionBody is { } expression
+    /// <summary>
+    /// An operator's body in either spelling, or null where it has neither (a partial declaration)
+    /// and there is nothing to write.
+    /// <para>
+    /// The hoisted locals come first, as they do for an ordinary method: `int.TryParse(s, out var n)`
+    /// inside an operator emits `n = …` with nothing declaring `n`, and an ES module is strict, so
+    /// the operator threw a ReferenceError the first time it ran instead of returning a value.
+    /// </para>
+    /// </summary>
+    private string? OperatorBody(BaseMethodDeclarationSyntax op)
+    {
+        var body = op.ExpressionBody is { } expression
             ? ExpressionBodyReturn(expression.Expression)
             : op.Body is { } block ? StripJsBraces(_converter.Convert(block)) : null;
+        return body is null
+            ? null
+            : OutParameters.HoistedLocals(op.Body ?? (SyntaxNode?)op.ExpressionBody) + body;
+    }
 
     /// <summary>
     /// C# 14 extension blocks (<c>extension(T receiver) { … }</c>): every member lowers to a

--- a/src/eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
@@ -1575,8 +1575,53 @@ public class TypeScriptEmitter
                     + (isAsync ? "async " : "");
                 c.Member(JsClassMember.Method(modifiers, mn, generics, pars, "", JsStatement.Raw(mbody)), m);
             }
+            // USER-DEFINED OPERATORS — the same family a record's twin already carries, and for the
+            // same reason: JavaScript cannot overload an operator, so the call site lowers `a + b`
+            // on two in-source objects to `T.opAdd(a, b)` whatever kind of type T is. It did that
+            // for a plain class too while nothing here wrote the method, so the page compiled, the
+            // server rendered it, and the browser said "T.opAdd is not a function".
+            //
+            // The NAMES come from RecordTypeEmitter, which is also where the call-site lowering gets
+            // them. Three places, one spelling — computing it here instead is how the two sides of a
+            // conversion came to disagree once already.
+            foreach (var op in cls.Members.OfType<OperatorDeclarationSyntax>())
+            {
+                var opName = op.ParameterList.Parameters.Count == 1
+                    ? RecordTypeEmitter.UnaryOperatorMethodName(op.OperatorToken.Text)
+                    : RecordTypeEmitter.OperatorMethodName(op.OperatorToken.Text);
+                // No name means the call site cannot lower it either, so writing a method nobody
+                // calls would only add a second way to be wrong.
+                if (opName is null) continue;
+                if (OperatorBody(op) is not { } opBody) continue;
+                var opPars = string.Join(", ", op.ParameterList.Parameters
+                    .Select(pp => pp.Identifier.Text.ToJsIdentifier()));
+                c.Member(JsClassMember.Method("static ", opName, "", opPars, "", JsStatement.Raw(opBody)), op);
+            }
+
+            foreach (var conversion in cls.Members.OfType<ConversionOperatorDeclarationSyntax>())
+            {
+                if (OperatorBody(conversion) is not { } convBody) continue;
+                var declared = _semanticModel?.GetDeclaredSymbol(conversion) as IMethodSymbol;
+                var convName = declared is not null
+                    ? RecordTypeEmitter.ConversionNameFor(declared)
+                    : RecordTypeEmitter.ConversionMethodName(
+                        conversion.Type.ToString() == cls.Identifier.Text
+                            ? conversion.ParameterList.Parameters[0].Type!.ToString()
+                            : conversion.Type.ToString(),
+                        from: conversion.Type.ToString() == cls.Identifier.Text);
+                var convPar = conversion.ParameterList.Parameters[0].Identifier.Text.ToJsIdentifier();
+                c.Member(JsClassMember.Method("static ", convName, "", convPar, "", JsStatement.Raw(convBody)), conversion);
+            }
+
             EmitExtensionBlocks(cls, c);
     }
+
+    /// <summary>An operator's body in either spelling, or null where it has neither (a partial
+    /// declaration) and there is nothing to write.</summary>
+    private string? OperatorBody(BaseMethodDeclarationSyntax op) =>
+        op.ExpressionBody is { } expression
+            ? ExpressionBodyReturn(expression.Expression)
+            : op.Body is { } block ? StripJsBraces(_converter.Convert(block)) : null;
 
     /// <summary>
     /// C# 14 extension blocks (<c>extension(T receiver) { … }</c>): every member lowers to a

--- a/tests/eQuantic.UI.Compiler.Tests/PlainClassOperatorTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/PlainClassOperatorTests.cs
@@ -73,4 +73,44 @@ public class PlainClassOperatorTests
         names.Where(n => record.Contains($"static {n}("))
             .Should().BeEquivalentTo(names.Where(n => plain.Contains($"static {n}(")));
     }
+
+    private static string OutVarSource(string keyword) => $$"""
+        using eQuantic.UI.Core;
+        using eQuantic.UI.Primitives;
+
+        public sealed {{keyword}} Tag
+        {
+            public string Label { get; init; } = "";
+
+            public static Tag operator +(Tag a, Tag b)
+            {
+                int.TryParse(a.Label, out var n);
+                return new Tag { Label = (n + 1).ToString() };
+            }
+        }
+
+        [Page("/tag")]
+        public sealed class TagPage : StatelessComponent
+        {
+            public override VisualNode Build(ComponentContext context)
+                => new Text("x", TypeRole.BodyM);
+        }
+        """;
+
+    [Theory]
+    [InlineData("record")]
+    [InlineData("class")]
+    public void AnOperatorBodyDeclaresItsOutVariables(string keyword)
+    {
+        var twin = new ComponentCompiler()
+            .CompileSource(OutVarSource(keyword), "Tag.cs")
+            .Single(r => r.ComponentName == "Tag").TypeScript;
+
+        // `out var n` emitted `n = parseInt(…)` with nothing declaring n. An ES module is strict, so
+        // the operator threw a ReferenceError the first time it ran rather than returning a value —
+        // and both emitters had it, which is why both are pinned here.
+        var opAdd = twin[twin.IndexOf("opAdd", StringComparison.Ordinal)..];
+        opAdd[..opAdd.IndexOf("return", StringComparison.Ordinal)]
+            .Should().Contain("let n", "the hoisted declaration comes before the body that assigns it");
+    }
 }

--- a/tests/eQuantic.UI.Compiler.Tests/PlainClassOperatorTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/PlainClassOperatorTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using eQuantic.UI.Compiler;
+using FluentAssertions;
+using Xunit;
+
+namespace eQuantic.UI.Compiler.Tests;
+
+/// <summary>
+/// A user-defined operator belongs to the twin of ANY type that declares it, not only a record's.
+/// <para>
+/// The call site lowers `a + b` on two in-source objects to <c>T.opAdd(a, b)</c> whatever kind of
+/// type T is — JavaScript cannot overload an operator, so there is nothing else it could do. A
+/// record's emitter writes those methods; a plain class's emitter did not, and nothing failed the
+/// build: the page compiled, the server rendered it, and the browser answered "T.opAdd is not a
+/// function". Three of them on one page, for a class with two operators and a conversion.
+/// </para>
+/// <para>
+/// The fixtures put a record and a class SIDE BY SIDE deliberately. That pairing is what surfaced
+/// this, and it is what stops the two emitters drifting apart again.
+/// </para>
+/// </summary>
+public class PlainClassOperatorTests
+{
+    private static string Source(string keyword) => $$"""
+        using System.Collections.Generic;
+        using eQuantic.UI.Core;
+        using eQuantic.UI.Primitives;
+
+        public sealed {{keyword}} Vec
+        {
+            public int X { get; init; }
+
+            public static Vec operator +(Vec a, Vec b) => new() { X = a.X + b.X };
+            public static Vec operator -(Vec a) => new() { X = -a.X };
+            public static implicit operator Vec(int v) => new() { X = v };
+            public static explicit operator int(Vec v) => v.X;
+        }
+
+        [Page("/vec")]
+        public sealed class VecPage : StatelessComponent
+        {
+            public override VisualNode Build(ComponentContext context)
+                => new Text("x", TypeRole.BodyM);
+        }
+        """;
+
+    private static string Twin(string keyword) => new ComponentCompiler()
+        .CompileSource(Source(keyword), "Vec.cs")
+        .Single(r => r.ComponentName == "Vec").TypeScript;
+
+    [Theory]
+    [InlineData("record")]
+    [InlineData("class")]
+    public void EveryUserDefinedOperatorReachesTheTwin(string keyword)
+    {
+        var twin = Twin(keyword);
+
+        twin.Should().Contain("static opAdd(", "the call site lowers `a + b` to it");
+        twin.Should().Contain("static opNegate(", "a unary operator is named by its arity");
+        twin.Should().Contain("static fromInt(", "an implicit conversion is named by its direction");
+        twin.Should().Contain("static toInt(", "and so is an explicit one");
+    }
+
+    [Fact]
+    public void TheTwoEmittersNameTheOperatorsIdentically()
+    {
+        // Not just "both emit something" — the SAME names, because one call-site lowering serves
+        // both and it has only one spelling to offer.
+        var names = new[] { "opAdd", "opNegate", "fromInt", "toInt" };
+        var record = Twin("record");
+        var plain = Twin("class");
+
+        names.Where(n => record.Contains($"static {n}("))
+            .Should().BeEquivalentTo(names.Where(n => plain.Contains($"static {n}(")));
+    }
+}


### PR DESCRIPTION
Follows a question about whether the transpiler understands `implicit`/`explicit` operators. It
does — **for records and structs**. For a plain class it emitted none of them and called them
anyway.

## What was happening

JavaScript cannot overload an operator, so the call site lowers `a + b` on two in-source objects to
`T.opAdd(a, b)` whatever kind of type `T` is. `RecordTypeEmitter` writes those methods.
`EmitStaticMembers` — the plain-class path — loops over fields, properties, events and methods, and
**had no loop for operators or conversions**.

Nothing failed the build. Measured on the sample, real SDK build:

```js
// before
class ClsVec{ constructor(props){…} x=0 }                       // ← no operators at all
sum=ClsVec.opAdd(a,b), neg=ClsVec.opNegate(a), back=ClsVec.toInt(sum)   // ← called regardless
```

Three `is not a function` on one page, for a class with two operators and a conversion. Green build,
correct SSR, and only the browser shows it — the same shape as everything else found in this area
today.

```js
// after
class ClsVec{ … static opAdd(a,b){…} static opNegate(a){…} static fromInt(v){…} static toInt(v){…} }
```

| | record / struct | plain class (before) | plain class (after) |
|---|---|---|---|
| binary operator | ✅ | ❌ | ✅ |
| unary operator | ✅ | ❌ | ✅ |
| implicit / explicit conversion | ✅ | ❌ | ✅ |

## Where the names come from

`RecordTypeEmitter.OperatorMethodName`, `UnaryOperatorMethodName` and `ConversionNameFor` — the same
functions the **call-site lowering** uses. Three places, one spelling. Computing it locally is
precisely how the two sides of a conversion came to disagree earlier today, and this avoids
repeating that.

An operator the namer has no entry for (`&`, `|`, shifts, `++`) is skipped, because the call site
cannot lower it either and a method nobody calls is only a second way to be wrong.

## What holds it

The fixtures put a **record and a class side by side** and assert the same four names on both — that
pairing is what surfaced this, and it is what stops the two emitters drifting apart again. A third
test asserts the two twins carry an identical set of operator names rather than merely each carrying
something.

A/B'd: removing the two loops fails the class case and leaves the record case passing.

`dotnet test` → Compiler 828, Conformance 1146, Web 563, Design 103. Verified in a real SDK build,
not only the harness.