### PR TITLE
🐛 fix: the bundle is the payload — RID allowlist, rebuilt not accreted, signed or failed

### DIFF
--- a/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
+++ b/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
@@ -96,19 +96,32 @@
             single stray .pdb leaves the app unsigned; and an unsigned app is refused by the very
             capabilities that check who is asking. LocalAuthentication simply never showed its sheet
             and never said why, which cost an afternoon to find.
+
+            runtimes/ is an ALLOWLIST (osx*, unix*), not a denylist: only RIDs a macOS process can
+            actually load belong in the bundle. The denylist this replaces named win/linux/android/
+            ios and let `browser-wasm` through — Microsoft.Data.Sqlite ships a static archive
+            (e_sqlite3.a) under it, which is not Mach-O, and codesign refused the ENTIRE bundle
+            (found by the OS Cleaner's F1 build). The next RID the ecosystem invents is excluded
+            here by construction instead of re-opening this.
         -->
         <ItemGroup>
             <_EqBundlePayload Include="$(TargetDir)**/*"
                               Exclude="$(TargetDir)$(_EqAppName).app/**/*;$(TargetDir)**/*.app/**/*;
                                        $(TargetDir)**/*.pdb;
-                                       $(TargetDir)runtimes/win*/**/*;
-                                       $(TargetDir)runtimes/linux*/**/*;
-                                       $(TargetDir)runtimes/android*/**/*;
-                                       $(TargetDir)runtimes/ios*/**/*" />
+                                       $(TargetDir)runtimes/**/*" />
+            <_EqBundlePayload Include="$(TargetDir)runtimes/osx*/**/*;
+                                       $(TargetDir)runtimes/unix*/**/*" />
         </ItemGroup>
+        <!--
+            Contents/MacOS is REBUILT from the payload every time, not accreted: the copy alone
+            never removes anything, so a file the payload stopped including (a package dropped, a
+            RID newly excluded) stayed in the bundle forever — and kept failing codesign long
+            after the exclusion was fixed. Everything under MacOS comes from this copy, so
+            removing the directory first is exactly "the bundle is the payload".
+        -->
+        <RemoveDir Directories="$(_EqBundleDir)/Contents/MacOS" />
         <Copy SourceFiles="@(_EqBundlePayload)"
-              DestinationFiles="@(_EqBundlePayload->'$(_EqBundleDir)/Contents/MacOS/%(RecursiveDir)%(Filename)%(Extension)')"
-              SkipUnchangedFiles="true" />
+              DestinationFiles="@(_EqBundlePayload->'$(_EqBundleDir)/Contents/MacOS/%(RecursiveDir)%(Filename)%(Extension)')" />
         <Exec Command="chmod +x &quot;$(_EqBundleDir)/Contents/MacOS/$(AssemblyName)&quot;" />
 
         <!--
@@ -117,9 +130,14 @@
             calling gets an answer that names nothing. Ad hoc is right for a development build: it
             proves nothing about origin, which is honest, and it is what a local app needs to be
             treated as an app at all. A shipped build re-signs with a real identity.
+
+            A signing failure FAILS THE BUILD. It used to be a warning, and the .app kept whatever
+            signature the previous build left — an identity that silently flips is how a TCC grant
+            (Full Disk Access) evaporates between builds, and nobody connects a lost permission to
+            a warning that scrolled past yesterday. A loud build is the cheap version of that hour.
         -->
         <Exec Command="codesign --force --deep --sign - --identifier &quot;$(_EqBundleId)&quot; &quot;$(_EqBundleDir)&quot;"
-              ContinueOnError="true" StandardOutputImportance="normal" />
+              StandardOutputImportance="normal" />
     </Target>
 
     <!--

--- a/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
+++ b/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
@@ -109,8 +109,16 @@
                               Exclude="$(TargetDir)$(_EqAppName).app/**/*;$(TargetDir)**/*.app/**/*;
                                        $(TargetDir)**/*.pdb;
                                        $(TargetDir)runtimes/**/*" />
-            <_EqBundlePayload Include="$(TargetDir)runtimes/osx*/**/*;
-                                       $(TargetDir)runtimes/unix*/**/*" />
+            <!--
+                The allowed runtimes ride a SEPARATE item rooted at runtimes/ — with the RID in the
+                include pattern itself (runtimes/osx*/**), %(RecursiveDir) starts AFTER the RID
+                folder, the copy drops the runtimes/osx-arm64/ segment, and two RIDs shipping the
+                same filename collide in the bundle. Rooting ** at runtimes/ keeps the RID inside
+                %(RecursiveDir); the filter is per-item metadata.
+            -->
+            <_EqRuntimesAll Include="$(TargetDir)runtimes/**/*" />
+            <_EqRuntimesPayload Include="@(_EqRuntimesAll)"
+                                Condition="$([System.String]::new('%(RecursiveDir)').StartsWith('osx')) or $([System.String]::new('%(RecursiveDir)').StartsWith('unix'))" />
         </ItemGroup>
         <!--
             Contents/MacOS is REBUILT from the payload every time, not accreted: the copy alone
@@ -122,6 +130,8 @@
         <RemoveDir Directories="$(_EqBundleDir)/Contents/MacOS" />
         <Copy SourceFiles="@(_EqBundlePayload)"
               DestinationFiles="@(_EqBundlePayload->'$(_EqBundleDir)/Contents/MacOS/%(RecursiveDir)%(Filename)%(Extension)')" />
+        <Copy SourceFiles="@(_EqRuntimesPayload)"
+              DestinationFiles="@(_EqRuntimesPayload->'$(_EqBundleDir)/Contents/MacOS/runtimes/%(RecursiveDir)%(Filename)%(Extension)')" />
         <Exec Command="chmod +x &quot;$(_EqBundleDir)/Contents/MacOS/$(AssemblyName)&quot;" />
 
         <!--


### PR DESCRIPTION
## What

The OS Cleaner's F1 build reported the macOS bundle signing broken by **any package shipping multi-RID native assets — and failing silently**. Reproduced byte-for-byte before fixing: `Microsoft.Data.Sqlite` brings `runtimes/browser-wasm/nativeassets/net9.0/e_sqlite3.a` (a static archive, not Mach-O); `codesign --deep` refuses the entire bundle ("bundle format unrecognized"); with `ContinueOnError` that refusal was a **warning**, the build stayed green, and the .app kept the previous signature — `codesign -dv` showed `Identifier=apphost` instead of the bundle id. An identity that flips between builds is how a TCC grant (Full Disk Access) evaporates, which is the exact thing W5 exists to prevent.

## Three fixes, each proven on the reproduction (WalletMobile, planted hostile asset)

1. **`runtimes/` is an allowlist (`osx*`, `unix*`), not a denylist.** The denylist named win/linux/android/ios and let `browser-wasm` through; the next RID the ecosystem invents is excluded by construction.
2. **`Contents/MacOS` is rebuilt from the payload, not accreted.** Found while fixing #1: the copy alone never removes anything, so the wasm archive from the *previous* build stayed inside the bundle and kept failing codesign long after the exclusion was in place. A stale payload is the silent-signature disease in another form (a dropped package or newly-excluded RID lingered forever).
3. **A codesign failure fails the build** (`ContinueOnError` removed). Proven with an unsignable file in an allowed path: exit 1, `error MSB3073` — loud. For the record, the failing shape is the `nativeassets/netX.Y` nesting (treated as a subcomponent by `--deep`); a bare `.a` under `native/` signs fine, which is why the denylist survived this long.

## Proof

With the hostile asset still present in the output directory after the fix: build green, zero `browser-wasm` inside the bundle, `Identifier=com.equantic.walletmobile`, and `codesign --verify --deep --strict` passes. Both bundle-producing samples (WalletMobile, PhotonDesktop) build clean.

Reported by the OS Cleaner consumer session with two of the three suggestions (allowlist, fail-hard); the rebuild-not-accrete came out of reproducing it here.