### PR TITLE
📝 docs: the vocabulary's doc links point at members that exist

### DIFF
--- a/src/eQuantic.UI.Primitives/Nodes/VisualNode.cs
+++ b/src/eQuantic.UI.Primitives/Nodes/VisualNode.cs
@@ -564,7 +564,7 @@ public sealed class Overlay : VisualNode
     // ANCESTOR that creates a stacking context (a Stack cell's paint-order z-index, a transform, a
     // filter) traps it — the layer then stacks inside that ancestor instead of over the page. Keep
     // Overlays out of such subtrees (a Column is layout-neutral and safe) until they portal to the
-    // document root. Native has no such rule: overlay layers queue against the viewport.</summary>
+    // document root. Native has no such rule: overlay layers queue against the viewport.
 }
 
 /// <summary>Where an <see cref="Anchored"/> panel attaches relative to its anchor (wave 3 v1: the
@@ -581,20 +581,6 @@ public enum AnchorPlacement : byte
     TopCenter = 5,
 }
 
-/// <summary>
-/// The ANCHORED overlay (wave 3): a floating <see cref="Panel"/> positioned relative to the
-/// in-flow <see cref="Anchor"/> — the primitive under menus, selects and popovers. The anchor owns
-/// layout (the node is layout-transparent); the panel exists only while <see cref="Open"/> and
-/// paints ABOVE the page. When <see cref="OnDismiss"/> is set, an invisible viewport scrim behind
-/// the panel consumes the outside tap and fires it (tap-outside-closes). Web realizes as a
-/// position:relative host with an absolute panel — pure CSS, no JS positioning, SSR-exact; native
-/// queues a synthetic overlay layer with the panel <c>Positioned</c> from the anchor's absolute
-/// bounds. A dismissible OPEN panel declares Escape through the shortcut pipeline (close = the
-/// same <see cref="OnDismiss"/> the scrim fires), and a hover-revealed one is Esc-SUPPRESSED by
-/// the runtime controller (WCAG 1.4.13). v1 fences: viewport flip/clamp (a panel near the edge
-/// does not reposition), escape from clipping ancestors on web (keep anchors out of
-/// overflow-hidden scrollers).
-/// </summary>
 /// <summary>What an <see cref="Anchored"/> panel IS to assistive tech. Grows with the composites
 /// that need it, never speculatively — the same rule <see cref="PressableRole"/> follows.</summary>
 public enum AnchorPanelRole : byte
@@ -618,6 +604,20 @@ public enum AnchorPanelRole : byte
     Dialog = 3,
 }
 
+/// <summary>
+/// The ANCHORED overlay (wave 3): a floating <see cref="Panel"/> positioned relative to the
+/// in-flow <see cref="Anchor"/> — the primitive under menus, selects and popovers. The anchor owns
+/// layout (the node is layout-transparent); the panel exists only while <see cref="Open"/> and
+/// paints ABOVE the page. When <see cref="OnDismiss"/> is set, an invisible viewport scrim behind
+/// the panel consumes the outside tap and fires it (tap-outside-closes). Web realizes as a
+/// position:relative host with an absolute panel — pure CSS, no JS positioning, SSR-exact; native
+/// queues a synthetic overlay layer with the panel <c>Positioned</c> from the anchor's absolute
+/// bounds. A dismissible OPEN panel declares Escape through the shortcut pipeline (close = the
+/// same <see cref="OnDismiss"/> the scrim fires), and a hover-revealed one is Esc-SUPPRESSED by
+/// the runtime controller (WCAG 1.4.13). v1 fences: viewport flip/clamp (a panel near the edge
+/// does not reposition), escape from clipping ancestors on web (keep anchors out of
+/// overflow-hidden scrollers).
+/// </summary>
 public sealed class Anchored : VisualNode
 {
     public override string NodeKind => "anchored";
@@ -872,7 +872,7 @@ public sealed class DragDismiss : VisualNode
 }
 
 /// <summary>
-/// NAVIGATION semantics in the vocabulary: the child becomes a link to <see cref="Href"/>. The child
+/// NAVIGATION semantics in the vocabulary: the child becomes a link to <see cref="Destination"/>. The child
 /// owns ALL visuals (like Pressable) — Link adds only the semantics and the interaction. Web lowers
 /// to a real <c>&lt;a destination&gt;</c> (SSR-crawlable; the SPA router intercepts internal clicks, so
 /// guards/prefetch apply); native registers a link region and resolves a tap through the HOST's
