### PR TITLE
👷 ci: the package set is discovered from IsPackable, not listed by hand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,8 +231,10 @@ jobs:
             name=$(basename "$(dirname "$csproj")")
             case " $SEPARATE " in *" $name "*) continue;; esac
             case "$name" in eQuantic.UI.Runtime.*) continue;; esac
-            packable=$(dotnet msbuild "$csproj" -getProperty:IsPackable -nologo 2>/dev/null | tr -d '[:space:]')
-            if [ "${packable,,}" = "false" ]; then continue; fi
+            # tr, not ${var,,}: the macOS runner's bash is 3.2, which has no case conversion —
+            # the same reason the Test step avoids globstar.
+            packable=$(dotnet msbuild "$csproj" -getProperty:IsPackable -nologo 2>/dev/null | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+            if [ "$packable" = "false" ]; then continue; fi
             echo "::group::pack $name"
             dotnet build "$csproj" -c Release -p:Version=$VERSION
             dotnet pack  "$csproj" -c Release --no-build -p:Version=$VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,55 +217,31 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.VERSION }}"
 
-          # The complete public package set — every ID the two SDKs (and their templates)
-          # resolve, plus the extras. eQuantic.Build and eQuantic.UI.Native.Build are embedded
-          # into the SDK packages as tools and are deliberately NOT here.
-          PACKAGES=(
-            eQuantic.UI.Core
-            eQuantic.UI.Primitives
-            eQuantic.UI.Codegen
-            eQuantic.UI.Compiler
-            eQuantic.UI.Components
-            eQuantic.UI.Generators
-            eQuantic.UI.Server
-            eQuantic.UI.Web
-            eQuantic.UI.Gtm
-            eQuantic.UI.Native.Components
-            eQuantic.UI.Native.Engine
-            eQuantic.UI.Native.Engine.Metal
-            eQuantic.UI.Native.Engine.Reference
-            eQuantic.UI.Native.Engine.Vulkan
-            eQuantic.UI.Native.Framework
-            eQuantic.UI.Native.Generators
-            eQuantic.UI.Native.Hosting
-            eQuantic.UI.Native.Shell.Apple
-            eQuantic.UI.Native.Shell.MacOS
-            eQuantic.UI.Native.Shell.iOS
-            eQuantic.UI.Native.Shell.Android
-            eQuantic.UI.BootstrapIcons
-            eQuantic.UI.FontAwesome6.Brands
-            eQuantic.UI.FontAwesome6.Regular
-            eQuantic.UI.FontAwesome6.Solid
-            eQuantic.UI.Heroicons
-            eQuantic.UI.Iconoir
-            eQuantic.UI.MaterialSymbols
-            eQuantic.UI.Lucide
-            eQuantic.UI.Material
-            eQuantic.UI.Phosphor
-            eQuantic.UI.RadixIcons
-            eQuantic.UI.SimpleIcons
-            eQuantic.UI.TablerIcons
-            eQuantic.UI.Images
-            eQuantic.UI.Lottie
-            eQuantic.UI.Charts
-            eQuantic.UI.Charts.ApexCharts
-            eQuantic.UI.Charts.ChartJs
-          )
-          for pkg in "${PACKAGES[@]}"; do
-            # Glob, not name convention: a few folders and their csproj names diverge.
-            dotnet build src/"$pkg"/*.csproj -c Release -p:Version=$VERSION
-            dotnet pack  src/"$pkg"/*.csproj -c Release --no-build -p:Version=$VERSION
+          # The package set is DISCOVERED, not listed: every project under src/ that says
+          # IsPackable (the csproj is the one place that decision already lives) is built and
+          # packed here. The hand-kept roster this replaces missed eQuantic.UI.Email for two
+          # releases — it never reached nuget.org while the release notes announced it. Tools
+          # that ride inside the SDK packages (eQuantic.Build, eQuantic.UI.Native.Build) and
+          # design-time projects say IsPackable=false themselves. Left out on purpose: the
+          # per-RID runtime packs (the platform matrix packs them) and the four projects below,
+          # whose pack targets stage tools and must not run with --no-build.
+          SEPARATE="eQuantic.UI.Runtime eQuantic.UI.Sdk eQuantic.UI.Sdk.Native eQuantic.UI.Templates"
+          PACKED=0
+          for csproj in src/*/*.csproj; do
+            name=$(basename "$(dirname "$csproj")")
+            case " $SEPARATE " in *" $name "*) continue;; esac
+            case "$name" in eQuantic.UI.Runtime.*) continue;; esac
+            packable=$(dotnet msbuild "$csproj" -getProperty:IsPackable -nologo 2>/dev/null | tr -d '[:space:]')
+            if [ "${packable,,}" = "false" ]; then continue; fi
+            echo "::group::pack $name"
+            dotnet build "$csproj" -c Release -p:Version=$VERSION
+            dotnet pack  "$csproj" -c Release --no-build -p:Version=$VERSION
+            echo "::endgroup::"
+            PACKED=$((PACKED + 1))
           done
