### PR TITLE
✅ test: the calendar's dates are chosen relative to today, not written down

### DIFF
--- a/tests/eQuantic.UI.Web.Tests/CalendarTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/CalendarTests.cs
@@ -17,6 +17,22 @@ namespace eQuantic.UI.Web.Tests;
 public class CalendarTests
 {
     private static readonly IAppTheme Theme = PhotonTheme.Instance;
+    /// <summary>
+    /// A day that is deliberately NOT today, on any day this ever runs.
+    /// <para>
+    /// The dates here used to be literals, and one of them (2026-09-03) became today — the cell's
+    /// accessible name gains ", today" on exactly that date, and a test asserting the plain name
+    /// went red for one day. A calendar reads <c>DateTime.Now</c> and no test can pin it, so the
+    /// dates a test asserts on must be chosen RELATIVE to today rather than written down.
+    /// </para>
+    /// </summary>
+    /// <summary>The culture <see cref="Render"/> pins, so an expectation built here reads the same
+    /// day and month names the tree does.</summary>
+    private static readonly CultureInfo Culture = new("en-US");
+
+    private static DateOnly NotToday(int daysFromNow) =>
+        DateOnly.FromDateTime(DateTime.Now).AddDays(daysFromNow == 0 ? 1 : daysFromNow);
+
     private static readonly DateOnly July17 = new(2026, 7, 17);
 
     private static IEnumerable<HtmlNode> Walk(HtmlNode node)
@@ -183,13 +199,18 @@ public class CalendarTests
         var mounted = new Calendar(July17);
         Render(mounted);
 
-        mounted.AdoptConfig(new Calendar(new DateOnly(2026, 9, 3)));
+        // Far enough ahead that it is never today, and never the same MONTH as today either —
+        // the assertion below names the month the view moved to.
+        var moved = NotToday(90);
+        mounted.AdoptConfig(new Calendar(moved));
         var after = Render(mounted);
 
+        var month = moved.ToDateTime(TimeOnly.MinValue).ToString("MMMM yyyy", Culture);
         Walk(after).Single(n => n.Attributes.GetValueOrDefault("role") == "grid")
-            .Attributes["aria-label"].Should().Be("September 2026");
+            .Attributes["aria-label"].Should().Be(month);
         Cells(after).Single(c => c.Attributes["aria-selected"] == "true")
-            .Attributes["aria-label"].Should().Be("Thursday, 3 September 2026");
+            .Attributes["aria-label"].Should().Be(
+                moved.ToDateTime(TimeOnly.MinValue).ToString("dddd, d MMMM yyyy", Culture));
     }
 
     [Fact]

--- a/tests/eQuantic.UI.Web.Tests/CalendarTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/CalendarTests.cs
@@ -17,19 +17,17 @@ namespace eQuantic.UI.Web.Tests;
 public class CalendarTests
 {
     private static readonly IAppTheme Theme = PhotonTheme.Instance;
-    /// <summary>
-    /// A day that is deliberately NOT today, on any day this ever runs.
-    /// <para>
-    /// The dates here used to be literals, and one of them (2026-09-03) became today — the cell's
-    /// accessible name gains ", today" on exactly that date, and a test asserting the plain name
-    /// went red for one day. A calendar reads <c>DateTime.Now</c> and no test can pin it, so the
-    /// dates a test asserts on must be chosen RELATIVE to today rather than written down.
-    /// </para>
-    /// </summary>
     /// <summary>The culture <see cref="Render"/> pins, so an expectation built here reads the same
     /// day and month names the tree does.</summary>
     private static readonly CultureInfo Culture = new("en-US");
 
+    /// <summary>A day that is deliberately NOT today, on any day this ever runs.</summary>
+    /// <remarks>
+    /// The dates here used to be literals, and one of them (2026-09-03) became today — the cell's
+    /// accessible name gains ", today" on exactly that date, and a test asserting the plain name
+    /// went red for one day. A calendar reads <c>DateTime.Now</c> and no test can pin it, so the
+    /// dates a test asserts on must be chosen RELATIVE to today rather than written down.
+    /// </remarks>
     private static DateOnly NotToday(int daysFromNow) =>
         DateOnly.FromDateTime(DateTime.Now).AddDays(daysFromNow == 0 ? 1 : daysFromNow);
 


### PR DESCRIPTION
## What

`CalendarTests.WhenTheAppMovesTheSelection_TheViewFollowsIt` is red on `main` **today, and only today**.

A calendar cell's accessible name gains `", today"` on the day it names. The test asserted the plain name for `2026-09-03` — which is today's date. The component reads `DateTime.Now` and no test can pin it, so a literal date in an assertion is a bomb with a fuse measured in months.

## Fix

The test picks its date 90 days out and builds its expectation from that date, under the same culture the renderer is pinned to — so it asserts the same thing on every day it ever runs. The helper carries the reason, because the next person writing a date here will not know it otherwise.

Checked the neighbours: the other literals in these files assert month labels (`"July 2026"`) and formatted values (`"7/17/2026"`), neither of which gains the suffix. They stay.

## The gap underneath, not fixed here

`Calendar.Today()` is `DateOnly.FromDateTime(DateTime.Now)` — the component asks the machine directly, so "what day is it" cannot be injected. That is why this class of test has to work around the clock instead of setting it. Worth a seam eventually; it is a wider change than a red build deserves today.