### PR TITLE
🔧 chore: the four high advisories close with one override

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "equantic-ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "equantic-ui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.14.0",
@@ -1673,9 +1673,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -147,5 +147,8 @@
     "preview",
     "visual editor"
   ],
-  "icon": "icon.png"
+  "icon": "icon.png",
+  "overrides": {
+    "fast-uri": "^3.1.6"
+  }
 }


### PR DESCRIPTION
## What

Dependabot's four HIGH advisories on `main` are all the same transitive package — `fast-uri` 3.1.5 (host confusion via percent-encoded scheme normalization, plus three SSRF paths), fixed in 3.1.6. An npm `overrides` entry raises it; it resolves to 3.1.7.

## Exposure, stated plainly

It reaches the tree **only** through the VS Code extension's build tooling: development scope, one manifest (`extensions/vscode/package-lock.json`), and **zero occurrences** in the `runtime.js` the SDK serves. Nothing shipped was exposed. That is a reason to be calm about it, not a reason to leave four high alerts standing on the default branch.

## Why an override and not an install

`npm install fast-uri` writes it into `dependencies`, which would claim the extension imports a package it never mentions — I did that first and backed it out. The override states what is actually true: this is somebody else's dependency, and it must be at least 3.1.6.

## Verification

`npm audit --audit-level=high` is clean, and the extension type-checks against a fresh `npm ci`.

One advisory remains, **moderate** (`qs`, also development scope). `npm audit fix` wants a major bump of its parent — a different change with a different risk, and not something to smuggle into a security patch.