### PR TITLE
📝 docs: the roadmap is fresh — measured numbers out, what shipped marked, this cycle recorded

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 | Challenge | Blazor WASM | JavaScript frameworks | **eQuantic.UI** |
 |-----------|-------------|----------------------|-----------------|
 | **Language** | C# | JavaScript/TypeScript | **C#, end to end** |
-| **Web payload** | ~2 MB+ runtime | varies | a **small gzipped runtime** (the site measures it at build time and shows the number on its landing), per-page code splitting |
+| **Web payload** | ~2 MB+ runtime | varies | a **small gzipped runtime** (the site measures it at build time and shows the number on its landing page), per-page code splitting |
 | **Native apps** | separate MAUI codebase | separate React Native/Electron | **the same components**, GPU-rendered |
 | **Styling** | CSS/Razor | CSS-in-JS / utility classes | **typed C# — no CSS authored**, atomic classes generated |
 | **Server calls** | SignalR setup | REST/GraphQL setup | **built-in RPC** (`[ServerAction]`) |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 | Challenge | Blazor WASM | JavaScript frameworks | **eQuantic.UI** |
 |-----------|-------------|----------------------|-----------------|
 | **Language** | C# | JavaScript/TypeScript | **C#, end to end** |
-| **Web payload** | ~2 MB+ runtime | varies | **~85 KB** gzipped runtime, per-page code splitting |
+| **Web payload** | ~2 MB+ runtime | varies | a **small gzipped runtime** (the site measures it at build time and shows the number on its landing), per-page code splitting |
 | **Native apps** | separate MAUI codebase | separate React Native/Electron | **the same components**, GPU-rendered |
 | **Styling** | CSS/Razor | CSS-in-JS / utility classes | **typed C# — no CSS authored**, atomic classes generated |
 | **Server calls** | SignalR setup | REST/GraphQL setup | **built-in RPC** (`[ServerAction]`) |
@@ -240,7 +240,7 @@ Each package owns its artifacts and the SDK wires them together through NuGet-ge
 
 ## Supported C# Features
 
-Fidelity is enforced by a **conformance harness** (500+ cases) that runs each C# construct as both
+Fidelity is enforced by a **conformance harness** (over a thousand cases, counted by the suite rather than here) that runs each C# construct as both
 transpiled JS and real .NET and asserts identical results. Every construct resolves to one of three
 mechanisms: a native JS strategy, a faithful `$eq.*` compat helper, or a build error when it's
 genuinely impossible.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,9 @@
 # eQuantic.UI — Roadmap & Honest State Assessment
 
