### PR TITLE
📝 docs: W7 — the developer loop (run, debug, hot reload)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -318,8 +318,8 @@ Windows/Linux shells stay post-M5 as the engine plan already decided.
 
 W7 (added same day, raised by Edgar): the DEVELOPER LOOP — one command per target with device
 discovery embedded in `Sdk.Native` (`-t:RunIos` / `-t:RunAndroid`), `launchSettings.json` profiles
-so Rider/VS run one-click, hot reload staying `dotnet watch` on desktop and redeploy-on-save as the
-simulator's first honest rung.
+so Rider/VS run and debug in one click, hot reload staying `dotnet watch` on desktop and
+redeploy-on-save as the first honest rung on simulators and emulators.
 
 Full gaps-with-evidence, sequencing and per-workstream acceptance: `docs/DESKTOP-PLAN.md`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -316,7 +316,7 @@ entitlements, notarization, publish-based bundling, minimal updater — sequence
 independents because the identity unblocks TCC, notifications and updates at once; W6
 Windows/Linux shells stay post-M5 as the engine plan already decided.
 
-W7 (added same day, raised by Edgar): the DEVELOPER LOOP — one command per target with device
+W7 (added 2026-08-25, raised by Edgar): the DEVELOPER LOOP — one command per target with device
 discovery embedded in `Sdk.Native` (`-t:RunIos` / `-t:RunAndroid`), `launchSettings.json` profiles
 so Rider/VS run and debug in one click, hot reload staying `dotnet watch` on desktop and
 redeploy-on-save as the first honest rung on simulators and emulators.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -316,6 +316,11 @@ entitlements, notarization, publish-based bundling, minimal updater — sequence
 independents because the identity unblocks TCC, notifications and updates at once; W6
 Windows/Linux shells stay post-M5 as the engine plan already decided.
 
+W7 (added same day, raised by Edgar): the DEVELOPER LOOP — one command per target with device
+discovery embedded in `Sdk.Native` (`-t:RunIos` / `-t:RunAndroid`), `launchSettings.json` profiles
+so Rider/VS run one-click, hot reload staying `dotnet watch` on desktop and redeploy-on-save as the
+simulator's first honest rung.
+
 Full gaps-with-evidence, sequencing and per-workstream acceptance: `docs/DESKTOP-PLAN.md`.
 
 ## Track M — Email rendering

--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -119,7 +119,7 @@ Running on a SIMULATOR or EMULATOR is a hand recipe: discover the device (`xcrun
 - **One command per target, embedded in `Sdk.Native`**: `dotnet build -t:RunIos` (find or boot a
   simulator, install, `simctl launch` with environment variables), `-t:RunAndroid` (`adb` discovery, `-gpu host`
   boot when needed, install, `am start`). The recipe already exists as prose; it becomes MSBuild.
-- **`launchSettings.json` profiles in the native template**, so Rider/VS run/debug are one click:
+- **`launchSettings.json` profiles in the native template**, so Rider/VS can run and debug in one click:
   a "Photon (desktop)" profile (`commandName: Project` — full debugging, it IS the project
   process) and "iOS Simulator"/"Android Emulator" profiles invoking the targets. Honest limit:
   DEBUGGING inside a simulator/emulator process is its own story (attach), out of this slice.

--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -109,6 +109,26 @@ Sequenced FIRST among the independents deliberately: signing identity unblocks t
 once — TCC grants that survive builds, notifications (which require a signed bundle), and any
 auto-update story. W4's notification work lands on it.
 
+### W7 — The developer loop: run, debug, hot reload (2–3 w)
+
+Raised by Edgar on 2026-08-25, and verified: TODAY only the DESKTOP loop is one command —
+`dotnet run` opens the Photon window, `dotnet watch` hot-reloads it in process (the window wakes).
+Running on a SIMULATOR or EMULATOR is a hand recipe: discover the device (`xcrun simctl list` /
+`adb devices`), boot it, install, launch with environment — steps that live in nobody's build.
+
+- **One command per target, embedded in `Sdk.Native`**: `dotnet build -t:RunIos` (find or boot a
+  simulator, install, `simctl launch` with env), `-t:RunAndroid` (`adb` discovery, `-gpu host`
+  boot when needed, install, `am start`). The recipe already exists as prose; it becomes MSBuild.
+- **`launchSettings.json` profiles in the native template**, so Rider/VS run/debug are one click:
+  a "Photon (desktop)" profile (`commandName: Project` — full debugging, it IS the project
+  process) and "iOS Simulator"/"Android Emulator" profiles invoking the targets. Honest limit:
+  DEBUGGING inside a simulator/emulator process is its own story (attach), out of this slice.
+- **Hot reload**: desktop stays `dotnet watch` (works today). For simulator/emulator the first
+  honest rung is REDEPLOY-on-save through the same targets; true in-process hot reload across the
+  device boundary is future work and says so.
+
+Unblocks: the everyday loop of every native app — and the OS Cleaner's F1 onward.
+
 ### W6 — Shells Windows/Linux (post-M5, quarters)
 
 Out of this plan's horizon, as the engine roadmap already says (D3D12-vs-Vulkan decision is

--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -114,10 +114,10 @@ auto-update story. W4's notification work lands on it.
 Raised by Edgar on 2026-08-25, and verified: TODAY only the DESKTOP loop is one command —
 `dotnet run` opens the Photon window, `dotnet watch` hot-reloads it in process (the window wakes).
 Running on a SIMULATOR or EMULATOR is a hand recipe: discover the device (`xcrun simctl list` /
-`adb devices`), boot it, install, launch with environment — steps that live in nobody's build.
+`adb devices`), boot it, install, launch with environment variables — steps that live in nobody's build.
 
 - **One command per target, embedded in `Sdk.Native`**: `dotnet build -t:RunIos` (find or boot a
-  simulator, install, `simctl launch` with env), `-t:RunAndroid` (`adb` discovery, `-gpu host`
+  simulator, install, `simctl launch` with environment variables), `-t:RunAndroid` (`adb` discovery, `-gpu host`
   boot when needed, install, `am start`). The recipe already exists as prose; it becomes MSBuild.
 - **`launchSettings.json` profiles in the native template**, so Rider/VS run/debug are one click:
   a "Photon (desktop)" profile (`commandName: Project` — full debugging, it IS the project


### PR DESCRIPTION
Registers the DX gap Edgar raised: running the native app on a device today means a hand recipe —
discover the simulator/emulator, boot, install, launch with parameters — while only the desktop
loop is one command (`dotnet run`, and `dotnet watch` hot-reloads in process).

W7, added to Track W:

- **One command per target, embedded in `Sdk.Native`**: `dotnet build -t:RunIos` /
  `-t:RunAndroid` carrying device discovery, boot, install and launch.
- **`launchSettings.json` profiles in the native template** so Rider/VS run and debug are one
  click — the desktop profile is the project process itself (full debugging); the device profiles
  invoke the targets. Debugging *inside* a simulator process is named as its own future story.
- **Hot reload ladder, stated honestly**: `dotnet watch` on desktop (works today),
  redeploy-on-save through the same targets as the device rung, true cross-device hot reload later.

Docs only; the implementation is the W7 slice itself.