### PR TITLE
🔧 chore: 0.2.0-preview.44

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.43</Version>
+        <Version>0.2.0-preview.44</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
Cuts `0.2.0-preview.44`. One line in `Directory.Build.props`; the tag `v0.2.0-preview.44` follows
once this lands, and that is what publishes to nuget.org.

## Twin correctness — the bulk of this version

Nine defects in how a type's twin is emitted, all of one shape: **build green, server correct, and
only a browser shows the difference.** Found by a consuming app whose branding vanished on
hydration, then narrowed by measuring rather than reasoning.

**A record's statics.** `static T P { get; } = new(…)` never reached the twin — an auto-property has
no getter, and the emitter's property loop knew only the three spellings that do. Every call site
still wrote `Chrome.default.tag`. Beside it, a `const` was counted as instance state, so the twin
took a positional parameter C# does not have and printed it in `toString`. That one was already
shipping: `CellRef` has `public const int MaxCols`, so the spreadsheet component's twin printed
`CellRef { Row = 0, Col = 0, MaxCols = 0 }` where .NET printed two members — pinned in a committed
fixture that was pinning the bug.

**Discovery.** Excluding consts from a record's *value* also deleted the type from discovery, so a
record whose only data is a const lost its twin entirely. Discovery asks its own question now, and
asks the emitter's own tables — an operator Emit has no name for (`&`, `|`, shifts) no longer
conjures an empty module.

**Ordering, defaults and behaviour.** Static initialisers now emit in declaration order, as .NET runs
them. An uninitialised static takes its type's default from the *symbol* — `'\0'` and the zero enum
member, where syntax alone answered `null`. A property with a custom setter is no longer flattened
into a field that silently drops it.

**Conversion naming.** The emitter compared type *syntax* while the call site compared *symbols*, so
a qualified declaration emitted one name and called another. One function names a conversion now,
and both sides call it. It also produced `fromList<int>` for a constructed type — not an identifier
in any JavaScript.

**Plain classes had none of it.** `a + b` on two in-source objects lowers to `T.opAdd(a, b)` whatever
kind of type T is, and the plain-class emitter wrote no operators or conversions at all — three
`is not a function` on one page. And an `out var` inside any operator body emitted an assignment
with nothing declaring it, in both emitters.

## Also

**#41 — the 404 fallback is no longer a second-class door.** One page reached two ways, and only the
mapped route handed over its payload and assets; the fallback served the right markup unhydrated and
unstyled. A 404 page that *failed* to render answered 500 in Production, telling every crawler the
server broke when the resource simply does not exist.

**#40 — every field of a prefetched page is public**, said on `IServerPrefetch` and in the wiki.

**#44 — Track M**, email rendering, on the roadmap.

## Verified

`dotnet test` → Compiler 830, Conformance 1146, Web 563, Server 142, Design 103, Native 1020,
Images 76. `npx vitest run` → 941. The emitter changes were checked in a **real SDK build** and not
only in a harness.