+          echo "::notice::packed $PACKED discovered packages"
+          # A discovery that finds nothing is a broken discovery, not an empty repository.
+          [ "$PACKED" -ge 30 ] || { echo "::error::only $PACKED packable projects found under src/"; exit 1; }
 
           # The Runtime meta-package and the SDKs pack WITHOUT --no-build: their pack targets
           # stage tools (eqc, eQuantic.Build, eqicon) and stamp versions.

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ extensions/vscode/icon.png
 artifacts/packages/*
 !artifacts/packages/.gitkeep
 
-# Local NuGet feed for end-to-end consumer validation (the recipe in docs/DESKTOP-PLAN.md):
+# Local NuGet feed for end-to-end consumer validation (the recipe: wiki BuildFlow,
+# "Consuming an unreleased SDK from local packages"):
 # packed on demand at 1.0.0-dev, never committed.
 artifacts/local-feed/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@ small and focused; the PR is the unit that must be substantial.
 
 ## Project Overview
 
-**eQuantic.UI** is a Flutter-inspired component-based UI framework for .NET that compiles C# components directly to optimized JavaScript at build time (not WASM). It provides type-safe, HTML-native components with a minimal runtime (~85 KB gzipped).
+**eQuantic.UI** is a Flutter-inspired component-based UI framework for .NET that compiles C# components directly to optimized JavaScript at build time (not WASM). It provides type-safe, HTML-native components with a small runtime (its gzip size is measured by the site's
+build and not quoted here — it changes every release).
 
 ### Core Principles
 


### PR DESCRIPTION
## What

**`eQuantic.UI.Email` never reached nuget.org** — not in 0.2.0-preview.44, not in .45 (whose release notes announce it). The publish job packed a hand-kept `PACKAGES=( … )` roster, and the Track M project was never added. Verified: `curl -I` on the flatcontainer returns 404 for every version; the package's `index.json` does not exist.

Third time this month the same disease bit (the `IsPackableProject` auto-pack list, the `ClearEQuanticCache` directory list): a hand copy of a decision the csproj files already carry. The `IsPackable` audit of `src/` says it all — every project outside the roster and the separate packs says `IsPackable=false` (`eQuantic.Build`, `eQuantic.UI.Native.Build`, `eQuantic.UI.Design`, `eQuantic.UI.Design.Photon`) **except Email, which says true**.

## The fix

The job walks `src/*/*.csproj` and asks MSBuild `-getProperty:IsPackable`. Excluded on principle: the per-RID runtime packs (the platform matrix packs them) and the four projects whose pack targets stage tools and must not run with `--no-build` (Runtime meta, Sdk, Sdk.Native, Templates — packed exactly as before). Simulated locally: **40 discovered = the old roster's 39 + Email**. A discovery under 30 fails the job — an empty result is a broken discovery, not an empty repository. YAML validated.

## Also

- `.gitignore` pointed the local-feed recipe at `docs/DESKTOP-PLAN.md`, which never held it — it lives on the wiki's BuildFlow page ("Consuming an unreleased SDK from local packages").
- `CLAUDE.md` quoted "~85 KB gzipped" for a runtime that gzips to 138 KB today; the site's build measures the number now and the docs stop quoting it.

## What this does NOT do

It cannot publish Email for .45 retroactively: `publish-nuget` runs only on tag refs, and a re-run of the tag executes the workflow **at the tag** (old roster). Email ships with the next tag — or by a one-off `dotnet nuget push` of the .45 nupkg with the API key.