### PR TITLE
🔧 chore: 0.2.0-preview.46

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.45</Version>
+        <Version>0.2.0-preview.46</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
One line in `Directory.Build.props`. The tag on the squash commit is what publishes.

## What this release carries

**Track W, the two workstreams it was waiting on:**

- **W2** — a real cubic-bezier solver (a smoothstep had stood in for every named curve on Photon, so one authored `Motion.Press` moved two different ways), `TransitionStore` honouring each track's own duration, delay and curve, `BoxStyle.Transition` honoured natively at last — colours, opacity, transform, the elevation shadow, and fixed sizes in layout — and `IFrameTicker` for what a style cannot express.
- **W3** — the `Canvas` node: a component draws its own pixels inside the box the layout gives it, and pointer events arrive in the canvas's **own** coordinates, so polar hit-testing is the app's arithmetic. On both targets, because the painter's vocabulary is the engine's.

**Around them:**

- **`IUiDispatcher`** — `SetState` from a worker thread stops racing the thread that draws.
- **`Bookmark`** — an in-page link has something to arrive at, with the room under a sticky header **measured** rather than declared.
- **Entitlements in C#** and a signature that can ship — plus the two the .NET runtime itself needs, added by the SDK because a developer should not have to learn that .NET on macOS has a library-validation problem.
- Icons from any pack in `EmptyState`/`IconButton`; tails for `Switch`, `Checkbox`, `SegmentedControl`.
- `[ServerOnly]` on a class; the solution mirrors the pack roster (**`eQuantic.UI.Email` publishes again** — it was missing from .45); the four high advisories closed; the calendar's time-bomb test defused.

## After the merge

Tag `v0.2.0-preview.46` on the squash commit, watch `ci.yml`, and verify every package indexes on nuget.org — `eQuantic.UI.Email` especially, since the roster fix is what makes it appear.