### PR TITLE
✨ feat: [ServerOnly] on a class — the type never crosses, so no module

### DIFF
--- a/src/eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/InvocationStrategy.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/InvocationStrategy.cs
@@ -356,7 +356,8 @@ public class InvocationStrategy : IExpressionIrStrategy
         context.Report(node, ConversionSeverity.Error, "EQ2004",
             $"'{declaring.ToDisplayString()}.{symbol.Name}' has no JavaScript translation. "
             + "The transpiler only knows the constructs it maps explicitly; add a strategy for it, "
-            + "or move the call behind a [ServerAction].");
+            + "move the call behind a [ServerAction], or mark the declaring class [ServerOnly] if it "
+            + "only ever runs on the server.");
     }
 
     /// <summary>Does the file import the declarative factory surface with `using static`? Matched on

--- a/src/eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/InvocationStrategy.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Strategies/Expressions/InvocationStrategy.cs
@@ -356,8 +356,8 @@ public class InvocationStrategy : IExpressionIrStrategy
         context.Report(node, ConversionSeverity.Error, "EQ2004",
             $"'{declaring.ToDisplayString()}.{symbol.Name}' has no JavaScript translation. "
             + "The transpiler only knows the constructs it maps explicitly; add a strategy for it, "
-            + "move the call behind a [ServerAction], or mark the declaring class [ServerOnly] if it "
-            + "only ever runs on the server.");
+            + "move the call behind a [ServerAction], or — if the class this call sits in only ever "
+            + "runs on the server — mark THAT class [ServerOnly] so no module is emitted for it.");
     }
 
     /// <summary>Does the file import the declarative factory surface with `using static`? Matched on

--- a/src/eQuantic.UI.Compiler/Parser/ComponentParser.cs
+++ b/src/eQuantic.UI.Compiler/Parser/ComponentParser.cs
@@ -185,6 +185,9 @@ public class ComponentParser
                     Services.ResourceClasses.DesignerPathFor(declared));
                 continue;
             }