@@ -1379,7 +1379,7 @@ public sealed record TextRun(string Content, ColorToken? Color = null, bool Mono
     /// <para>
     /// A link is a TARGET-NEUTRAL idea — a run of text that goes somewhere when you touch it, which
     /// every platform has. What is missing is realization, not meaning: the native realizer reads
-    /// neither this, nor <see cref="Text.Spans"/>, nor even <see cref="Link.Href"/>, so a paragraph
+    /// neither this, nor <see cref="Text.Spans"/>, nor even <see cref="Link.Destination"/>, so a paragraph
     /// with links draws on Photon as its text, unlinked. Closing that needs per-run hit testing (the
     /// engine has to know each run's rect) and a navigation action a shell can answer.
     /// </para>
@@ -1391,11 +1391,12 @@ public sealed record TextRun(string Content, ColorToken? Color = null, bool Mono
     /// </para>
     /// <para>
     /// The NAME is not universal, and it is worth being exact about that. Apple says <c>link</c>,
-    /// Android says <c>URLSpan</c>, and <c>destination</c> is HTML's word. It is used here for internal
-    /// consistency with <see cref="Link.Href"/>, which shipped first — one concept with two names
-    /// inside one vocabulary would be worse than one borrowed name. That is a consistency argument,
-    /// not a neutrality one; the abstract layer otherwise avoids a target's vocabulary on purpose
-    /// (<see cref="Pressable"/>, not "Button" or "Clickable").
+    /// Android says <c>URLSpan</c>, and <c>href</c> is HTML's word. <c>Destination</c> is none of
+    /// theirs, and it is used here for internal consistency with <see cref="Link.Destination"/>,
+    /// which shipped first — one concept with two names inside one vocabulary would be worse than
+    /// one word shared with the node that wraps it. The abstract layer avoids a target's vocabulary
+    /// on purpose (<see cref="Pressable"/>, not "Button" or "Clickable"), and this name is the rule,
+    /// not an exception to it.
     /// </para>
     /// </summary>
     public string? Destination { get; init; }

--- a/src/eQuantic.UI.Primitives/Nodes/VisualNode.cs
+++ b/src/eQuantic.UI.Primitives/Nodes/VisualNode.cs
@@ -874,7 +874,7 @@ public sealed class DragDismiss : VisualNode
 /// <summary>
 /// NAVIGATION semantics in the vocabulary: the child becomes a link to <see cref="Destination"/>. The child
 /// owns ALL visuals (like Pressable) — Link adds only the semantics and the interaction. Web lowers
-/// to a real <c>&lt;a destination&gt;</c> (SSR-crawlable; the SPA router intercepts internal clicks, so
+/// to a real <c>&lt;a href&gt;</c> (SSR-crawlable; the SPA router intercepts internal clicks, so
 /// guards/prefetch apply); native registers a link region and resolves a tap through the HOST's
 /// navigation seam (<c>PhotonHost.NavigationRequested</c> — the platform shell maps hrefs to pages).
 /// Pressables INSIDE a link win the tap (topmost dispatch), exactly like a button inside an anchor.

--- a/src/eQuantic.UI.Web/WebRealizer.cs
+++ b/src/eQuantic.UI.Web/WebRealizer.cs
@@ -2236,7 +2236,7 @@ public static class WebRealizer
     }
 
     /// <summary>
-    /// Navigation semantics: a REAL <c>&lt;a destination&gt;</c> (SSR-crawlable, router-intercepted) whose
+    /// Navigation semantics: a REAL <c>&lt;a href&gt;</c> (SSR-crawlable, router-intercepted) whose
     /// UA chrome is neutralized — the child owns all visuals, exactly the Pressable contract. A Fill
     /// child gets the 100% pass-through chain the same way.
     /// </summary>


### PR DESCRIPTION
## What

Every unresolved `cref` in `src/eQuantic.UI.Primitives/Nodes/VisualNode.cs` — 8 sites, which MSBuild reports twice each, so the 16 `CS1574` lines you see in a build log. Comments only: no code, no public surface, no behaviour.

## Two causes, neither a typo

**`Anchored`'s class doc was orphaned.** `d4e37e64` inserted the `AnchorPanelRole` enum, with its own summary, *between* the `Anchored` doc block and the class it describes. Roslyn then bound `Panel`, `Anchor`, `Open` and `OnDismiss` against the **enum**, which has none of them — so five crefs went nowhere, `Anchored` shipped undocumented, and `AnchorPanelRole` carried two `<summary>` elements (the second silently wins). The fix moves the block back on top of `public sealed class Anchored`; not one word of it changed, and every cref now resolves against `Anchored`'s own properties.

**`Link.Href` no longer exists.** `119dd0c8` renamed it to `Destination` — the abstract layer speaks no target's language — and updated the code but not the three doc links. They now read `Link.Destination`, which is what they should point at.

That same rename also rewrote the word inside the paragraph that *explains* the name, which is how `TextRun.Destination` ended up claiming `destination` is HTML's word (it is `href`) and that the name is one borrowed from a target — the opposite of what the rename established. The cref there could not be fixed without fixing the sentence around it, so the paragraph now says the true thing: `Destination` is nobody's target vocabulary, it matches `Link.Destination` because that shipped first, and the neutrality is the rule rather than an exception to it.

Also drops a stray `</summary>` left behind in the `Overlay` web-fence comment when it was demoted from a doc comment to a plain `//` one. Harmless to the compiler, confusing to a reader.

## Verification

- `dotnet build src/eQuantic.UI.Primitives -t:Rebuild -v n` → **zero CS1574**, on a forced full recompile rather than an incremental one.
- The doc analysis is demonstrably still running rather than silently off: the project's pre-existing `CS1573` (missing `param` tags, in `Nodes/Icon.cs` and `Theme/Typography.cs`) and `CS1734` (`paramref` with no such parameter, in `Nodes/Icon.cs`, `Sheet/SheetDocument.cs` and `Vector/VectorPath.cs`) are untouched here and still reported.
- `dotnet build` on the solution → 0 errors.
- The generated `obj/Debug/net10.0/eQuantic.UI.Primitives.xml` parses, and `Anchored`, `AnchorPanelRole`, `Link` and `TextRun.Destination` each carry exactly one `<summary>` with every `cref` bound to a real member (`P:…Anchored.Panel`, `P:…Link.Destination`, …).

No cref named anything that has gone missing without a successor, so nothing here is left pointing at a guess.
