### PR TITLE
🔧 chore: 0.2.0-preview.45

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.44</Version>
+        <Version>0.2.0-preview.45</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
## Release 0.2.0-preview.45

The one-line bump; the tag `v0.2.0-preview.45` on the merge commit publishes.

### What ships since 0.2.0-preview.44

- 🐛 **#56 — macOS bundle signing: RID allowlist, rebuilt not accreted, signed or failed.** Any package with foreign-RID native assets (`browser-wasm` from `Microsoft.Data.Sqlite`) made `codesign --deep` refuse the bundle, the build stayed green on a warning, and the .app kept its previous signature (`Identifier=apphost`) — an identity that flips between builds is how TCC grants evaporate. Now an allowlist (osx*/unix*), `Contents/MacOS` rebuilt from the payload every build, and a signing failure fails the build.
- ✨ **#55 — the declarative surface can state semantics.** `Pressable(+label, selected, disabled, pressedBackground, expanded)`, `Link(+label, current)`, `TextEntry(+label, placeholder, disabled, obscure)` — factory tails applied via initializer, on both sides of the twin; the factory contract grew the rule (optional tail = public init-only property).
- ✨ **#53 — `FillAnnularSector`**, the W1 ring-slice primitive as an exact SDF across Reference/Metal/Vulkan (+ `FillCircle` sugar), consumer-proven on a real 5.38M-file sunburst; plus the reactive `ClearEQuanticCache`, samples no longer packing, and `Native.Shell.iOS`/`UI.Runtime` back in the solution.
- ✨ **#48 — the email realizer (Track M)**: tables, inline styles, literal colors, plain-text twin.
- 🐛 **#50 — a foreign record keeps the hydration boundary typed** (structural `{ members }` spec); 🐛 **#49 — `SizeValue.windowMinus` on the twin.**
- 📝 #51/#52/#54 — Track W plan, W7 developer loop, first-contact friction ledger.