+            // [ServerOnly] on the class: it never crosses, so no module — the class-level twin of the
+            // method rule below, for the Roslyn service or hosted warm-up that lives in the web project.
+            if (IsServerOnly(classDecl)) continue;
             if (classDecl.Modifiers.Any(SyntaxKind.StaticKeyword))
             {
                 results.Add(new ComponentDefinition
@@ -271,6 +274,7 @@ public class ComponentParser
             if (componentNames.Contains(classDecl.Identifier.Text)) continue; // component path
             if (stateNames.Contains(classDecl.Identifier.Text)) continue;     // owned by its page
             if (classDecl.Members.Count == 0) continue;
+            if (IsServerOnly(classDecl)) continue;                             // never crosses: no module
             // Track L D2: a resx Designer is a plain non-static class by shape, and a module of
             // ResourceManager.GetString calls cannot run in a browser — its accessors rewrite to
             // $eq.str at every use site instead. Recorded on the way past (see the static-helper
@@ -537,6 +541,12 @@ public class ComponentParser
     /// server surface (an SSR prefetch's HttpClient, EF, the request's services). The counterpart of
     /// <c>[ServerAction]</c>, which keeps the method callable FROM the browser through an RPC stub.
     /// </summary>
+    /// <summary>The class-level form: <c>[ServerOnly]</c> on a static helper or a plain class says
+    /// the whole type stays on the server, and the parser emits no module for it.</summary>
+    private static bool IsServerOnly(ClassDeclarationSyntax classDecl) =>
+        classDecl.AttributeLists.SelectMany(list => list.Attributes)
+            .Any(attribute => attribute.Name.ToString() is "ServerOnly" or "ServerOnlyAttribute");
+
     private static bool IsServerOnly(MethodDeclarationSyntax method) =>
         method.AttributeLists.SelectMany(list => list.Attributes)
             .Any(attribute => attribute.Name.ToString() is "ServerOnly" or "ServerOnlyAttribute");

--- a/src/eQuantic.UI.Core/ServerOnlyAttribute.cs
+++ b/src/eQuantic.UI.Core/ServerOnlyAttribute.cs
@@ -18,8 +18,10 @@ namespace eQuantic.UI.Core;
 /// top-level static class and every plain class in an app is otherwise mirrored to JavaScript — a
 /// Roslyn compilation service, a hosted warm-up, a repository living in the web project failed the
 /// build with EQ2004 on their first server-only call, and nothing short of moving them to another
-/// assembly could say "this never ships". A component cannot be ServerOnly; a class the client's
-/// code instantiates or calls must not be either, for the same reason as the method.
+/// assembly could say "this never ships". On a COMPONENT it has no effect — the component path
+/// ignores it, because a component always ships. And a class the client's code instantiates or
+/// calls must not carry it, for the same reason as the method: the reference would resolve to
+/// nothing at runtime.
 /// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]

--- a/src/eQuantic.UI.Core/ServerOnlyAttribute.cs
+++ b/src/eQuantic.UI.Core/ServerOnlyAttribute.cs
@@ -13,8 +13,16 @@ namespace eQuantic.UI.Core;
 /// A method the client's own code calls must NOT be ServerOnly — the call would resolve to nothing
 /// at runtime; make it a ServerAction instead.
 /// </para>
+/// <para>
+/// On a CLASS it says the same of the whole type: the transpiler emits no module for it. Every
+/// top-level static class and every plain class in an app is otherwise mirrored to JavaScript — a
+/// Roslyn compilation service, a hosted warm-up, a repository living in the web project failed the
+/// build with EQ2004 on their first server-only call, and nothing short of moving them to another
+/// assembly could say "this never ships". A component cannot be ServerOnly; a class the client's
+/// code instantiates or calls must not be either, for the same reason as the method.
+/// </para>
 /// </summary>
-[AttributeUsage(AttributeTargets.Method)]
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
 public sealed class ServerOnlyAttribute : Attribute
 {
 }

--- a/tests/eQuantic.UI.Compiler.Tests/ServerOnlyClassTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/ServerOnlyClassTests.cs
@@ -1,0 +1,73 @@
+using System.Linq;
+using eQuantic.UI.Compiler;
+using FluentAssertions;
+using Xunit;
+
+namespace eQuantic.UI.Compiler.Tests;
+
+/// <summary>
+/// <c>[ServerOnly]</c> on a CLASS: the type never crosses, so the parser emits no module for it.
+/// <para>
+/// Every top-level static class and every plain class in an app is otherwise mirrored to
+/// JavaScript — a Roslyn compilation service and a hosted warm-up living in a web project failed
+/// the build with EQ2004 on their first server-only call (Stopwatch, CSharpCompilation), and
+/// nothing short of moving them to another assembly could say "this never ships". The method-level
+/// attribute already said it for methods; this is the same sentence for a whole type.
+/// </para>
+/// </summary>
+public class ServerOnlyClassTests
+{
+    private static string Source(string attribute) => $$"""
+        using System.Diagnostics;
+        using eQuantic.UI.Core;
+        using eQuantic.UI.Primitives;
+
+        {{attribute}}
+        public static class Warmup
+        {
+            public static long Measure()
+            {
+                var watch = Stopwatch.StartNew();
+                watch.Stop();
+                return watch.ElapsedMilliseconds;
+            }
+        }
+
+        {{attribute}}
+        public sealed class CompileService
+        {
+            public string Run() => Stopwatch.GetTimestamp().ToString();
+        }
+
+        [Page("/probe")]
+        public sealed class ProbePage : StatelessComponent
+        {
+            public override VisualNode Build(ComponentContext context)
+                => new Text("x", TypeRole.BodyM);
+        }
+        """;
+
+    [Fact]
+    public void AServerOnlyClass_GetsNoModule_AndItsServerCallsRaiseNothing()
+    {
+        var results = new ComponentCompiler().CompileSource(Source("[ServerOnly]"), "Probe.cs").ToList();
+
+        results.Select(r => r.ComponentName).Should().BeEquivalentTo(["ProbePage"],
+            "neither the static helper nor the plain class crosses to the client");
+        results.SelectMany(r => r.Errors).Should().NotContain(e => e.Code == "EQ2004",
+            "a class that never ships cannot fail on the server surface it uses");
+    }
+
+    [Fact]
+    public void WithoutTheAttribute_BothClassesAreMirrored_AndTheServerCallsAreTheError()
+    {
+        // The control: the same source minus the attribute is exactly the failure the attribute
+        // exists to prevent — both classes become modules, and Stopwatch has no translation.
+        var results = new ComponentCompiler().CompileSource(Source(""), "Probe.cs").ToList();
+
+        results.Select(r => r.ComponentName).Should().Contain(["Warmup", "CompileService"]);
+        results.SelectMany(r => r.Errors).Should().Contain(e => e.Code == "EQ2004"
+            && e.Message.Contains("[ServerOnly]"),
+            "the diagnostic names the way out");
+    }
+}


### PR DESCRIPTION
## What

`[ServerOnly]` now applies to **classes**: the transpiler emits no module for a type marked with it.

## Why

Every top-level static class and every plain class in an app is mirrored to JavaScript — by design, so `new Bucket()` and `Format.Foo()` resolve at runtime (`ComponentParser`, the static-helper and plain-class paths). The site's migration to 0.2.0-preview.45 found the other side of that rule: `PlaygroundCompilation` (a Roslyn compilation service) and `PlaygroundWarmup` (a hosted warm-up) live in the web project and failed the build with **34 × EQ2004** on their first server-only calls (`Stopwatch.StartNew`, `CSharpCompilation.Create`, `Task.WaitAsync`, `AppDomain.GetAssemblies`). Nothing short of moving them to another assembly could say "this never ships" — the method-level attribute already said it for methods.

## The change

- `ServerOnlyAttribute`: `AttributeUsage(Method | Class)`, with the doc saying what a class-level mark means and what must not carry it (a component; a class the client instantiates).
- `ComponentParser`: a `[ServerOnly]` class is skipped on both emission paths (static helper, plain class) — the class-level twin of the existing `IsServerOnly(MethodDeclarationSyntax)` skip.
- EQ2004's hint names the way out: "…or mark the declaring class `[ServerOnly]` if it only ever runs on the server."

## Tests

`ServerOnlyClassTests`: with the attribute, neither class becomes a module and no EQ2004 is raised; the **control** (same source, no attribute) mirrors both and raises EQ2004 whose message names `[ServerOnly]`. Compiler and Web suites green.

## Consumer

Unblocks the site's bump to the current release (parked as a local WIP: version pins, Roslyn 5.9.0 for the tests project, and the generated factories now resolving `IThemeController` themselves). Ships with the next release.