-> Last updated: 2026-06-10. This document is an honest, evidence-based assessment of where
-> eQuantic.UI stands against its vision, and a prioritized roadmap to close the gaps.
+> Last updated: 2026-09-02 (a freshness pass: measured numbers replaced by where the count lives,
+> shipped work marked with the release that carries it). This document is an honest, evidence-based
+> assessment of where eQuantic.UI stands against its vision, and a prioritized roadmap to close the
+> gaps.
 >
 > **Update (2026-06-10): Phase 1 (transpiler correctness & conformance) is essentially complete.** The
 > correctness net now exists — a **differential conformance harness** (emitted JS run via embedded Bun and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 > eQuantic.UI stands against its vision, and a prioritized roadmap to close the gaps.
 >
 > **Update (2026-06-10): Phase 1 (transpiler correctness & conformance) is essentially complete.** The
-> correctness net now exists — a **492-case conformance harness** (emitted JS run via embedded Bun and
+> correctness net now exists — a **differential conformance harness** (emitted JS run via embedded Bun and
 > compared to .NET), **fail-on-unsupported** diagnostics (no silent miscompiles), and a documented
 > supported subset (`docs/DOTNET-COVERAGE-PROGRAM.md` + wiki `SupportedFeatures`). The "honest state"
 > below describes the pre-hardening starting point; the transpiler rows are updated inline. The forward
@@ -23,7 +23,7 @@ eQuantic.UI aims to be a **true 100% C# UI SDK**:
 ## Current State (honest)
 
 eQuantic.UI is a **technically real, ambitious project at an advanced-alpha stage** — not vaporware.
-What genuinely exists and works: a Roslyn-based C#→JS transpiler (**118 conversion strategies**),
+What genuinely exists and works: a Roslyn-based C#→JS transpiler (**one strategy per C# construct**, writing an IR),
 SSR, Server Actions with authorization, a keyed-LIS reconciler, a theming/StyleBuilder system,
 Tailwind integration, embedded Bun, and large auto-generated icon packages.
 
@@ -33,15 +33,15 @@ miscompilations (integer division producing floats, `Math.Truncate` crashing at 
 representing as a number in one path and a string in another, `.ToString("F2")` dropping its format,
 `Text` dropping its content, SVG created in the wrong DOM namespace, source-map columns all wrong,
 hydration mis-aligning on whitespace). These have been fixed, and their *nature* was the real signal —
-so the correctness net has since been built (Phase 1): a 530-case conformance harness, fail-on-unsupported
+so the correctness net has since been built (Phase 1): a conformance harness that executes every case on both sides (the suite counts them; this file does not), fail-on-unsupported
 diagnostics, and a documented supported subset. That was the linchpin; it is now in place.
 
 ### Evidence snapshot
 
 | Area | State |
 |------|-------|
-| Transpiler | 120+ strategies; **correctness net in place** — 530-case Bun-vs-.NET conformance harness, fail-on-unsupported diagnostics (`EQ2001/2002/21xx/1001/1002`), documented supported subset; the silent fallbacks are resolved to support or explicit diagnostics |
-| Components | **77** component files (Inputs 14, Overlays 11, Display 11, Navigation 8, Layout 8, Surfaces 6, Feedback 5, Forms 3 + primitives); some were half-implemented |
+| Transpiler | A strategy per construct over an IR; **correctness net in place** — the Bun-vs-.NET conformance harness (over a thousand cases, counted by the suite), fail-on-unsupported diagnostics (`EQ2001/2002/21xx/1001/1002`), documented supported subset; the silent fallbacks are resolved to support or explicit diagnostics |
+| Components | The write-once catalog (index: the wiki's Components page); some were half-implemented |
 | Client routing | **Shipped** — link-driven client router (`src/router`), layout preserved across navigation by reconcile-on-navigate. A typed programmatic `Navigator` API is still ahead |
 | Forms & validation | **Shipped** — `FormController`/`FormField`/`Rules` in Primitives (write-once, quiet-until-touched, cross-field, conditional via `Rules.When`/`relevantWhen`), `FormInput`/`FormSubmit` surface, async submit through Server Actions with `ApplyServerErrors`, and the `[FormModel]` DataAnnotations bridge (build-time, no second engine) |
 | State management | Component-local `SetState` only; **no global state / signals / context** |
@@ -60,7 +60,7 @@ fixed were silent miscompilations — the worst failure mode for a C#-only devel
 appears in the browser with no C# vocabulary to debug it. The transpiler-correctness gaps are now done:
 - ✅ A **defined, documented supported subset** of C# (`DOTNET-COVERAGE-PROGRAM.md` + wiki).
 - ✅ **Compile-time errors for unsupported constructs** — never silent wrong output (`EQ20xx/21xx/10xx`).
-- ✅ A **conformance suite that executes the emitted JS (via Bun) and compares to .NET** — 492 cases.
+- ✅ A **conformance suite that executes the emitted JS (via Bun) and compares to .NET** — every case runs on both sides; the number lives in the test run, not here.
 - 🔄 **Source maps** validated (generation/decode); in-browser C# stack-trace smoke test still to add.
 
 Still genuinely missing (UI surface, not transpiler correctness):
@@ -78,14 +78,16 @@ The `Build(context)` model is genuinely Flutter-like. Missing the productivity m
 components, and layout/diagnostic tooling.
 
 ### 4. shadcn-like components
-77 components is a respectable start, but shadcn's value is **polish + accessibility + variants**.
+The catalog (the wiki's Components page is its index) is a respectable start, but shadcn's value is **polish + accessibility + variants**.
 Missing: serious a11y (focus management, keyboard nav, correct `aria-*`, focus-trap in overlays),
 consistent variant coverage, and finishing the half-baked ones. Quality > quantity here.
 
-### 5. Pluggable CSS engine
-The abstraction exists (`IStyleProvider`). Missing: at least one **complete first-party embedded
-engine** (utility parser → CSS, purge/tree-shake, design tokens) working end-to-end without Node,
-plus a documented contract so third parties (UnoCSS, etc.) can implement a provider.
+### 5. Pluggable CSS engine — **resolved by decision, not by plugging**
+The first-party engine shipped (Track S): typed C# styles lowered to deduplicated atomic classes,
+generated at build time from the shared `Primitives` tokens — the same design system Photon paints —
+and byte-identical between SSR and hydration. Pluggability is deliberately NOT pursued: the framework
+ships exactly ONE styling engine, and any external CSS a consumer brings is their own build concern.
+The raw-HTML/CSS escape hatch (`HtmlElement`, `ClassBuilder`) stays for web-only pages.
 
 ### Cross-cutting maturity (framework → SDK)
 - **Compiler diagnostics**: actionable messages with C# `file:line` + suggestions.
@@ -94,7 +96,21 @@ plus a documented contract so third parties (UnoCSS, etc.) can implement a provi
 - **Docs & examples**: essential for a "0 JS" audience — the supported subset and recipes.
 - **SSR/hydration robustness**: the hydration mis-alignment shows this path is still fragile.
 - **Security**: hardened in this pass (deserialization allow-list, SignalR relay, payload cap);
-  needs a formal hardening review + CSP guidance.
+  needs a formal hardening review + CSP guidance. **Consent before cookies (2026-09)**: `IConsent` as
+  a capability, the `CookieConsent` card, and `UseGtm(...).WithConsent()` — Consent Mode defaults to
+  denied and the container is fetched only on a granted answer, on the first paint and live.
+- **Server-only code in a web project**: `[ServerOnly]` on a CLASS (2026-09) says the type never
+  crosses; before it, a Roslyn service or a hosted warm-up in the web project failed the build on its
+  first server-only call, and only another assembly could say otherwise.
+- **The declarative surface says everything a screen needs (2026-09)**: factory tails for semantics
+  (`label`, `selected`, `expanded`, `role`…) and layout (`width`/`height` on the containers), each an
+  init-only property the mirrored constructor deliberately does not carry — reported by the first
+  real consumer after migrating its whole UI, counted (49 places), and closed by a contract rule
+  rather than an exemption.
+- **A real consumer program**: the OS Cleaner (Track W's first consumer) builds against the SDK from
+  LOCAL packages (wiki: Build Flow → "Consuming an unreleased SDK from local packages"), renders
+  byte-identically from packages and from source, and files every first-contact friction in the
+  ledger at the end of `docs/DESKTOP-PLAN.md` — the input a rename or an editor hint needs.
 
 ---
 
@@ -104,7 +120,7 @@ plus a documented contract so third parties (UnoCSS, etc.) can implement a provi
 > missing SPA primitives (routing, forms, state), then DX (hot reload) and component/CSS polish.
 
 - **Phase 1 — Transpiler correctness & conformance** *(linchpin)* — **✅ essentially complete**:
-  supported-subset spec, fail-on-unsupported diagnostics, conformance harness (530 cases, emitted JS via
+  supported-subset spec, fail-on-unsupported diagnostics, conformance harness (emitted JS via
   Bun vs .NET) all in place; remaining polish is the in-browser source-map smoke test.
   → see `docs/IMPLEMENTATION-PLAN.md`.
 - **Phase 2 — Client router** — **✅ complete**: navigation without reload, typed route params, persistent
@@ -132,7 +148,9 @@ plus a documented contract so third parties (UnoCSS, etc.) can implement a provi
   (`PressableRole.Destination` / `Link.Current` → `aria-current="page"`, the Selected trait on both
   mobiles), which no existing role could express. Remaining: variant coverage, a component test
   harness.
-- **Phase 6 — First-party embedded CSS engine** + documented provider contract. **Normative
+- **Phase 6 — First-party embedded CSS engine** — **✅ shipped** (Track S: atomic classes deduplicated
+  by a hash cross-pinned between C# and TypeScript, theme tokens as custom properties with
+  fallbacks, one engine and no provider contract by decision — see pillar 5). **Normative
   (2026-07-03): the embedded CSS follows exactly the same design system as mobile** — the Photon
   Design System, generated at build time from the shared `eQuantic.UI.Primitives` tokens (single
   source of truth; no hand-maintained CSS values, parity tested). Tailwind/other engines remain
@@ -295,7 +313,7 @@ English), the `CurrentCulture`/`CurrentUICulture` pair, and `<html lang>` from t
 
 Added 2026-08-25, born from the OS Cleaner migration plan (the app's own plan maps its S1–S6 onto
 W1–W6 here) — but nothing in it is app-specific: these are the fences Photon has to close to claim
-DESKTOP APP, each verified in code, not docs. Eight draw commands and no arbitrary paths
+DESKTOP APP, each verified in code, not docs. Nine draw commands and no arbitrary paths
 (`DisplayList.cs`); a deliberately PERIODIC `IClock` whose own fence names the frame clock as the
 thing not yet built; rectangle-only hit-testing (`PhotonHost.cs` — `Bounds.Contains` on AABBs); no
 desktop shell surface (menus, tray, file dialogs, notifications, deep links); ad-hoc signing
@@ -304,8 +322,10 @@ desktop shell surface (menus, tray, file dialogs, notifications, deep links); ad
 The sweep also found what SHRINKS the work: a deterministic time channel already runs through
 layout (`TransitionStore`, pure in `(path, target, timeMs)`, wired at two call sites), the 120 Hz
 driver exists (as a run-loop timer — the ticker work upgrades it to a display link), two-stop
-radial gradients exist, and the shader toolchain self-resolves — so W1 (annular-sector SDF) is
-startable immediately.
+radial gradients exist, and the shader toolchain self-resolves — and **W1's first shape is
+DONE**: `FillAnnularSector` shipped in 0.2.0-preview.45 as an exact SDF with Reference↔Metal↔Vulkan
+parity, consumer-proven on a real 5.38-million-file sunburst; the polygon-vs-texture decision waits
+on the consumer's blob benchmark (W2).
 
 Workstreams: W1 engine shapes (annular sector + convex polygon, SDF family, NOT a path engine);
 W2 frame clock + tweens/springs + `BoxStyle.Transition` honored natively + `IUiDispatcher`
@@ -314,7 +334,10 @@ node with local-coordinate pointer events (also the hit-testing seam the headles
 instrument has waited for); W4 the macOS desktop shell surface; W5 real packaging — signing,
 entitlements, notarization, publish-based bundling, minimal updater — sequenced FIRST among the
 independents because the identity unblocks TCC, notifications and updates at once; W6
-Windows/Linux shells stay post-M5 as the engine plan already decided.
+Windows/Linux shells stay post-M5 as the engine plan already decided. Landed ahead of W5's real
+identity (0.2.0-preview.45): the ad-hoc bundle is rebuilt from the payload every build, `runtimes/` is
+an allowlist, and a signing failure fails the build — an identity that flips between builds is how a
+TCC grant evaporates, and that was happening.
 
 W7 (added 2026-08-25, raised by Edgar): the DEVELOPER LOOP — one command per target with device
 discovery embedded in `Sdk.Native` (`-t:RunIos` / `-t:RunAndroid`), `launchSettings.json` profiles
@@ -336,9 +359,12 @@ What is missing is the medium — nested-table layout for Outlook's Word engine,
 instead of custom properties, absolute image URLs, a 600px shell, and a fence over everything an
 email cannot do (`ScrollView`, `Pressable`, hover, `position: absolute`).
 
-Full design, slices and fences: wiki **[Email Rendering](https://github.com/eQuantic/equantic-ui/wiki/EmailRealizer)**.
-M0 MEASURES what the two existing calls already survive in Gmail, Outlook and Apple Mail before M1
-builds anything — half a day, no new code, and it decides the size of the rest.
+**Status: the core SHIPPED in 0.2.0-preview.45** — `eQuantic.UI.Email` (`EmailRealizer`/`EmailRenderer`):
+nested tables with spacer cells for gaps, inline styles, literal colors (translucent flattened over
+the surface), absolute-URL guard, a 600px shell, a plain-text twin from the same tree, and the fences
+(gradients, `MaxLines`, anything an email cannot do) as build-time refusals. Ahead: the real-client
+matrix (a generated sample against Gmail, Outlook and Apple Mail) and HTML pins once the output
+settles. Full design and fences: wiki **[Email Rendering](https://github.com/eQuantic/equantic-ui/wiki/EmailRealizer)**.
 
 ## Definition of "production-ready" (per pillar)
 - **0 JS**: any unsupported C# fails the build with a clear message; conformance suite green; C#

--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -16,7 +16,7 @@ Each was verified by reading the code, not the docs. File references are the pro
 | W-B3 | No app-facing frame clock | `IClock.cs` — the fence is verbatim: "this is a PERIODIC clock, not a frame clock… Per-frame animation is a [different thing]" |
 | W-B4 | Hit-testing is rectangle-only | `PhotonHost.cs:1431-1459` — every pointer resolution is `Bounds.Contains(point)` on AABBs; `OnPressed` carries no coordinates |
 | W-B5 | No desktop shell surface (menus, tray, file dialogs, notifications, deep links, drag & drop, dock, launch-at-login) | the macOS shell exposes a window + capabilities; none of these seams exist |
-| W-B6 | Ad-hoc signing, no notarization hook | `src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets:121` — `codesign --force --deep --sign -`; TCC grants (Full Disk Access) are keyed to the identity, so they break every build — **the bundle's three rules landed in 0.2.0-preview.45** (rebuilt from the payload, RID allowlist, a signing failure fails the build); the real identity, entitlements and notarization remain W5 |
+| W-B6 | Ad-hoc signing, no notarization hook | `src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets` — grep `codesign --force --deep --sign -` (cited by line until 0.2.0-preview.45 moved it: an anchor that rots is not proof); TCC grants (Full Disk Access) are keyed to the identity, so they break every build — **the bundle's three rules landed in 0.2.0-preview.45** (rebuilt from the payload, RID allowlist, a signing failure fails the build); the real identity, entitlements and notarization remain W5 |
 | W-B7 | One window per process | `PhotonContentView` / `PhotonAccessibility` hold static fields; `PhotonWindow.Run` blocks |
 
 **What already exists and shrinks the work** — found in the same sweep, and the reason estimates

--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -33,7 +33,7 @@ below are smaller than a cold reading suggests:
 - **Two-stop elliptical radial gradients exist** (`Paint.cs` — `RadialGradient = 2`, center +
   radii), which is the shading an annular sector needs.
 - **The shader toolchain self-resolves** (`scripts/generate-shaders.sh` downloads and
-  SHA-256-verifies the pinned slangc), so W1 is startable immediately.
+  SHA-256-verifies the pinned slangc) — which is how W1's first shape shipped within days.
 - **Headless screenshots** (`--Photon:ScreenshotPath`, Reference backend) already give any
   desktop app golden tests in CI.
 

--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -12,11 +12,11 @@ Each was verified by reading the code, not the docs. File references are the pro
 | # | Gap | Evidence |
 |---|---|---|
 | W-B1 | No Windows/Linux shell; Vulkan creates only Android surfaces | `VulkanSurfaceNative.cs` — `vkCreateAndroidSurfaceKHR` is the only surface entry point |
-| W-B2 | No arbitrary paths/arcs in the engine — 8 draw commands, all SDF/texture | `DisplayList.cs` — `Clear..BackdropBlur` (0..7); paths are a normative "v2+" fence in `NATIVE-GPU-ENGINE-PLAN.md` |
+| W-B2 | No arbitrary paths/arcs in the engine — nine draw commands, all SDF/texture (the ninth, `FillAnnularSector`, is W1's first shape, shipped 0.2.0-preview.45) | `DisplayList.cs` — `Clear..FillAnnularSector` (0..8); paths are a normative "v2+" fence in `NATIVE-GPU-ENGINE-PLAN.md` |
 | W-B3 | No app-facing frame clock | `IClock.cs` — the fence is verbatim: "this is a PERIODIC clock, not a frame clock… Per-frame animation is a [different thing]" |
 | W-B4 | Hit-testing is rectangle-only | `PhotonHost.cs:1431-1459` — every pointer resolution is `Bounds.Contains(point)` on AABBs; `OnPressed` carries no coordinates |
 | W-B5 | No desktop shell surface (menus, tray, file dialogs, notifications, deep links, drag & drop, dock, launch-at-login) | the macOS shell exposes a window + capabilities; none of these seams exist |
-| W-B6 | Ad-hoc signing, no notarization hook | `src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets:121` — `codesign --force --deep --sign -`; TCC grants (Full Disk Access) are keyed to the identity, so they break every build |
+| W-B6 | Ad-hoc signing, no notarization hook | `src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets:121` — `codesign --force --deep --sign -`; TCC grants (Full Disk Access) are keyed to the identity, so they break every build — **the bundle's three rules landed in 0.2.0-preview.45** (rebuilt from the payload, RID allowlist, a signing failure fails the build); the real identity, entitlements and notarization remain W5 |
 | W-B7 | One window per process | `PhotonContentView` / `PhotonAccessibility` hold static fields; `PhotonWindow.Run` blocks |
 
 **What already exists and shrinks the work** — found in the same sweep, and the reason estimates
@@ -149,7 +149,7 @@ capability or `IPlatformStrategy`-style seam, as today.
 
 ```
 W5 (packaging)  ──────────────►  smallest independent; unblocks TCC/notifications/updates
-W1 (engine)     ──────────────►  startable now (toolchain self-resolves); consumer spike gates it
+W1 (engine)     ──────────────►  sector SHIPPED (0.2.0-preview.45, consumer-proven); polygon decision waits on W2's blob benchmark
 W2 (framework)  ──────────────►  after W1's first shape lands (shares the golden harness)
 W3 (primitives) ──────────────►  with W2 (pointer events ride the same host loop work)
 W4 (shell)      ──── partial early (file dialogs + deep links), rest after W5


### PR DESCRIPTION
## What

A freshness pass over `ROADMAP.md` and `docs/DESKTOP-PLAN.md` — the plan itself does not change; what was stale in its description of reality does.

- **Measured numbers out.** "118 conversion strategies", a "530-case" harness on one line and "492 cases" on another, "77 component files" — each true for one release. Replaced with statements that cannot rot and a pointer to where the count actually lives (the test run, the wiki's Components index).
- **What shipped, marked.** Pillar 5 was still "missing a pluggable engine" after the decision to ship exactly one (Track S) — now "resolved by decision". Phase 6 gets its ✅. Track M said "M0 measures before M1 builds" after `eQuantic.UI.Email` shipped in 0.2.0-preview.45 — now the shipped status plus what remains (the real-client matrix). Track W said "W1 startable immediately" after `FillAnnularSector` shipped and was consumer-proven — now the shipped half plus the open polygon decision; the bundle rules that landed under W-B6 are recorded ahead of W5's real identity.
- **This cycle recorded** under cross-cutting maturity: consent before cookies (`IConsent`, `CookieConsent`, `UseGtm(...).WithConsent()`), class-level `[ServerOnly]`, the declarative surface's semantic and layout tails (a contract rule, not an exemption), and the consumer program — local-packages validation, byte-identical proofs, the first-contact friction ledger.
- `DESKTOP-PLAN.md`: nine draw commands in the gap table, W1's sector shipped in the sequencing, the bundle rules under W-B6.

The wiki's Roadmap (EN + pt-BR) and the `SupportedFeatures` page get the same pass in the wiki repo.