### PR TITLE
📝 docs: first-contact friction ledger + signposts on the imperative samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ extensions/vscode/icon.png
 # Only the marker, never the packages a local build drops there.
 artifacts/packages/*
 !artifacts/packages/.gitkeep
+
+# Local NuGet feed for end-to-end consumer validation (the recipe in docs/DESKTOP-PLAN.md):
+# packed on demand at 1.0.0-dev, never committed.
+artifacts/local-feed/

--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -163,9 +163,12 @@ editor suggestion) is a decision, not an oversight. Newest first.
 
 - **`SizeValue` has no Fraction** (2026-08-26, OS Cleaner F1): width proportional to the parent —
   usage/size bars, a common data-app pattern — is done today with `Flexible` weights sharing
-  leftover main-axis space (`Row[Flexible(used), Flexible(free)]`), or by computing dp by hand.
-  That IS the intended idiom; whether `SizeKind.Fraction` earns a slot is open and waits for a
-  consumer the weights idiom cannot serve.
+  leftover main-axis space: `Row(children: [Flexible(bar, flex: 62), Flexible(track, flex: 38)])`.
+  That IS the intended idiom — with an honest wrinkle the same consumer hit: `flex` is an `int`
+  clamped to ≥ 1, so a CONTINUOUS fraction (disk usage 0..1) scales first —
+  `flex: (int)(fraction * 1000)` — and a 0%/100% side still occupies weight 1 of 1001. Whether
+  `SizeKind.Fraction` (or a float weight) earns a slot is open and waits on this pressure
+  repeating.
 - **`VariantColors.Base` reads as `.Solid` from web-land** (2026-08-26, OS Cleaner F1): the record
   is `Base/OnBase/Pressed/Subtle/OnSubtle` (`ColorToken.cs`) — the `On*` pairing is the Material
   contract, and `Base` is the anchor that pairing names. A rename is a surface decision, not a
@@ -176,9 +179,17 @@ editor suggestion) is a decision, not an oversight. Newest first.
   `eQuantic.UI.Primitives`.
 - **The imperative native samples taught the wrong idiom** (2026-08-26, OS Cleaner F1): the
   canonical authoring surface — factories, no `new` — is injected by BOTH SDKs (web
-  `Sdk.props:136`, native `Sdk.props:24`); `DefaultUIDashboard/Screens/DeclarativeScreen.cs` is
-  the proof screen. PhotonDesktop's Studio and WalletMobile predate the surface and compose
+  `Sdk.props:136`, native `Sdk.props:24`); `samples/DefaultUIDashboard/Screens/DeclarativeScreen.cs`
+  is the proof screen. PhotonDesktop's Studio and WalletMobile predate the surface and compose
   primitives imperatively as framework instruments; both now carry a signpost saying so.
+- **The `Pressable` factory cannot express accessibility state** (2026-08-26, OS Cleaner F1): the
+  factory mirrors the constructor — `Pressable(child, onPressed)` — and `Label`, `Selected` and
+  `PressedBackground` are init-only properties the mirror never reaches. `Label`/`Selected` feed
+  the SEMANTICS tree, so a fully declarative screen today cannot mark a nav item selected or name
+  an icon-only button for VoiceOver; the consumer stayed imperative deliberately rather than work
+  around it. The fix path the mirror rule already implies: widen the CONSTRUCTOR with optional
+  parameters and the factory follows — a Primitives surface change with its own tests, not a docs
+  patch.
 - **`TypeRole.Body` does not exist** (2026-08-25, OS Cleaner F0): the ramp's body rungs are
   `BodyL/BodyM` (the dense-scale work split them). Second and third consumers hit the same
   guess; an editor suggestion for role names is Track I territory.

--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -155,6 +155,34 @@ W3 (primitives) ──────────────►  with W2 (pointer 
 W4 (shell)      ──── partial early (file dialogs + deep links), rest after W5
 ```
 
+## First-contact friction ledger (consumer reports)
+
+What tripped a fresh consumer on their FIRST build — none blocking, all resolved at the call
+site. Recorded because each cost someone a build cycle, and the fix (rename, new API, doc line,
+editor suggestion) is a decision, not an oversight. Newest first.
+
+- **`SizeValue` has no Fraction** (2026-08-26, OS Cleaner F1): width proportional to the parent —
+  usage/size bars, a common data-app pattern — is done today with `Flexible` weights sharing
+  leftover main-axis space (`Row[Flexible(used), Flexible(free)]`), or by computing dp by hand.
+  That IS the intended idiom; whether `SizeKind.Fraction` earns a slot is open and waits for a
+  consumer the weights idiom cannot serve.
+- **`VariantColors.Base` reads as `.Solid` from web-land** (2026-08-26, OS Cleaner F1): the record
+  is `Base/OnBase/Pressed/Subtle/OnSubtle` (`ColorToken.cs`) — the `On*` pairing is the Material
+  contract, and `Base` is the anchor that pairing names. A rename is a surface decision, not a
+  patch; registered, not promised.
+- **`Devices/` types live in the ROOT namespace** (2026-08-26, OS Cleaner F1): `using
+  eQuantic.UI.Primitives.Devices` fails by design — Primitives is ONE flat namespace and folders
+  only organize files. Every capability (`IClock`, `ICamera`, `ILocation`…) is
+  `eQuantic.UI.Primitives`.
+- **The imperative native samples taught the wrong idiom** (2026-08-26, OS Cleaner F1): the
+  canonical authoring surface — factories, no `new` — is injected by BOTH SDKs (web
+  `Sdk.props:136`, native `Sdk.props:24`); `DefaultUIDashboard/Screens/DeclarativeScreen.cs` is
+  the proof screen. PhotonDesktop's Studio and WalletMobile predate the surface and compose
+  primitives imperatively as framework instruments; both now carry a signpost saying so.
+- **`TypeRole.Body` does not exist** (2026-08-25, OS Cleaner F0): the ramp's body rungs are
+  `BodyL/BodyM` (the dense-scale work split them). Second and third consumers hit the same
+  guess; an editor suggestion for role names is Track I territory.
+
 ## What stays fenced, on purpose
 
 - Generic vector paths (the "v2+" fence in the engine plan stands; W1 adds a shape, not a path

--- a/samples/PhotonDesktop/Studio/StudioShell.cs
+++ b/samples/PhotonDesktop/Studio/StudioShell.cs
@@ -12,6 +12,13 @@ namespace eQuantic.Studio;
 /// Authored in the write-once vocabulary ONLY, so the same tree runs as GPU pixels in this NSWindow
 /// and as DOM in the browser. Nothing in this file knows which target it is on.
 /// </para>
+/// <para>
+/// SIGNPOST — this file predates the declarative factory surface and composes nodes imperatively
+/// (<c>new Column</c>, <c>.Add</c>). Do not learn app authoring here: the canonical idiom is
+/// factories with no <c>new</c> — injected by both SDKs — and
+/// <c>DefaultUIDashboard/Screens/DeclarativeScreen.cs</c> is the proof screen. The Studio stays
+/// imperative on purpose: it is a framework instrument whose walk tests build trees piecewise.
+/// </para>
 /// </summary>
 public sealed class StudioShell : StatefulComponent
 {

--- a/samples/PhotonDesktop/Studio/StudioShell.cs
+++ b/samples/PhotonDesktop/Studio/StudioShell.cs
@@ -16,7 +16,7 @@ namespace eQuantic.Studio;
 /// SIGNPOST — this file predates the declarative factory surface and composes nodes imperatively
 /// (<c>new Column</c>, <c>.Add</c>). Do not learn app authoring here: the canonical idiom is
 /// factories with no <c>new</c> — injected by both SDKs — and
-/// <c>DefaultUIDashboard/Screens/DeclarativeScreen.cs</c> is the proof screen. The Studio stays
+/// <c>samples/DefaultUIDashboard/Screens/DeclarativeScreen.cs</c> is the proof screen. The Studio stays
 /// imperative on purpose: it is a framework instrument whose walk tests build trees piecewise.
 /// </para>
 /// </summary>

--- a/samples/WalletMobile/WalletApp.cs
+++ b/samples/WalletMobile/WalletApp.cs
@@ -16,7 +16,7 @@ namespace eQuantic.Wallet;
 /// SIGNPOST — this file predates the declarative factory surface and composes nodes imperatively
 /// (<c>new Column</c>, <c>.Add</c>). Do not learn app authoring here: the canonical idiom is
 /// factories with no <c>new</c> — injected by both SDKs — and
-/// <c>DefaultUIDashboard/Screens/DeclarativeScreen.cs</c> is the proof screen.
+/// <c>samples/DefaultUIDashboard/Screens/DeclarativeScreen.cs</c> is the proof screen.
 /// </para>
 /// </summary>
 public sealed class WalletApp : StatefulComponent

--- a/samples/WalletMobile/WalletApp.cs
+++ b/samples/WalletMobile/WalletApp.cs
@@ -12,6 +12,12 @@ namespace eQuantic.Wallet;
 /// gestures: the transactions list pulls to refresh and its first row swipes to reveal, both on the
 /// same <see cref="Draggable"/> the vocabulary now carries.
 /// </para>
+/// <para>
+/// SIGNPOST — this file predates the declarative factory surface and composes nodes imperatively
+/// (<c>new Column</c>, <c>.Add</c>). Do not learn app authoring here: the canonical idiom is
+/// factories with no <c>new</c> — injected by both SDKs — and
+/// <c>DefaultUIDashboard/Screens/DeclarativeScreen.cs</c> is the proof screen.
+/// </para>
 /// </summary>
 public sealed class WalletApp : StatefulComponent
 {


### PR DESCRIPTION
## What

The OS Cleaner's F1 milestone — the SDK's first real product screen, built entirely from the local 1.0.0-dev feed — reported four first-contact frictions, each costing the consumer one build cycle. None is a bug; each is a decision (rename, new API, doc line, editor suggestion). This PR records them where they can be acted on instead of evaporating in chat.

- **New section in `docs/DESKTOP-PLAN.md`: the first-contact friction ledger.** SizeValue-has-no-Fraction (names `Flexible` weights as the intended idiom for proportional bars), `VariantColors.Base` read as `.Solid` from web-land (the `On*` pairing is the Material contract; rename registered, not promised), `Devices/` types living in the flat root namespace by design, the imperative-samples trap, and the earlier `TypeRole.Body` report — which had been answered in chat but never registered anywhere searchable.
- **Signposts on `StudioShell.cs` and `WalletApp.cs`**: both predate the declarative factory surface and compose nodes imperatively; the headers now say not to learn app authoring there and point at `DefaultUIDashboard/Screens/DeclarativeScreen.cs`. The factory surface is injected by BOTH SDKs (web `Sdk.props:136`, native `Sdk.props:24`) — the consumer followed the imperative sample believing it canonical. The Studio stays imperative on purpose (its walk tests build trees piecewise); the signpost makes the purpose visible.
- **`.gitignore` covers `artifacts/local-feed/`** — the consumer-validation feed from the local-packages recipe showed up untracked; only `artifacts/packages/*` was ignored.

## Why a ledger and not fixes

Three consumers have now tripped on first contact (TypeRole twice, this batch once each). Every item has a working idiom today, so the cost of a silent workaround is zero — but the PATTERN (what newcomers guess vs. what the surface offers) is exactly the input a rename or Track I editor suggestion needs. The ledger keeps the evidence with dates and sources.

## Tests

Comments and docs only; both touched samples still build clean (PhotonDesktop, WalletMobile — 0 errors).