### PR TITLE
✨ feat: a Photon app you can actually ship — the bundle comes from `dotnet publish`

### DIFF
--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -108,16 +108,36 @@ The largest slice, all of it generic:
   launch-at-login (`SMAppService`), global shortcuts
 - Dynamic DPI on monitor change — `backingScaleFactor` is read once today (`PhotonWindow.cs:122`)
 
-### W5 — Sdk.Native: real packaging (4–6 w; SEQUENCE FIRST)
+### W5 — Sdk.Native: real packaging (4–6 w; SEQUENCE FIRST) — DELIVERED but for one proof
 
 MSBuild properties for a real signing identity, entitlements, hardened runtime and notarization
-(`notarytool` + stapler); arbitrary `Info.plist` keys (the set is fixed today); bundling from
-PUBLISH output (trimming/self-contained never reach the .app today); DMG generation; a minimal
-`IAppUpdater` (manifest endpoint → download → verify → swap → relaunch).
+(`notarytool` + stapler); arbitrary `Info.plist` keys; bundling from PUBLISH output; DMG generation;
+a minimal `IAppUpdater` (manifest endpoint → download → verify → swap → relaunch).
 
 Sequenced FIRST among the independents deliberately: signing identity unblocks three things at
 once — TCC grants that survive builds, notifications (which require a signed bundle), and any
 auto-update story. W4's notification work lands on it.
+
+**State.** Signing identity and entitlements shipped in 0.2.0-preview.46. The rest landed together:
+the bundle is assembled from the PUBLISH output (it was assembled from the build output, so trimming
+and self-contained never reached the `.app` — measured 172 MB against a 23 MB publish), the plist is
+declared in C# (`builder.Bundle.Copyright(…).Category(…).Agent().UrlScheme(…)`), notarization runs
+`ditto` → `notarytool submit --wait` → `stapler staple`, and `EQuanticPackageFormat=Dmg` writes a
+signed image. Trimming had to be made to WORK for any of it to mean anything: four defects, all of
+them the trimmer reading the same evidence the design relies on and concluding the opposite.
+
+**Owed.** Two things, and neither is more code:
+
+- **A notarized bundle has never been produced.** The steps run in order and fail loudly on a
+  credential that does not exist, but nobody on this machine holds a Developer ID. This is the one
+  line of the acceptance below still open, and it needs a certificate.
+- **`IAppUpdater` is not started.** It is the last piece of W5 and the natural next slice, and the
+  acceptance ("installed and relaunched by the minimal updater") depends on it.
+
+**Handed to W4.** `builder.Bundle.UrlScheme("acme")` now declares the scheme, so macOS launches the
+app for `acme://…` — and nothing delivers the URL, because `kAEGetURL` handling is W4's and the
+macOS shell has none. The plist half shipped first deliberately (a handler for a scheme no app can
+declare would be the wrong order), and the delivery seam is the first thing W4 should take.
 
 ### W7 — The developer loop: run, debug, hot reload (2–3 w)
 

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -104,7 +104,7 @@ than pick for you, eqc asks.
 | `EQ3002` | A Photon app has more than one program. |
 | `EQ3003` | A capability's reason must be a constant. |
 | `EQ3004` | An entitlement's key must be a constant — it is signed into the app at build time, so a key built at run time never reaches the signature. |
-| `EQ3005` | A bundle key's value must be a constant — the Info.plist is written at build time, so a value built at run time never reaches the app's manifest. Applies to whatever the method takes: a string, a bool, an `AppCategory`. |
+| `EQ3005` | A bundle fact must be constant — the Info.plist is written at build time, so an argument built at run time never reaches the app's manifest. Either argument counts, and whatever the method takes: a string, a bool, an `AppCategory`. |
 
 ## EQ3101–EQ3105 — the source generators
 

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -96,7 +96,7 @@ than pick for you, eqc asks.
 | `EQ2111` | `GetService` with no type argument to cross — the registry is keyed by the interface NAME, and there is nothing to key on. | Call the generic overload. |
 | `EQ2113` | `ConfigureAwait` is dropped — there is one context to resume on — and dropping it would discard a NON-CONSTANT argument without evaluating it. | Pass a constant, or evaluate the expression into a local first. |
 
-## EQ3001–EQ3004 — the Photon app generator
+## EQ3001–EQ3005 — the Photon app generator
 
 | Code | Meaning |
 |---|---|
@@ -104,6 +104,7 @@ than pick for you, eqc asks.
 | `EQ3002` | A Photon app has more than one program. |
 | `EQ3003` | A capability's reason must be a constant. |
 | `EQ3004` | An entitlement's key must be a constant — it is signed into the app at build time, so a key built at run time never reaches the signature. |
+| `EQ3005` | A bundle key's value must be a constant — the Info.plist is written at build time, so a value built at run time never reaches the app's manifest. |
 
 ## EQ3101–EQ3105 — the source generators
 

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -104,7 +104,7 @@ than pick for you, eqc asks.
 | `EQ3002` | A Photon app has more than one program. |
 | `EQ3003` | A capability's reason must be a constant. |
 | `EQ3004` | An entitlement's key must be a constant — it is signed into the app at build time, so a key built at run time never reaches the signature. |
-| `EQ3005` | A bundle key's value must be a constant — the Info.plist is written at build time, so a value built at run time never reaches the app's manifest. |
+| `EQ3005` | A bundle key's value must be a constant — the Info.plist is written at build time, so a value built at run time never reaches the app's manifest. Applies to whatever the method takes: a string, a bool, an `AppCategory`. |
 
 ## EQ3101–EQ3105 — the source generators
 

--- a/samples/PhotonDesktop/PhotonDesktop.csproj
+++ b/samples/PhotonDesktop/PhotonDesktop.csproj
@@ -6,6 +6,13 @@
         <TargetFramework>net10.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <ApplicationTitle>eQuantic Studio</ApplicationTitle>
+
+        <!-- Published TRIMMED, deliberately: this sample is the repository's proving ground, and a
+             shipped app is a published one. Trimming is where the framework's reflection seams show
+             (a shell nothing references in code, a root component the container builds, options
+             bound from configuration), and each of those was a real app that opened a window and
+             then did nothing. Measured here: 86 MB → 23 MB, same 110 accessibility elements. -->
+        <PublishTrimmed>true</PublishTrimmed>
     </PropertyGroup>
 
     <Import Project="../../src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets" />

--- a/samples/PhotonDesktop/Program.cs
+++ b/samples/PhotonDesktop/Program.cs
@@ -18,6 +18,14 @@ public partial class Program
         builder.Capabilities.UseLocation("Shows where this Mac is — the capability demo.");
         builder.Capabilities.UseCamera("Shows a live preview in the Device section.");
 
+        // And what the SYSTEM reads about the app before it runs — the Get Info panel, the Finder
+        // category, the URLs it answers to. The same journey again: a call here, an assembly
+        // declaration from the generator, the Info.plist from the build. No plist anywhere.
+        builder.Bundle
+               .Copyright("© 2026 eQuantic")
+               .Category(AppCategory.DeveloperTools)
+               .UrlScheme("equantic-studio");
+
         builder.Configure(photon =>
         {
             photon.Theme = PhotonTheme.Instance;

--- a/src/Shared/BundleFactRule.cs
+++ b/src/Shared/BundleFactRule.cs
@@ -1,0 +1,37 @@
+namespace eQuantic.UI;
+
+/// <summary>
+/// What a bundle fact's KEY and its URL SCHEME look like once accepted.
+///
+/// <para>
+/// Two places have to agree, and they live in assemblies that cannot reference each other: the
+/// builder an app calls (<c>PhotonBundleBuilder</c>, net10.0) and the generator that reads that
+/// call (netstandard2.0, because that is what Roslyn loads analyzers as). They agreed by both
+/// calling <c>Trim()</c> — right up until one of them did and the other did not.
+/// </para>
+/// <para>
+/// The drift is invisible in C#: <c>builder.Bundle.Key(" LSUIElement ", …)</c> compiles, the
+/// builder's own copy holds the trimmed key, and the GENERATED attribute — which is the one the
+/// build actually reads — holds the untrimmed one. What ships is a plist key macOS does not
+/// recognise, in an app whose source looks correct. Three separate review comments on one pull
+/// request were this same drift at three call sites, which is the shape of a rule that should not
+/// be written more than once.
+/// </para>
+/// </summary>
+internal static class BundleFactRule
+{
+    /// <summary>
+    /// The key as it should be stored, or null when there is nothing to store. Whitespace around an
+    /// Apple key is never meaningful, and an empty key names nothing — both are dropped rather than
+    /// reported, because a value that CAN be evaluated is not the problem EQ3005 describes.
+    /// </summary>
+    internal static string? Key(string? key) =>
+        key?.Trim() is { Length: > 0 } trimmed ? trimmed : null;
+
+    /// <summary>
+    /// A URL scheme as it should be stored, or null when there is nothing to store. Same rule as a
+    /// key, and for one more reason: two spellings of one scheme defeat the de-duplication that
+    /// collects them into a single <c>CFBundleURLTypes</c> array.
+    /// </summary>
+    internal static string? Scheme(string? scheme) => Key(scheme);
+}

--- a/src/eQuantic.UI.Codegen/PropertyListWriter.cs
+++ b/src/eQuantic.UI.Codegen/PropertyListWriter.cs
@@ -56,6 +56,17 @@ public sealed class PropertyListWriter : CodeWriter
         return this;
     }
 
+    /// <summary>An array of dictionaries — the shape Apple uses for the lists that have more than
+    /// one thing to say about each entry (CFBundleURLTypes, CFBundleDocumentTypes).</summary>
+    public PropertyListWriter DictionaryArray(string key, params Action<PropertyListWriter>[] entries)
+    {
+        Key(key);
+        using (BeginScope("<array>", "</array>"))
+            foreach (var entry in entries)
+                using (BeginScope("<dict>", "</dict>")) entry(this);
+        return this;
+    }
+
     public PropertyListWriter StringArray(string key, params string[] values)
     {
         Key(key);

--- a/src/eQuantic.UI.Native.Build/BundleManifest.cs
+++ b/src/eQuantic.UI.Native.Build/BundleManifest.cs
@@ -1,0 +1,85 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace eQuantic.UI.Build;
+
+/// <summary>
+/// What the app declared about its own BUNDLE, read straight off the compiled assembly — the third
+/// of the three platform-fact families, beside <see cref="CapabilityManifest"/> (what it asks of a
+/// person) and <see cref="EntitlementsManifest"/> (what it asks of the system).
+/// <para>
+/// These are the answers macOS reads before the app runs: the copyright line in Get Info, the
+/// category Finder groups by, the oldest system it will start on, whether it takes a Dock tile,
+/// the URLs it answers to. Every one of them used to be unsayable — the Info.plist the SDK writes
+/// had a fixed set of keys — so an app that needed any of them had no path at all short of
+/// post-processing the bundle.
+/// </para>
+/// </summary>
+public static class BundleManifest
+{
+    private const string AttributeName = "PhotonBundleKeyAttribute";
+
+    /// <summary>How a value is written. Mirrors <c>PhotonBundleValueKind</c>, which lives in
+    /// Primitives and is not referenced here: this tool reads METADATA, and loading the app's
+    /// framework to name an enum member would mean loading the app.</summary>
+    public enum ValueKind
+    {
+        /// <summary>A plain string.</summary>
+        Text = 0,
+
+        /// <summary>A real boolean.</summary>
+        Flag = 1,
+
+        /// <summary>A URL scheme, collected into CFBundleURLTypes rather than written under a key.</summary>
+        UrlScheme = 2,
+    }
+
+    /// <summary>One declared fact.</summary>
+    public readonly record struct Fact(string Key, string Value, ValueKind Kind);
+
+    /// <summary>
+    /// The facts, in a stable order. Later declarations of the same key win, which is what the
+    /// builder's own dictionary does — the generator writes them in key order, so "later" only
+    /// arises when an app hand-writes the attribute.
+    /// </summary>
+    public static IReadOnlyList<Fact> Read(string assemblyPath)
+    {
+        if (!File.Exists(assemblyPath)) return [];
+
+        using var stream = File.OpenRead(assemblyPath);
+        using var reader = new PEReader(stream);
+        var metadata = reader.GetMetadataReader();
+
+        var keyed = new Dictionary<string, Fact>(StringComparer.Ordinal);
+        var schemes = new List<string>();
+
+        foreach (var handle in metadata.GetAssemblyDefinition().GetCustomAttributes())
+        {
+            var attribute = metadata.GetCustomAttribute(handle);
+            if (CapabilityManifest.NameOf(metadata, attribute) != AttributeName) continue;
+
+            // Two strings and an enum, in that order — decoded by hand for the same reason the
+            // other two manifests do it: a typed decoder would need the attribute's assembly
+            // loaded, and this tool must never load the app it is packaging.
+            var blob = metadata.GetBlobReader(attribute.Value);
+            if (blob.ReadUInt16() != 1) continue;                       // prolog
+            var key = blob.ReadSerializedString();
+            var value = blob.ReadSerializedString();
+            if (blob.RemainingBytes < sizeof(int)) continue;
+            var kind = (ValueKind)blob.ReadInt32();                     // the enum's underlying type
+
+            if (value is null) continue;
+            if (kind == ValueKind.UrlScheme)
+            {
+                if (!schemes.Contains(value, StringComparer.Ordinal)) schemes.Add(value);
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(key)) keyed[key!] = new Fact(key!, value, kind);
+        }
+
+        var facts = keyed.Values.OrderBy(fact => fact.Key, StringComparer.Ordinal).ToList();
+        facts.AddRange(schemes.Select(scheme => new Fact("", scheme, ValueKind.UrlScheme)));
+        return facts;
+    }
+}

--- a/src/eQuantic.UI.Native.Build/MacAppBundle.cs
+++ b/src/eQuantic.UI.Native.Build/MacAppBundle.cs
@@ -18,6 +18,21 @@ public static class MacAppBundle
     public static void Write(string bundlePath, string executable, string displayName,
         string identifier, string version, string? icnsSource, string? capabilitiesAssembly = null)
     {
+        // What the app SAID about itself, read off the same assembly the capabilities come from.
+        // Read before anything is written because a declared fact OVERRIDES the framework's
+        // default: an app that states LSMinimumSystemVersion 13.0 means it, and a default written
+        // first and overwritten later is a plist with the key twice.
+        var declared = capabilitiesAssembly is not null
+            ? BundleManifest.Read(capabilitiesAssembly)
+            : [];
+        var stated = declared
+            .Where(fact => fact.Kind != BundleManifest.ValueKind.UrlScheme)
+            .ToDictionary(fact => fact.Key, fact => fact, StringComparer.Ordinal);
+        var schemes = declared
+            .Where(fact => fact.Kind == BundleManifest.ValueKind.UrlScheme)
+            .Select(fact => fact.Value)
+            .ToList();
+
         var contents = Path.Combine(bundlePath, "Contents");
         var resources = Path.Combine(contents, "Resources");
         Directory.CreateDirectory(Path.Combine(contents, "MacOS"));
@@ -33,17 +48,41 @@ public static class MacAppBundle
                  .String("CFBundleIdentifier", identifier)
                  .String("CFBundleExecutable", executable)
                  .String("CFBundlePackageType", "APPL")
-                 .String("CFBundleShortVersionString", version)
-                 .String("CFBundleVersion", version)
+                 .String("CFBundleShortVersionString", AppleVersion(version))
+                 .String("CFBundleVersion", AppleVersion(version))
                  // The one that decides whether this is an APPLICATION: without it the process gets
                  // no Dock tile, no menu bar and no place in the app switcher, however many windows
                  // it opens.
-                 .Bool("LSUIElement", false)
-                 // 11.0 is where every API the Metal backend uses is present.
-                 .String("LSMinimumSystemVersion", "11.0")
+                 .Bool("LSUIElement", Flag("LSUIElement", @default: false))
+                 // 11.0 is where every API the Metal backend uses is present. An app that needs a
+                 // newer floor says so, and the system then refuses to LAUNCH it on anything older
+                 // instead of letting it crash inside an API that is not there.
+                 .String("LSMinimumSystemVersion", Text("LSMinimumSystemVersion", "11.0"))
                  .Bool("NSHighResolutionCapable", true)
                  .Bool("NSSupportsAutomaticGraphicsSwitching", true);
             if (icon is not null) plist.String("CFBundleIconFile", icon);
+
+            // The URLs this app answers to. One array with one type in it: a Photon app declares
+            // schemes, not document types, and CFBundleURLName is the bundle id by convention so
+            // two apps claiming the same scheme are at least distinguishable in the registry.
+            if (schemes.Count > 0)
+            {
+                plist.DictionaryArray("CFBundleURLTypes", entry => entry
+                    .String("CFBundleURLName", identifier)
+                    .StringArray("CFBundleURLSchemes", [.. schemes]));
+            }
+
+            // And everything else the app stated, in key order. The framework's own keys above are
+            // already resolved against these, so what lands here is what the SDK had no opinion
+            // about — a copyright line, a category, whatever Apple adds next.
+            foreach (var fact in stated.Values.OrderBy(fact => fact.Key, StringComparer.Ordinal))
+            {
+                if (Owned.Contains(fact.Key)) continue;
+                if (fact.Kind == BundleManifest.ValueKind.Flag)
+                    plist.Bool(fact.Key, fact.Value == "true");
+                else
+                    plist.String(fact.Key, fact.Value);
+            }
 
             // What the app DECLARED, straight off its compiled assembly — the same attributes the
             // iOS partial plist is written from. The Mac spelling of the location key differs from
@@ -61,6 +100,56 @@ public static class MacAppBundle
 
         // The Finder reads this to know the directory IS a bundle even before the plist is parsed.
         File.WriteAllText(Path.Combine(contents, "PkgInfo"), "APPL????");
+        return;
+
+        string Text(string key, string @default) =>
+            stated.TryGetValue(key, out var fact) ? fact.Value : @default;
+
+        bool Flag(string key, bool @default) =>
+            stated.TryGetValue(key, out var fact) ? fact.Value == "true" : @default;
+    }
+
+    /// <summary>
+    /// The keys the framework writes itself, above. A declared value for one of these is honoured
+    /// where it is written and must not be written AGAIN at the end — a plist with a key twice is
+    /// not an error anywhere, it simply means whichever the parser reaches last, which is how a
+    /// declaration silently loses to a default.
+    /// </summary>
+    private static readonly HashSet<string> Owned = new(StringComparer.Ordinal)
+    {
+        "LSUIElement", "LSMinimumSystemVersion",
+    };
+
+    /// <summary>
+    /// The version, in the only shape Apple accepts: one to three integers separated by dots.
+    /// <para>
+    /// A .NET version is routinely not that. This repository's own is <c>0.2.0-preview.46</c>, and
+    /// it went into the plist verbatim — which is a bundle the App Store rejects and notarization
+    /// refuses, reported in a vocabulary ("CFBundleShortVersionString must be a period-separated
+    /// list of at most three non-negative integers") that names nothing you wrote. The prerelease
+    /// tag is dropped rather than mangled, and the build says so once, because a version that
+    /// silently becomes a different version is worse than either.
+    /// </para>
+    /// </summary>
+    public static string AppleVersion(string version)
+    {
+        var numeric = new List<string>();
+        foreach (var part in (version ?? "").Split('.'))
+        {
+            // The NUMERIC PREFIX of each component, and the version ends at the first component
+            // that has anything after it: "0.2.0-preview.46" is 0.2.0 and "1.0.0+sha.abc" is 1.0.0.
+            // Reading the component as all-or-nothing instead loses the third number entirely,
+            // which is how this method first answered "0.2" — caught by its own test.
+            var digits = 0;
+            while (digits < part.Length && char.IsAsciiDigit(part[digits])) digits++;
+            if (digits == 0) break;
+
+            var value = part[..digits].TrimStart('0');
+            numeric.Add(value.Length > 0 ? value : "0");
+            if (numeric.Count == 3 || digits < part.Length) break;
+        }
+
+        return numeric.Count > 0 ? string.Join('.', numeric) : "1.0.0";
     }
 
     private static IEnumerable<string> AppleKeys(string capability)

--- a/src/eQuantic.UI.Native.Build/MacAppBundle.cs
+++ b/src/eQuantic.UI.Native.Build/MacAppBundle.cs
@@ -33,6 +33,9 @@ public static class MacAppBundle
             .Select(fact => fact.Value)
             .ToList();
 
+        // Every key the framework writes, recorded as it is written — see Text/Flag below.
+        var written = new HashSet<string>(StringComparer.Ordinal);
+
         var contents = Path.Combine(bundlePath, "Contents");
         var resources = Path.Combine(contents, "Resources");
         Directory.CreateDirectory(Path.Combine(contents, "MacOS"));
@@ -43,13 +46,19 @@ public static class MacAppBundle
 
         File.WriteAllText(Path.Combine(contents, "Info.plist"), PropertyListWriter.Document(plist =>
         {
-            plist.String("CFBundleName", displayName)
-                 .String("CFBundleDisplayName", displayName)
-                 .String("CFBundleIdentifier", identifier)
-                 .String("CFBundleExecutable", executable)
-                 .String("CFBundlePackageType", "APPL")
-                 .String("CFBundleShortVersionString", AppleVersion(version))
-                 .String("CFBundleVersion", AppleVersion(version))
+            // Every key goes through Text/Flag, which means EVERY key the framework writes can be
+            // overridden by a declaration and NONE of them can be written twice. The first version
+            // of this consulted the declarations for two keys and kept a list of "the ones the
+            // framework owns" to skip at the end — a list that is wrong the moment a key is added
+            // above it, and whose failure is silent: a plist with a key twice is not an error
+            // anywhere, it just means whichever the parser reaches last.
+            plist.String("CFBundleName", Text("CFBundleName", displayName))
+                 .String("CFBundleDisplayName", Text("CFBundleDisplayName", displayName))
+                 .String("CFBundleIdentifier", Text("CFBundleIdentifier", identifier))
+                 .String("CFBundleExecutable", Text("CFBundleExecutable", executable))
+                 .String("CFBundlePackageType", Text("CFBundlePackageType", "APPL"))
+                 .String("CFBundleShortVersionString", Text("CFBundleShortVersionString", AppleVersion(version)))
+                 .String("CFBundleVersion", Text("CFBundleVersion", AppleVersion(version)))
                  // The one that decides whether this is an APPLICATION: without it the process gets
                  // no Dock tile, no menu bar and no place in the app switcher, however many windows
                  // it opens.
@@ -58,43 +67,47 @@ public static class MacAppBundle
                  // newer floor says so, and the system then refuses to LAUNCH it on anything older
                  // instead of letting it crash inside an API that is not there.
                  .String("LSMinimumSystemVersion", Text("LSMinimumSystemVersion", "11.0"))
-                 .Bool("NSHighResolutionCapable", true)
-                 .Bool("NSSupportsAutomaticGraphicsSwitching", true);
-            if (icon is not null) plist.String("CFBundleIconFile", icon);
+                 .Bool("NSHighResolutionCapable", Flag("NSHighResolutionCapable", @default: true))
+                 .Bool("NSSupportsAutomaticGraphicsSwitching",
+                     Flag("NSSupportsAutomaticGraphicsSwitching", @default: true));
+            if (icon is not null) plist.String("CFBundleIconFile", Text("CFBundleIconFile", icon));
 
             // The URLs this app answers to. One array with one type in it: a Photon app declares
             // schemes, not document types, and CFBundleURLName is the bundle id by convention so
             // two apps claiming the same scheme are at least distinguishable in the registry.
             if (schemes.Count > 0)
             {
+                written.Add("CFBundleURLTypes");
                 plist.DictionaryArray("CFBundleURLTypes", entry => entry
                     .String("CFBundleURLName", identifier)
                     .StringArray("CFBundleURLSchemes", [.. schemes]));
             }
 
-            // And everything else the app stated, in key order. The framework's own keys above are
-            // already resolved against these, so what lands here is what the SDK had no opinion
-            // about — a copyright line, a category, whatever Apple adds next.
-            foreach (var fact in stated.Values.OrderBy(fact => fact.Key, StringComparer.Ordinal))
-            {
-                if (Owned.Contains(fact.Key)) continue;
-                if (fact.Kind == BundleManifest.ValueKind.Flag)
-                    plist.Bool(fact.Key, fact.Value == "true");
-                else
-                    plist.String(fact.Key, fact.Value);
-            }
-
-            // What the app DECLARED, straight off its compiled assembly — the same attributes the
-            // iOS partial plist is written from. The Mac spelling of the location key differs from
-            // the phones' (Apple's names are historical, not derivable), so both are written: a
-            // key the platform does not read is inert, a missing one silently suppresses the
-            // system prompt.
+            // What the app DECLARED about the DEVICE, straight off its compiled assembly — the same
+            // attributes the iOS partial plist is written from. The Mac spelling of the location key
+            // differs from the phones' (Apple's names are historical, not derivable), so both are
+            // written: a key the platform does not read is inert, a missing one silently suppresses
+            // the system prompt.
             if (capabilitiesAssembly is not null && File.Exists(capabilitiesAssembly))
             {
                 foreach (var (capability, reason) in CapabilityManifest.Read(capabilitiesAssembly))
                 {
-                    foreach (var key in AppleKeys(capability)) plist.String(key, reason);
+                    foreach (var key in AppleKeys(capability))
+                    {
+                        if (written.Add(key)) plist.String(key, Text(key, reason));
+                    }
                 }
+            }
+
+            // And everything else the app stated, in key order: what the SDK had no opinion about —
+            // a copyright line, a category, whatever Apple adds next.
+            foreach (var fact in stated.Values.OrderBy(fact => fact.Key, StringComparer.Ordinal))
+            {
+                if (written.Contains(fact.Key)) continue;
+                if (fact.Kind == BundleManifest.ValueKind.Flag)
+                    plist.Bool(fact.Key, fact.Value == "true");
+                else
+                    plist.String(fact.Key, fact.Value);
             }
         }));
 
@@ -102,23 +115,21 @@ public static class MacAppBundle
         File.WriteAllText(Path.Combine(contents, "PkgInfo"), "APPL????");
         return;
 
-        string Text(string key, string @default) =>
-            stated.TryGetValue(key, out var fact) ? fact.Value : @default;
+        // A declared value WINS, and recording the key here is what stops it being written a second
+        // time at the end. Every key the framework writes goes through one of these two, so the
+        // record is complete by construction rather than by a list somebody has to remember.
+        string Text(string key, string @default)
+        {
+            written.Add(key);
+            return stated.TryGetValue(key, out var fact) ? fact.Value : @default;
+        }
 
-        bool Flag(string key, bool @default) =>
-            stated.TryGetValue(key, out var fact) ? fact.Value == "true" : @default;
+        bool Flag(string key, bool @default)
+        {
+            written.Add(key);
+            return stated.TryGetValue(key, out var fact) ? fact.Value == "true" : @default;
+        }
     }
-
-    /// <summary>
-    /// The keys the framework writes itself, above. A declared value for one of these is honoured
-    /// where it is written and must not be written AGAIN at the end — a plist with a key twice is
-    /// not an error anywhere, it simply means whichever the parser reaches last, which is how a
-    /// declaration silently loses to a default.
-    /// </summary>
-    private static readonly HashSet<string> Owned = new(StringComparer.Ordinal)
-    {
-        "LSUIElement", "LSMinimumSystemVersion",
-    };
 
     /// <summary>
     /// The version, in the only shape Apple accepts: one to three integers separated by dots.

--- a/src/eQuantic.UI.Native.Build/MacAppPayload.cs
+++ b/src/eQuantic.UI.Native.Build/MacAppPayload.cs
@@ -1,0 +1,118 @@
+namespace eQuantic.UI.Build;
+
+/// <summary>
+/// What goes inside <c>Contents/MacOS</c>, decided from a directory of build or publish output.
+/// <para>
+/// This used to be a glob in the SDK's targets, and a glob is where the rules that matter here
+/// cannot be tested: each of them was learned from a bundle that failed to sign or an app that
+/// failed to launch, and none of them is guessable from the file name alone.
+/// </para>
+/// <para>
+/// The reason the rules are strict rather than generous: <c>codesign</c> refuses to sign a bundle
+/// containing a file it cannot sign, and it refuses the WHOLE bundle, not the file. So one stray
+/// <c>.pdb</c>, or one static archive under a runtime pack for a platform this app will never run
+/// on, leaves the app unsigned — and an unsigned app is quietly refused by the very capabilities
+/// that check who is asking (LocalAuthentication simply never shows its sheet, and says nothing).
+/// </para>
+/// </summary>
+public static class MacAppPayload
+{
+    /// <summary>
+    /// The files to place under <c>Contents/MacOS</c>, as paths relative to <paramref name="payloadDir"/>.
+    /// <para>
+    /// <paramref name="excluded"/> is for what PACKAGING itself writes into the payload directory
+    /// — a file or a whole directory. Two of them, both found the same way, by packaging twice:
+    /// <list type="bullet">
+    /// <item>the publish directory lives under the build output, so a build-output bundle that does
+    /// not exclude it ships a second, entire copy of the app inside itself (86 MB of it, measured
+    /// on this repo's own desktop sample);</item>
+    /// <item>the disk image lands beside the app in the publish directory, so the NEXT publish
+    /// copies it into <c>Contents/MacOS</c> — and codesign then refuses the whole bundle, because a
+    /// .dmg is a subcomponent it cannot sign.</item>
+    /// </list>
+    /// The caller passes the paths because MSBuild knows them. Excluding by NAME instead would drop
+    /// an app's own data folder that happened to be called "publish", or a disk image it ships on
+    /// purpose.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<string> Select(string payloadDir, params string[] excluded)
+    {
+        var root = Path.GetFullPath(payloadDir);
+        // A file is excluded by being ITSELF; a directory by being a prefix of what is under it.
+        // Appending a separator to every entry (which is right for a directory) silently stopped
+        // matching the disk image, whose path names one file.
+        var skip = excluded
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(Path.GetFullPath)
+            .ToArray();
+
+        var selected = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            var full = Path.GetFullPath(file);
+            if (skip.Any(path => full == path
+                || full.StartsWith(EnsureTrailingSeparator(path), StringComparison.Ordinal))) continue;
+
+            var relative = Path.GetRelativePath(root, full);
+            if (Includes(relative)) selected.Add(relative);
+        }
+
+        // Sorted so a bundle is the same bundle whatever order the file system enumerated in —
+        // the copy is idempotent either way, but a stable list is one a test can pin.
+        selected.Sort(StringComparer.Ordinal);
+        return selected;
+    }
+
+    private static bool Includes(string relative)
+    {
+        var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        // A bundle inside the payload is the OUTPUT of a previous run, never its input.
+        if (segments.Any(segment => segment.EndsWith(".app", StringComparison.OrdinalIgnoreCase)))
+            return false;
+
+        // Debug symbols are not payload. They are also not merely wasteful: codesign cannot sign
+        // one, and refuses the bundle that holds it.
+        if (relative.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase)) return false;
+
+        // runtimes/ is an ALLOWLIST, not a denylist: only RIDs a macOS process can actually load
+        // belong in the bundle. The denylist this replaces named win/linux/android/ios and let
+        // `browser-wasm` through — Microsoft.Data.Sqlite ships a static archive (e_sqlite3.a) under
+        // it, which is not Mach-O, and codesign refused the entire bundle. The next RID the
+        // ecosystem invents is excluded here by construction instead of re-opening this.
+        if (segments is ["runtimes", var rid, ..])
+            return rid.StartsWith("osx", StringComparison.OrdinalIgnoreCase)
+                || rid.StartsWith("unix", StringComparison.OrdinalIgnoreCase);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Rebuilds <c>Contents/MacOS</c> from the payload — REBUILDS, not tops up.
+    /// <para>
+    /// A copy alone never removes anything, so a file the payload stopped including (a package
+    /// dropped, a RID newly excluded) stayed in the bundle forever and kept failing codesign long
+    /// after the exclusion was fixed. Removing the directory first is exactly the sentence "the
+    /// bundle is the payload".
+    /// </para>
+    /// </summary>
+    public static int Populate(string payloadDir, string bundleDir, params string[] excluded)
+    {
+        var files = Select(payloadDir, excluded);
+        var destination = Path.Combine(bundleDir, "Contents", "MacOS");
+        if (Directory.Exists(destination)) Directory.Delete(destination, recursive: true);
+        Directory.CreateDirectory(destination);
+
+        foreach (var relative in files)
+        {
+            var target = Path.Combine(destination, relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            File.Copy(Path.Combine(payloadDir, relative), target, overwrite: true);
+        }
+
+        return files.Count;
+    }
+
+    private static string EnsureTrailingSeparator(string path) =>
+        path.EndsWith(Path.DirectorySeparatorChar) ? path : path + Path.DirectorySeparatorChar;
+}

--- a/src/eQuantic.UI.Native.Build/Program.cs
+++ b/src/eQuantic.UI.Native.Build/Program.cs
@@ -123,17 +123,46 @@ if (args.Length > 0 && args[0] == "bundle")
     if (bundle is null || executable is null)
     {
         Console.Error.WriteLine("Usage: eqicon bundle --app <Name.app> --exec <executable> "
-            + "[--name <display>] [--id <bundle id>] [--version <x.y.z>] [--icns <file>]");
+            + "[--name <display>] [--id <bundle id>] [--version <x.y.z>] [--icns <file>] "
+            + "[--payload <dir> [--exclude <dir>]]");
         return 1;
     }
 
+    var declaredVersion = Arg("--version") ?? "1.0.0";
     MacAppBundle.Write(bundle, executable,
         Arg("--name") ?? executable,
         Arg("--id") ?? $"com.equantic.{executable.ToLowerInvariant()}",
-        Arg("--version") ?? "1.0.0",
+        declaredVersion,
         Arg("--icns"),
         Arg("--capabilities"));
-    Console.WriteLine($"eqicon: wrote {bundle}");
+
+    // Said once, where it is actionable: Apple's version is one to three integers, and a .NET
+    // prerelease version is not that. Trimming it silently would mean the app reports a version
+    // nobody chose; the alternative — passing it through — is a bundle notarization refuses.
+    if (MacAppBundle.AppleVersion(declaredVersion) is var apple && apple != declaredVersion)
+    {
+        Console.WriteLine($"eqicon: the bundle version is {apple} — Apple accepts one to three "
+            + $"integers, so the rest of \"{declaredVersion}\" cannot travel in the plist.");
+    }
+
+    // The payload — what the app needs to RUN — when the caller says where it is. Optional so the
+    // verb still writes a bundle SHELL for anything that fills it another way; the SDK always
+    // passes it, because deciding what belongs inside is the half that cannot live in a glob.
+    if (Arg("--payload") is { } payload)
+    {
+        var excluded = args
+            .Select((value, index) => (value, index))
+            .Where(entry => entry.value == "--exclude" && args.Length > entry.index + 1)
+            .Select(entry => args[entry.index + 1])
+            .ToArray();
+        var copied = MacAppPayload.Populate(payload, bundle, excluded);
+        Console.WriteLine($"eqicon: wrote {bundle} ({copied} file(s))");
+    }
+    else
+    {
+        Console.WriteLine($"eqicon: wrote {bundle}");
+    }
+
     return 0;
 }
 

--- a/src/eQuantic.UI.Native.Generators/BundleDeclarations.cs
+++ b/src/eQuantic.UI.Native.Generators/BundleDeclarations.cs
@@ -1,0 +1,174 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace eQuantic.UI.Native.Generators;
+
+/// <summary>
+/// Reads <c>builder.Bundle.…</c> out of <c>Program.cs</c>, so the app states what the system reads
+/// about it in C# and the generator writes the assembly declaration the build turns into an
+/// Info.plist.
+/// <para>
+/// The same shape as <see cref="CapabilityDeclarations"/> and <see cref="EntitlementDeclarations"/>
+/// — one idiom for platform facts, whether what is being asked is a person, the operating system,
+/// or the Finder.
+/// </para>
+/// </summary>
+internal static class BundleDeclarations
+{
+    private const string BuilderType = "eQuantic.UI.Native.Hosting.PhotonBundleBuilder";
+
+    internal static readonly DiagnosticDescriptor ValueMustBeConstant = new(
+        "EQ3005", "A bundle key's value must be a constant",
+        "The value passed to builder.Bundle.{0}() is built at run time, and the Info.plist is "
+        + "written at BUILD time — so this one would never reach the app's manifest. Use a literal "
+        + "or a const string.",
+        "eQuantic.UI", DiagnosticSeverity.Error, isEnabledByDefault: true);
+
+    /// <summary>
+    /// One declared fact: Apple's key, the value as text, and how to write it. A null
+    /// <paramref name="Key"/> means the call was ours but its value could not be read at build
+    /// time — reported at <paramref name="Location"/> rather than silently dropped.
+    /// </summary>
+    internal readonly struct Declaration(
+        string? key, string value, string kind, string method, Location location)
+    {
+        /// <summary>Apple's key, or null when the value could not be read at build time.</summary>
+        internal string? Key { get; } = key;
+
+        /// <summary>The value, as text — <see cref="Kind"/> decides how it is written.</summary>
+        internal string Value { get; } = value;
+
+        /// <summary>Text, Flag or UrlScheme — the name of a PhotonBundleValueKind member.</summary>
+        internal string Kind { get; } = kind;
+
+        /// <summary>The builder method that stated it, so a diagnostic can name it.</summary>
+        internal string Method { get; } = method;
+
+        /// <summary>Where it was written.</summary>
+        internal Location Location { get; } = location;
+    }
+
+    private static readonly string[] Methods =
+    [
+        "Copyright", "Category", "MinimumSystemVersion", "Agent", "UrlScheme", "Key", "Flag",
+    ];
+
+    internal static bool MightDeclare(SyntaxNode node) =>
+        node is InvocationExpressionSyntax
+        {
+            Expression: MemberAccessExpressionSyntax { Name.Identifier.ValueText: var name },
+        } && System.Array.IndexOf(Methods, name) >= 0;
+
+    /// <summary>The fact, or null when this call is not one of ours.</summary>
+    internal static Declaration? Read(GeneratorSyntaxContext context)
+    {
+        if (context.SemanticModel.GetOperation(context.Node) is not IInvocationOperation invocation)
+            return null;
+        if (invocation.TargetMethod.ContainingType?.ToDisplayString() != BuilderType) return null;
+
+        var method = invocation.TargetMethod.Name;
+        var location = context.Node.GetLocation();
+        var arguments = invocation.Arguments;
+
+        Declaration Unreadable(string kind) => new(null, "", kind, method, location);
+        Declaration Fact(string key, string value, string kind) => new(key, value, kind, method, location);
+
+        switch (method)
+        {
+            // No argument at all: the method IS the fact.
+            case "Agent":
+                return Fact("LSUIElement", "true", "Flag");
+
+            case "Copyright":
+                return Constant(arguments, 0) is { } notice
+                    ? Fact("NSHumanReadableCopyright", notice, "Text")
+                    : Unreadable("Text");
+
+            case "MinimumSystemVersion":
+                return Constant(arguments, 0) is { } version
+                    ? Fact("LSMinimumSystemVersion", version, "Text")
+                    : Unreadable("Text");
+
+            case "Category":
+                return AppleCategory(EnumMemberName(arguments, 0)) is { } category
+                    ? Fact("LSApplicationCategoryType", category, "Text")
+                    : Unreadable("Text");
+
+            case "UrlScheme":
+                // Not written under a key of its own: the schemes are collected into the one
+                // CFBundleURLTypes array the system reads.
+                return Constant(arguments, 0) is { } scheme ? Fact("", scheme, "UrlScheme") : Unreadable("UrlScheme");
+
+            case "Key":
+                return Constant(arguments, 0) is { } key && Constant(arguments, 1) is { } value
+                    ? Fact(key, value, "Text")
+                    : Unreadable("Text");
+
+            case "Flag":
+                return Constant(arguments, 0) is { } flagKey && Boolean(arguments, 1) is { } flag
+                    ? Fact(flagKey, flag ? "true" : "false", "Flag")
+                    : Unreadable("Flag");
+
+            default:
+                return null;
+        }
+    }
+
+    private static string? Constant(System.Collections.Immutable.ImmutableArray<IArgumentOperation> arguments, int index) =>
+        arguments.Length > index && arguments[index].Value.ConstantValue is { HasValue: true, Value: string value }
+            ? value
+            : null;
+
+    private static bool? Boolean(System.Collections.Immutable.ImmutableArray<IArgumentOperation> arguments, int index) =>
+        arguments.Length > index && arguments[index].Value.ConstantValue is { HasValue: true, Value: bool value }
+            ? value
+            : null;
+
+    /// <summary>
+    /// The NAME of the enum member passed, found from the constant it reduces to.
+    /// <para>
+    /// By name and never by ordinal, which is a lesson this repository paid for once already: an
+    /// enum member inserted in the middle shifted every value after it, and a manifest quietly
+    /// declared Motion where the app had asked for Location. A name that stops matching is a
+    /// compile error in the map below; an ordinal that shifts is a wrong app.
+    /// </para>
+    /// </summary>
+    private static string? EnumMemberName(
+        System.Collections.Immutable.ImmutableArray<IArgumentOperation> arguments, int index)
+    {
+        if (arguments.Length <= index) return null;
+        var argument = arguments[index].Value;
+        if (argument.ConstantValue is not { HasValue: true, Value: { } constant }) return null;
+        if (argument.Type is not INamedTypeSymbol { TypeKind: TypeKind.Enum } enumType) return null;
+
+        return enumType.GetMembers()
+            .OfType<IFieldSymbol>()
+            .FirstOrDefault(field => field.HasConstantValue && Equals(field.ConstantValue, constant))
+            ?.Name;
+    }
+
+    /// <summary>Apple's spelling, by the member's NAME. Spelled here because a source generator
+    /// sees the CALL and never the method body that maps it — the same split the entitlements
+    /// builder lives with, and a test walks the enum to prove neither side has drifted.</summary>
+    internal static string? AppleCategory(string? member) => member switch
+    {
+        "Utilities" => "public.app-category.utilities",
+        "DeveloperTools" => "public.app-category.developer-tools",
+        "Productivity" => "public.app-category.productivity",
+        "Business" => "public.app-category.business",
+        "Finance" => "public.app-category.finance",
+        "GraphicsDesign" => "public.app-category.graphics-design",
+        "Photography" => "public.app-category.photography",
+        "Music" => "public.app-category.music",
+        "Video" => "public.app-category.video",
+        "Education" => "public.app-category.education",
+        "SocialNetworking" => "public.app-category.social-networking",
+        "News" => "public.app-category.news",
+        "Reference" => "public.app-category.reference",
+        "HealthcareFitness" => "public.app-category.healthcare-fitness",
+        "Games" => "public.app-category.games",
+        _ => null,   // None, or a member added without its Apple spelling — the test catches that.
+    };
+}

--- a/src/eQuantic.UI.Native.Generators/BundleDeclarations.cs
+++ b/src/eQuantic.UI.Native.Generators/BundleDeclarations.cs
@@ -101,7 +101,16 @@ internal static class BundleDeclarations
             case "UrlScheme":
                 // Not written under a key of its own: the schemes are collected into the one
                 // CFBundleURLTypes array the system reads.
-                return Constant(arguments, 0) is { } scheme ? Fact("", scheme, "UrlScheme") : Unreadable("UrlScheme");
+                //
+                // TRIMMED here, because PhotonBundleBuilder trims too and the two must agree: the
+                // generator reads the CALL, not the method body, so " acme " would reach the plist
+                // with its spaces from one path and without them from the other — and two spellings
+                // of one scheme also defeat the de-duplication downstream.
+                if (Constant(arguments, 0) is not { } declared) return Unreadable("UrlScheme");
+                // An EMPTY constant is not an unreadable one: the builder drops it silently, so
+                // reporting "this value is built at run time" over a literal "" would be a
+                // diagnostic that describes the wrong problem.
+                return declared.Trim() is { Length: > 0 } scheme ? Fact("", scheme, "UrlScheme") : null;
 
             case "Key":
                 return Constant(arguments, 0) is { } key && Constant(arguments, 1) is { } value

--- a/src/eQuantic.UI.Native.Generators/BundleDeclarations.cs
+++ b/src/eQuantic.UI.Native.Generators/BundleDeclarations.cs
@@ -1,3 +1,4 @@
+using eQuantic.UI;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -101,26 +102,25 @@ internal static class BundleDeclarations
             case "UrlScheme":
                 // Not written under a key of its own: the schemes are collected into the one
                 // CFBundleURLTypes array the system reads.
-                //
-                // TRIMMED here, because PhotonBundleBuilder trims too and the two must agree: the
-                // generator reads the CALL, not the method body, so " acme " would reach the plist
-                // with its spaces from one path and without them from the other — and two spellings
-                // of one scheme also defeat the de-duplication downstream.
                 if (Constant(arguments, 0) is not { } declared) return Unreadable("UrlScheme");
-                // An EMPTY constant is not an unreadable one: the builder drops it silently, so
+                // An EMPTY constant is not an unreadable one: the shared rule drops it, and
                 // reporting "this value is built at run time" over a literal "" would be a
                 // diagnostic that describes the wrong problem.
-                return declared.Trim() is { Length: > 0 } scheme ? Fact("", scheme, "UrlScheme") : null;
+                return BundleFactRule.Scheme(declared) is { } scheme ? Fact("", scheme, "UrlScheme") : null;
 
+            // The KEY goes through the shared rule; the VALUE is left exactly as written, because a
+            // copyright line's spacing is the app's business and an Apple key's never is.
             case "Key":
-                return Constant(arguments, 0) is { } key && Constant(arguments, 1) is { } value
-                    ? Fact(key, value, "Text")
-                    : Unreadable("Text");
+                if (Constant(arguments, 0) is not { } key || Constant(arguments, 1) is not { } value)
+                    return Unreadable("Text");
+                return BundleFactRule.Key(key) is { } named ? Fact(named, value, "Text") : null;
 
             case "Flag":
-                return Constant(arguments, 0) is { } flagKey && Boolean(arguments, 1) is { } flag
-                    ? Fact(flagKey, flag ? "true" : "false", "Flag")
-                    : Unreadable("Flag");
+                if (Constant(arguments, 0) is not { } flagKey || Boolean(arguments, 1) is not { } flag)
+                    return Unreadable("Flag");
+                return BundleFactRule.Key(flagKey) is { } namedFlag
+                    ? Fact(namedFlag, flag ? "true" : "false", "Flag")
+                    : null;
 
             default:
                 return null;

--- a/src/eQuantic.UI.Native.Generators/BundleDeclarations.cs
+++ b/src/eQuantic.UI.Native.Generators/BundleDeclarations.cs
@@ -22,11 +22,13 @@ internal static class BundleDeclarations
 
     internal static readonly DiagnosticDescriptor ValueMustBeConstant = new(
         "EQ3005", "A bundle key's value must be a constant",
-        // Not "use a const STRING": these methods take a bool and an enum too, and a message that
-        // names the wrong shape sends someone looking for a conversion that was never the problem.
-        "The value passed to builder.Bundle.{0}() is built at run time, and the Info.plist is "
-        + "written at BUILD time — so this one would never reach the app's manifest. Pass something "
-        + "the compiler can evaluate: a literal, a const, or an AppCategory member.",
+        // "An argument", not "the value": Key and Flag take a key as well, and it is just as
+        // likely to be the non-constant one — a message that names the wrong argument sends
+        // someone to the wrong half of their own call. Nor "a const STRING": these methods take a
+        // bool and an enum too.
+        "An argument passed to builder.Bundle.{0}() is built at run time, and the Info.plist is "
+        + "written at BUILD time — so it would never reach the app's manifest. Pass something the "
+        + "compiler can evaluate: a literal, a const, or an AppCategory member.",
         "eQuantic.UI", DiagnosticSeverity.Error, isEnabledByDefault: true);
 
     /// <summary>

--- a/src/eQuantic.UI.Native.Generators/BundleDeclarations.cs
+++ b/src/eQuantic.UI.Native.Generators/BundleDeclarations.cs
@@ -21,9 +21,11 @@ internal static class BundleDeclarations
 
     internal static readonly DiagnosticDescriptor ValueMustBeConstant = new(
         "EQ3005", "A bundle key's value must be a constant",
+        // Not "use a const STRING": these methods take a bool and an enum too, and a message that
+        // names the wrong shape sends someone looking for a conversion that was never the problem.
         "The value passed to builder.Bundle.{0}() is built at run time, and the Info.plist is "
-        + "written at BUILD time — so this one would never reach the app's manifest. Use a literal "
-        + "or a const string.",
+        + "written at BUILD time — so this one would never reach the app's manifest. Pass something "
+        + "the compiler can evaluate: a literal, a const, or an AppCategory member.",
         "eQuantic.UI", DiagnosticSeverity.Error, isEnabledByDefault: true);
 
     /// <summary>

--- a/src/eQuantic.UI.Native.Generators/PhotonProgramGenerator.cs
+++ b/src/eQuantic.UI.Native.Generators/PhotonProgramGenerator.cs
@@ -63,11 +63,38 @@ public sealed class PhotonProgramGenerator : IIncrementalGenerator
             .Where(static declaration => declaration is not null)
             .Collect();
 
+        // And what the system reads ABOUT the app — its copyright, its category, the URLs it
+        // answers to. Same idiom again, and the last of the three platform-fact families.
+        var bundle = context.SyntaxProvider.CreateSyntaxProvider(
+                predicate: static (node, _) => BundleDeclarations.MightDeclare(node),
+                transform: static (ctx, _) => BundleDeclarations.Read(ctx))
+            .Where(static declaration => declaration is not null)
+            .Collect();
+
+        // The three declaration families travel together rather than as three more levels of
+        // Combine: `input.Left.Left.Left.Left.Left` is not a thing anyone can read, and the next
+        // family would add another one.
+        var declarations = capabilities.Combine(entitlements).Combine(bundle);
+
         context.RegisterSourceOutput(
-            context.CompilationProvider.Combine(programs).Combine(icon).Combine(capabilities)
-                .Combine(entitlements),
-            static (context, input) => Emit(context, input.Left.Left.Left.Left,
-                input.Left.Left.Left.Right, input.Left.Left.Right, input.Left.Right, input.Right));
+            context.CompilationProvider.Combine(programs).Combine(icon).Combine(declarations),
+            static (context, input) => Emit(context,
+                input.Left.Left.Left,       // compilation
+                input.Left.Left.Right,      // programs
+                input.Left.Right,           // has an app icon
+                input.Right.Left.Left,      // capabilities
+                input.Right.Left.Right,     // entitlements
+                input.Right.Right));        // bundle facts
+    }
+
+    /// <summary>Ordered, so the generated file is the same file for the same declarations: a
+    /// manifest that reshuffles is a diff nobody can review.</summary>
+    private static System.Collections.Generic.List<string> Sorted(
+        System.Collections.Generic.IEnumerable<string> keys)
+    {
+        var list = new System.Collections.Generic.List<string>(keys);
+        list.Sort(System.StringComparer.Ordinal);
+        return list;
     }
 
     /// <summary>A C# string literal for a value that came from the app's own source.</summary>
@@ -91,7 +118,8 @@ public sealed class PhotonProgramGenerator : IIncrementalGenerator
     private static void Emit(SourceProductionContext context, Compilation compilation,
         System.Collections.Immutable.ImmutableArray<INamedTypeSymbol?> programs, bool hasIcon,
         System.Collections.Immutable.ImmutableArray<CapabilityDeclaration?> capabilities,
-        System.Collections.Immutable.ImmutableArray<(string? Key, Location Location)?> entitlements)
+        System.Collections.Immutable.ImmutableArray<(string? Key, Location Location)?> entitlements,
+        System.Collections.Immutable.ImmutableArray<BundleDeclarations.Declaration?> bundle)
     {
         // Nothing to write for a library that merely REFERENCES the hosting assembly.
         if (compilation.GetTypeByMetadataName(ApplicationType) is null) return;
@@ -170,6 +198,63 @@ public sealed class PhotonProgramGenerator : IIncrementalGenerator
             foreach (var key in entitled)
                 file.AppendLine($"[assembly: global::eQuantic.UI.Primitives.PhotonEntitlement({Quote(key)})]");
             context.AddSource("PhotonEntitlements.g.cs", file.ToString());
+        }
+
+        // ---- What the system reads ABOUT the app -----------------------------------------------
+        // One more step along the same road: fluent call → assembly attribute → Info.plist. The
+        // keys are Apple's; the app author never types one unless they reach for the escape hatch.
+        var facts = new System.Collections.Generic.List<BundleDeclarations.Declaration>();
+        foreach (var stated in bundle)
+        {
+            if (stated is not { } declaration) continue;
+            if (declaration.Key is null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    BundleDeclarations.ValueMustBeConstant, declaration.Location, declaration.Method));
+                continue;
+            }
+            facts.Add(declaration);
+        }
+
+        if (facts.Count > 0)
+        {
+            // LAST WINS for a repeated key, and the URL schemes accumulate — the same semantics the
+            // builder itself has, so what the generated file declares is what the C# said.
+            var byKey = new System.Collections.Generic.Dictionary<string, BundleDeclarations.Declaration>(
+                System.StringComparer.Ordinal);
+            var schemes = new System.Collections.Generic.List<string>();
+            foreach (var fact in facts)
+            {
+                if (fact.Kind == "UrlScheme")
+                {
+                    if (!schemes.Contains(fact.Value)) schemes.Add(fact.Value);
+                }
+                else
+                {
+                    byKey[fact.Key!] = fact;
+                }
+            }
+
+            var manifest = new System.Text.StringBuilder();
+            manifest.AppendLine("// <auto-generated/> Written by eQuantic.UI.Native.Generators.");
+            manifest.AppendLine("#nullable enable");
+            manifest.AppendLine();
+            manifest.AppendLine("// What the system reads about this app before it runs, said once on the builder. The");
+            manifest.AppendLine("// SDK reads these off the compiled assembly and writes the Info.plist — nobody opens one.");
+            foreach (var key in Sorted(byKey.Keys))
+            {
+                var fact = byKey[key];
+                manifest.AppendLine($"[assembly: global::eQuantic.UI.Primitives.PhotonBundleKey("
+                    + $"{Quote(key)}, {Quote(fact.Value)}, "
+                    + $"global::eQuantic.UI.Primitives.PhotonBundleValueKind.{fact.Kind})]");
+            }
+            foreach (var scheme in schemes)
+            {
+                manifest.AppendLine($"[assembly: global::eQuantic.UI.Primitives.PhotonBundleKey("
+                    + $"\"\", {Quote(scheme)}, "
+                    + "global::eQuantic.UI.Primitives.PhotonBundleValueKind.UrlScheme)]");
+            }
+            context.AddSource("PhotonBundle.g.cs", manifest.ToString());
         }
 
         // ---- What the app asked of the device ------------------------------------------------

--- a/src/eQuantic.UI.Native.Generators/eQuantic.UI.Native.Generators.csproj
+++ b/src/eQuantic.UI.Native.Generators/eQuantic.UI.Native.Generators.csproj
@@ -25,4 +25,11 @@
               PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
 
+    <!-- One rule, two callers: what a bundle key and a URL scheme look like once accepted. The
+         builder and the generator cannot reference each other, and they drifted the moment only
+         one of them trimmed. -->
+    <ItemGroup>
+        <Compile Include="../Shared/BundleFactRule.cs" Link="Shared/BundleFactRule.cs" />
+    </ItemGroup>
+
 </Project>

--- a/src/eQuantic.UI.Native.Hosting/IPhotonCapabilities.cs
+++ b/src/eQuantic.UI.Native.Hosting/IPhotonCapabilities.cs
@@ -24,7 +24,14 @@ public interface IPhotonCapabilities
 
 /// <summary>A shell assembly's declaration of what it can offer the device.</summary>
 [AttributeUsage(AttributeTargets.Assembly)]
-public sealed class PhotonCapabilitiesAttribute(Type providerType) : Attribute
+public sealed class PhotonCapabilitiesAttribute(
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    Type providerType) : Attribute
 {
+    /// <summary>The provider, constructed by the host — annotated for the trimmer for the same
+    /// reason <see cref="PhotonRunnerAttribute.RunnerType"/> is.</summary>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public Type ProviderType { get; } = providerType;
 }

--- a/src/eQuantic.UI.Native.Hosting/IPhotonRunner.cs
+++ b/src/eQuantic.UI.Native.Hosting/IPhotonRunner.cs
@@ -15,7 +15,18 @@ public interface IPhotonRunner
 /// entry assembly's references, which is how <c>app.Run()</c> stays the same line on every device.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly)]
-public sealed class PhotonRunnerAttribute(Type runnerType) : Attribute
+public sealed class PhotonRunnerAttribute(
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    Type runnerType) : Attribute
 {
+    /// <summary>
+    /// The runner, constructed by the host. Annotated so the TRIMMER keeps the constructor: an app
+    /// never names its shell in code, which is the whole point of the design and also exactly the
+    /// evidence the trimmer uses to decide nothing needs it. Without this the published app dies at
+    /// launch, having built and signed cleanly.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public Type RunnerType { get; } = runnerType;
 }

--- a/src/eQuantic.UI.Native.Hosting/PhotonApplication.cs
+++ b/src/eQuantic.UI.Native.Hosting/PhotonApplication.cs
@@ -70,7 +70,10 @@ public sealed class PhotonApplication
     /// The screen this app opens on, resolved from the container — so a component takes its
     /// dependencies through its constructor like anything else in .NET.
     /// </summary>
-    public PhotonApplication UseRoot<TRoot>() where TRoot : VisualNode
+    public PhotonApplication UseRoot<
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        TRoot>() where TRoot : VisualNode
     {
         Root = () => ActivatorUtilities.CreateInstance<TRoot>(Services);
         return this;
@@ -123,31 +126,39 @@ public sealed class PhotonApplication
         services.TryAddSingleton<eQuantic.UI.Primitives.IFrameTicker>(
             Native.Components.PhotonFrameTicker.Shared);
 
-        foreach (var declaration in ShellAssemblies()
-            .SelectMany(assembly => assembly.GetCustomAttributes<PhotonCapabilitiesAttribute>())
-            .Select(attribute => attribute.ProviderType)
-            .Distinct())
+        // Constructed from the ATTRIBUTE, not from a Type that travelled through a LINQ pipeline
+        // first. The annotation that tells the trimmer to keep the provider's constructor lives on
+        // the property, and it does not survive a Select into an IEnumerable<Type> — so the pretty
+        // version compiles, publishes, and leaves the app with no capabilities at run time.
+        var registered = new HashSet<Type>();
+        foreach (var assembly in ShellAssemblies())
+        foreach (var declaration in assembly.GetCustomAttributes<PhotonCapabilitiesAttribute>())
         {
-            ((IPhotonCapabilities)Activator.CreateInstance(declaration)!).Register(services);
+            if (!registered.Add(declaration.ProviderType)) continue;
+            ((IPhotonCapabilities)Activator.CreateInstance(declaration.ProviderType)!).Register(services);
         }
     }
 
     private static IPhotonRunner FindRunner()
     {
-        var declarations = ShellAssemblies()
-            .SelectMany(assembly => assembly.GetCustomAttributes<PhotonRunnerAttribute>())
-            .Select(attribute => attribute.RunnerType)
-            .Distinct()
-            .ToArray();
-
-        return declarations.Length switch
+        // Same as the capability loop above: the runner is constructed from the attribute, where
+        // the trimmer can still see the annotation that keeps its constructor.
+        var declarations = new List<PhotonRunnerAttribute>();
+        var seen = new HashSet<Type>();
+        foreach (var assembly in ShellAssemblies())
+        foreach (var declaration in assembly.GetCustomAttributes<PhotonRunnerAttribute>())
         {
-            1 => (IPhotonRunner)Activator.CreateInstance(declarations[0])!,
+            if (seen.Add(declaration.RunnerType)) declarations.Add(declaration);
+        }
+
+        return declarations.Count switch
+        {
+            1 => (IPhotonRunner)Activator.CreateInstance(declarations[0].RunnerType)!,
             0 => throw new InvalidOperationException(
                 "No platform shell is referenced. The SDK adds one per target framework — check that "
                 + "this project builds through eQuantic.UI.Sdk.Native."),
             _ => throw new InvalidOperationException(
-                $"More than one platform shell is referenced ({string.Join(", ", declarations.Select(t => t.Name))}). "
+                $"More than one platform shell is referenced ({string.Join(", ", declarations.Select(d => d.RunnerType.Name))}). "
                 + "An app runs on the device its target framework names, and only that one."),
         };
     }
@@ -158,6 +169,15 @@ public sealed class PhotonApplication
     /// What actually ships is what is in the folder beside the program — which on a phone is the
     /// app bundle, and on a desktop the output directory.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000",
+        Justification = "Guarded: a single-file app has no base directory to scan, and the loaded "
+                        + "assemblies above are the whole answer there.")]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "The SDK ROOTS the shell it referenced (TrimmerRootAssembly in Sdk.props), "
+                        + "so a trimmed app finds it among the already-loaded assemblies and never "
+                        + "reaches this scan. The scan stays for the case the design allows and the "
+                        + "trimmer cannot see: a shell dropped beside the app rather than "
+                        + "referenced. It loads nothing it did not find in the app's own folder.")]
     private static IEnumerable<Assembly> ShellAssemblies()
     {
         const string prefix = "eQuantic.UI.Native.Shell.";

--- a/src/eQuantic.UI.Native.Hosting/PhotonApplicationBuilder.cs
+++ b/src/eQuantic.UI.Native.Hosting/PhotonApplicationBuilder.cs
@@ -70,6 +70,14 @@ public sealed class PhotonApplicationBuilder
     /// </summary>
     public PhotonEntitlementsBuilder Entitlements { get; } = new();
 
+    /// <summary>
+    /// What the system reads ABOUT this app before it runs — its copyright line, its category, the
+    /// oldest macOS it starts on, whether it takes a Dock tile, the URLs it answers to. The same
+    /// journey as the other two: a call here, an assembly declaration from the generator, and the
+    /// SDK writes the Info.plist.
+    /// </summary>
+    public PhotonBundleBuilder Bundle { get; } = new();
+
     public PhotonApplication Build()
     {
         // LAST, so anything the app registered itself already sits in the collection and the

--- a/src/eQuantic.UI.Native.Hosting/PhotonBundleBuilder.cs
+++ b/src/eQuantic.UI.Native.Hosting/PhotonBundleBuilder.cs
@@ -1,3 +1,4 @@
+using eQuantic.UI;
 using eQuantic.UI.Primitives;
 
 namespace eQuantic.UI.Native.Hosting;
@@ -59,9 +60,11 @@ public sealed class PhotonBundleBuilder
     /// </summary>
     public PhotonBundleBuilder UrlScheme(string scheme)
     {
-        var trimmed = scheme?.Trim();
-        if (!string.IsNullOrEmpty(trimmed) && !_schemes.Contains(trimmed, StringComparer.Ordinal))
-            _schemes.Add(trimmed);
+        if (BundleFactRule.Scheme(scheme) is { } accepted
+            && !_schemes.Contains(accepted, StringComparer.Ordinal))
+        {
+            _schemes.Add(accepted);
+        }
         return this;
     }
 
@@ -69,7 +72,7 @@ public sealed class PhotonBundleBuilder
     /// methods where one exists: they say what the key MEANS, which a key never does.</summary>
     public PhotonBundleBuilder Key(string key, string value)
     {
-        if (!string.IsNullOrWhiteSpace(key)) _keys[key.Trim()] = (value, PhotonBundleValueKind.Text);
+        if (BundleFactRule.Key(key) is { } named) _keys[named] = (value, PhotonBundleValueKind.Text);
         return this;
     }
 
@@ -77,8 +80,8 @@ public sealed class PhotonBundleBuilder
     /// plist is typed: a reader asking for a boolean gets the wrong answer from a string.</summary>
     public PhotonBundleBuilder Flag(string key, bool value)
     {
-        if (!string.IsNullOrWhiteSpace(key))
-            _keys[key.Trim()] = (value ? "true" : "false", PhotonBundleValueKind.Flag);
+        if (BundleFactRule.Key(key) is { } named)
+            _keys[named] = (value ? "true" : "false", PhotonBundleValueKind.Flag);
         return this;
     }
 

--- a/src/eQuantic.UI.Native.Hosting/PhotonBundleBuilder.cs
+++ b/src/eQuantic.UI.Native.Hosting/PhotonBundleBuilder.cs
@@ -1,0 +1,106 @@
+using eQuantic.UI.Primitives;
+
+namespace eQuantic.UI.Native.Hosting;
+
+/// <summary>
+/// What the operating system reads about this app before a line of it runs — its copyright line in
+/// Get Info, its category, the oldest macOS it will start on, whether it takes a Dock tile, the
+/// URLs it answers to.
+/// <para>
+/// Stated where every other app fact is stated: on the builder, in <c>Program.cs</c>, in C#. The
+/// generator turns these calls into assembly declarations and the SDK writes the Info.plist, so an
+/// app author never opens one — which is the promise the whole SDK is making, and the reason a
+/// key that Apple spells <c>LSUIElement</c> is called <see cref="Agent"/> here.
+/// </para>
+/// <code>
+/// builder.Bundle
+///        .Copyright("© 2026 Acme")
+///        .Category(AppCategory.Utilities)
+///        .MinimumSystemVersion("13.0")
+///        .UrlScheme("acme");
+/// </code>
+/// </summary>
+public sealed class PhotonBundleBuilder
+{
+    private readonly Dictionary<string, (string Value, PhotonBundleValueKind Kind)> _keys = new(StringComparer.Ordinal);
+    private readonly List<string> _schemes = [];
+
+    /// <summary>What this app declared, keyed by Apple's key.</summary>
+    public IReadOnlyDictionary<string, (string Value, PhotonBundleValueKind Kind)> Declared => _keys;
+
+    /// <summary>The URL schemes this app answers to.</summary>
+    public IReadOnlyList<string> UrlSchemes => _schemes;
+
+    /// <summary>The line Finder shows under Copyright in Get Info.</summary>
+    public PhotonBundleBuilder Copyright(string notice) => Key("NSHumanReadableCopyright", notice);
+
+    /// <summary>Where this app belongs — Finder groups by it, and the App Store requires it.</summary>
+    public PhotonBundleBuilder Category(AppCategory category) =>
+        AppleCategory(category) is { } value ? Key("LSApplicationCategoryType", value) : this;
+
+    /// <summary>
+    /// The oldest macOS this app will start on. The SDK's own floor is the oldest release where
+    /// every API the Metal backend uses exists; declare a newer one when YOUR code needs it, and
+    /// the system refuses to launch the app on anything older instead of crashing inside it.
+    /// </summary>
+    public PhotonBundleBuilder MinimumSystemVersion(string version) =>
+        Key("LSMinimumSystemVersion", version);
+
+    /// <summary>
+    /// This app lives in the menu bar and takes no Dock tile and no menu bar of its own — a status
+    /// item, a launcher, a background agent with a preferences window.
+    /// <para>Apple calls the key <c>LSUIElement</c>, which says nothing about what it does.</para>
+    /// </summary>
+    public PhotonBundleBuilder Agent() => Flag("LSUIElement", true);
+
+    /// <summary>
+    /// A URL scheme this app answers to — <c>acme://…</c> opens it and hands it the URL. Say it as
+    /// many times as there are schemes; they are collected into the one array the system reads.
+    /// </summary>
+    public PhotonBundleBuilder UrlScheme(string scheme)
+    {
+        var trimmed = scheme?.Trim();
+        if (!string.IsNullOrEmpty(trimmed) && !_schemes.Contains(trimmed, StringComparer.Ordinal))
+            _schemes.Add(trimmed);
+        return this;
+    }
+
+    /// <summary>Any key by name, because the key space is Apple's and it grows. Prefer the named
+    /// methods where one exists: they say what the key MEANS, which a key never does.</summary>
+    public PhotonBundleBuilder Key(string key, string value)
+    {
+        if (!string.IsNullOrWhiteSpace(key)) _keys[key.Trim()] = (value, PhotonBundleValueKind.Text);
+        return this;
+    }
+
+    /// <summary>Any boolean key by name. Separate from <see cref="Key(string,string)"/> because a
+    /// plist is typed: a reader asking for a boolean gets the wrong answer from a string.</summary>
+    public PhotonBundleBuilder Flag(string key, bool value)
+    {
+        if (!string.IsNullOrWhiteSpace(key))
+            _keys[key.Trim()] = (value ? "true" : "false", PhotonBundleValueKind.Flag);
+        return this;
+    }
+
+    /// <summary>Apple's spelling of a category. Spelled here and in the generator, which sees the
+    /// CALL and not this method body — the same split the entitlements builder lives with.</summary>
+    internal static string? AppleCategory(AppCategory category) => category switch
+    {
+        AppCategory.Utilities => "public.app-category.utilities",
+        AppCategory.DeveloperTools => "public.app-category.developer-tools",
+        AppCategory.Productivity => "public.app-category.productivity",
+        AppCategory.Business => "public.app-category.business",
+        AppCategory.Finance => "public.app-category.finance",
+        AppCategory.GraphicsDesign => "public.app-category.graphics-design",
+        AppCategory.Photography => "public.app-category.photography",
+        AppCategory.Music => "public.app-category.music",
+        AppCategory.Video => "public.app-category.video",
+        AppCategory.Education => "public.app-category.education",
+        AppCategory.SocialNetworking => "public.app-category.social-networking",
+        AppCategory.News => "public.app-category.news",
+        AppCategory.Reference => "public.app-category.reference",
+        AppCategory.HealthcareFitness => "public.app-category.healthcare-fitness",
+        AppCategory.Games => "public.app-category.games",
+        _ => null,
+    };
+}

--- a/src/eQuantic.UI.Native.Hosting/eQuantic.UI.Native.Hosting.csproj
+++ b/src/eQuantic.UI.Native.Hosting/eQuantic.UI.Native.Hosting.csproj
@@ -5,6 +5,18 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Description>The host a Photon app is built and run through: PhotonApplication.CreateBuilder(args), Services / Configuration / Environment / Logging, and app.Run&lt;TRoot&gt;(). The same shape as WebApplicationBuilder, because a .NET developer already knows it.</Description>
+
+        <!--
+            PhotonOptions is bound by GENERATED code, not by reflection. It has to be set HERE and
+            not on the app: the binding generator works by intercepting the call, and the call is
+            this assembly's — `_host.Services.AddOptions<PhotonOptions>().Bind(...)` in the builder's
+            constructor. Setting it on the app's project leaves that call reflective, the trimmer
+            removes the property setters nothing appears to use, and the app comes up with every
+            option at its default: a window that opens and ignores every setting, silently.
+            Measured on this repo's desktop sample, where the Photon:MaxFrames argument stopped
+            being read and the app simply never finished.
+        -->
+        <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/eQuantic.UI.Native.Hosting/eQuantic.UI.Native.Hosting.csproj
+++ b/src/eQuantic.UI.Native.Hosting/eQuantic.UI.Native.Hosting.csproj
@@ -28,4 +28,11 @@
         <ProjectReference Include="..\eQuantic.UI.Native.Components\eQuantic.UI.Native.Components.csproj" />
     </ItemGroup>
 
+    <!-- One rule, two callers: what a bundle key and a URL scheme look like once accepted. The
+         builder and the generator cannot reference each other, and they drifted the moment only
+         one of them trimmed. -->
+    <ItemGroup>
+        <Compile Include="../Shared/BundleFactRule.cs" Link="Shared/BundleFactRule.cs" />
+    </ItemGroup>
+
 </Project>

--- a/src/eQuantic.UI.Primitives/Devices/PhotonBundleKeyAttribute.cs
+++ b/src/eQuantic.UI.Primitives/Devices/PhotonBundleKeyAttribute.cs
@@ -1,0 +1,109 @@
+namespace eQuantic.UI.Primitives;
+
+/// <summary>How a value is written into the app's manifest — a plist is TYPED, and the reader that
+/// asks it for a boolean gets the wrong answer from <c>&lt;string&gt;true&lt;/string&gt;</c>.</summary>
+public enum PhotonBundleValueKind
+{
+    /// <summary>A plain string value.</summary>
+    Text,
+
+    /// <summary>A real boolean.</summary>
+    Flag,
+
+    /// <summary>A URL scheme this app answers to. These do not each get a key: they are collected
+    /// into the one <c>CFBundleURLTypes</c> array the system reads, which is why the kind exists
+    /// rather than the caller building the array.</summary>
+    UrlScheme,
+}
+
+/// <summary>
+/// One fact about the app BUNDLE — the answers the operating system reads before a line of the app
+/// runs: what it is called in Finder's Get Info, which category it belongs to, the oldest macOS it
+/// will start on, whether it takes a Dock tile at all, the URLs it answers to.
+/// <para>
+/// Written by the source generator from <c>builder.Bundle.…</c>, exactly as
+/// <see cref="PhotonCapabilityAttribute"/> is written from <c>builder.Capabilities.…</c>. An app
+/// author declares the fact once in C#; the SDK writes the Info.plist. Reaching for this attribute
+/// by hand is legal and occasionally right, but the fluent surface is the path.
+/// </para>
+/// <para>
+/// The escape hatch is deliberate and narrow: Apple owns this key space and adds to it, so the
+/// facts that matter are typed on the builder (<c>Copyright</c>, <c>Category</c>, <c>Agent</c>) and
+/// anything else is still sayable — in C#, in one line, without opening a plist.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public sealed class PhotonBundleKeyAttribute(string key, string value, PhotonBundleValueKind kind)
+    : Attribute
+{
+    /// <summary>Apple's key, e.g. <c>NSHumanReadableCopyright</c>. Empty for a
+    /// <see cref="PhotonBundleValueKind.UrlScheme"/>, which is not written under a key of its own.</summary>
+    public string Key { get; } = key;
+
+    /// <summary>The value, as text. <see cref="Kind"/> decides how it is written.</summary>
+    public string Value { get; } = value;
+
+    /// <summary>How to write it.</summary>
+    public PhotonBundleValueKind Kind { get; } = kind;
+}
+
+/// <summary>
+/// The Finder and App Store category an app declares, as C# rather than as
+/// <c>public.app-category.utilities</c> — one more platform string that is a typo away from being
+/// silently ignored, and that nobody should have to look up.
+/// <para>
+/// Apple's list is longer than this (it includes every game genre); these are the ones a Photon
+/// desktop app reaches for. Anything else is one line away:
+/// <c>builder.Bundle.Key("LSApplicationCategoryType", "public.app-category.puzzle-games")</c>.
+/// </para>
+/// </summary>
+public enum AppCategory
+{
+    /// <summary>Not declared.</summary>
+    None,
+
+    /// <summary>Utilities — the default home of a tool that does one job well.</summary>
+    Utilities,
+
+    /// <summary>Developer tools.</summary>
+    DeveloperTools,
+
+    /// <summary>Productivity.</summary>
+    Productivity,
+
+    /// <summary>Business.</summary>
+    Business,
+
+    /// <summary>Finance.</summary>
+    Finance,
+
+    /// <summary>Graphics and design.</summary>
+    GraphicsDesign,
+
+    /// <summary>Photography.</summary>
+    Photography,
+
+    /// <summary>Music.</summary>
+    Music,
+
+    /// <summary>Video.</summary>
+    Video,
+
+    /// <summary>Education.</summary>
+    Education,
+
+    /// <summary>Social networking.</summary>
+    SocialNetworking,
+
+    /// <summary>News.</summary>
+    News,
+
+    /// <summary>Reference.</summary>
+    Reference,
+
+    /// <summary>Healthcare and fitness.</summary>
+    HealthcareFitness,
+
+    /// <summary>Games.</summary>
+    Games,
+}

--- a/src/eQuantic.UI.Runtime/src/shared/enums.generated.ts
+++ b/src/eQuantic.UI.Runtime/src/shared/enums.generated.ts
@@ -18,6 +18,11 @@ export type AnchorPanelRoleValue = 'none' | 'menu' | 'listbox' | 'dialog';
 export type AnchorPlacementValue =
   'bottomStart' | 'bottomEnd' | 'topStart' | 'topEnd' | 'bottomCenter' | 'topCenter';
 
+export type AppCategoryValue =
+  'none' | 'utilities' | 'developerTools' | 'productivity' | 'business' | 'finance'
+  | 'graphicsDesign' | 'photography' | 'music' | 'video' | 'education' | 'socialNetworking' | 'news'
+  | 'reference' | 'healthcareFitness' | 'games';
+
 export type BiometricResultValue =
   'succeeded' | 'failed' | 'cancelled' | 'fallbackRequested' | 'notEnrolled' | 'unavailable';
 
@@ -82,6 +87,8 @@ export type NetworkKindValue = 'none' | 'wifi' | 'cellular' | 'wired' | 'other';
 
 export type PermissionStateValue =
   'notDetermined' | 'granted' | 'denied' | 'limited' | 'unavailable';
+
+export type PhotonBundleValueKindValue = 'text' | 'flag' | 'urlScheme';
 
 export type PointerCursorValue =
   'default' | 'pointer' | 'text' | 'notAllowed' | 'crosshair' | 'colResize' | 'rowResize';

--- a/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.props
+++ b/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.props
@@ -10,6 +10,15 @@
     <PropertyGroup>
         <ImplicitUsings Condition="'$(ImplicitUsings)' == ''">enable</ImplicitUsings>
         <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
+
+        <!--
+            Configuration bound by GENERATED code rather than by reflection. Every Photon app binds
+            PhotonOptions from appsettings.json in the builder's own constructor, so without this
+            every app that trims gets a warning it did not cause, about a call it did not make, in
+            a framework method — and the binding it warns about is one the trimmer may remove.
+            The app author has no way to know this and no reason to; the SDK knows.
+        -->
+        <EnableConfigurationBindingGenerator Condition="'$(EnableConfigurationBindingGenerator)' == ''">true</EnableConfigurationBindingGenerator>
     </PropertyGroup>
 
     <!-- The DECLARATIVE factory surface, available in every file without an import, exactly as on
@@ -189,5 +198,39 @@
     <ItemGroup Condition="'$(_EqPlatform)' == '' AND '$(IsEQuanticDevMode)' != 'true'">
         <PackageReference Include="eQuantic.UI.Native.Shell.MacOS" Version="$(EQuanticUIVersion)" />
         <PackageReference Include="eQuantic.UI.Native.Engine.Reference" Version="$(EQuanticUIVersion)" />
+    </ItemGroup>
+
+    <!--
+        WHAT TRIMMING MUST NOT REMOVE. An app never names its shell in code — that is the whole
+        point of the design: the SDK adds the one its target framework implies, and the app writes
+        C#. The trimmer reads exactly the same evidence and reaches the opposite conclusion: nothing
+        references this assembly, so it goes.
+
+        The result is an app that builds, publishes and DIES at launch with "No platform shell is
+        referenced" — the message that tells you to check your SDK, in a project whose SDK put the
+        shell there. Measured on this repo's desktop sample the first time a publish was trimmed.
+
+        So the SDK roots what the SDK added: it is the only party that knows the shell is reachable,
+        and asking the app author to know it would be asking them to know the thing this design
+        exists to hide.
+
+        RootMode="library" — keep every visible member, because what reaches into these assemblies
+        is an attribute and a Type, not a call. It is also REQUIRED rather than merely right: the
+        Android SDK's own ILLink targets read %(RootMode) unqualified, so an item without it fails
+        the whole Android build with MSB4096.
+    -->
+    <ItemGroup Condition="'$(_EqPlatform)' == ''">
+        <TrimmerRootAssembly Include="eQuantic.UI.Native.Shell.MacOS" RootMode="library" />
+        <TrimmerRootAssembly Include="eQuantic.UI.Native.Shell.Apple" RootMode="library" />
+        <TrimmerRootAssembly Include="eQuantic.UI.Native.Engine.Reference" RootMode="library" />
+        <TrimmerRootAssembly Include="eQuantic.UI.Native.Engine.Metal" RootMode="library" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(_EqPlatform)' == 'ios'">
+        <TrimmerRootAssembly Include="eQuantic.UI.Native.Shell.iOS" RootMode="library" />
+        <TrimmerRootAssembly Include="eQuantic.UI.Native.Engine.Metal" RootMode="library" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(_EqPlatform)' == 'android'">
+        <TrimmerRootAssembly Include="eQuantic.UI.Native.Shell.Android" RootMode="library" />
+        <TrimmerRootAssembly Include="eQuantic.UI.Native.Engine.Vulkan" RootMode="library" />
     </ItemGroup>
 </Project>

--- a/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
+++ b/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
@@ -26,6 +26,16 @@
         <_EqIconDir>$(MSBuildProjectDirectory)/obj/eQuantic</_EqIconDir>
         <_EqAssetsGenerated>$(EQuanticGeneratedAssetsDir)</_EqAssetsGenerated>
         <_EqIconSetDir>$(_EqIconDir)/Assets.xcassets</_EqIconSetDir>
+
+        <!--
+            Whether this project is a macOS HEAD, which the three packaging targets below all ask.
+            Spelled once here rather than three times on the targets — but only the half that can
+            be answered at EVALUATION time: `Exists(eqicon.dll)` stays on each target, because the
+            tool is built by this same solution and a cold build evaluates before it exists. A
+            packaging condition that answers "no" on the first build of the day and "yes" on the
+            second is the kind of bug nobody reproduces.
+        -->
+        <_EqMacHead Condition="'$(_EqPlatform)' == '' AND '$(TargetFramework)' != '' AND '$(OutputType)' == 'Exe' AND '$([MSBuild]::IsOSPlatform(`OSX`))' == 'true' AND '$(EQuanticMacAppBundle)' != 'false'">true</_EqMacHead>
     </PropertyGroup>
 
     <!--
@@ -65,97 +75,23 @@
         Dock tile, no menu bar, no app switcher, and nothing the OS will treat as an app.
         Skipped when an app opts out (EQuanticMacAppBundle=false) or is not an executable.
     -->
-    <Target Name="EQuanticMacAppBundle" AfterTargets="Build"
-            Condition="'$(_EqPlatform)' == '' AND '$(TargetFramework)' != '' AND '$(OutputType)' == 'Exe' AND '$([MSBuild]::IsOSPlatform(`OSX`))' == 'true' AND '$(EQuanticMacAppBundle)' != 'false' AND Exists('$(_EqIconToolDir)eqicon.dll')">
+    <!--
+        WHAT SIGNING THIS APP MEANS — resolved once, and read by both the development bundle and
+        the shipped one. It used to live inside the single build-time target, which is why there
+        was no shipped one: everything an app needs in order to be distributable was tangled with
+        the thing that runs after every Build.
+    -->
+    <Target Name="EQuanticResolveMacPackaging"
+            Condition="'$(_EqMacHead)' == 'true' AND Exists('$(_EqIconToolDir)eqicon.dll')">
         <PropertyGroup>
             <!-- The name the user reads, which a project already states as ApplicationTitle —
                  the same property MAUI uses, so nobody learns a second one. -->
             <_EqAppName>$(AssemblyName)</_EqAppName>
             <_EqAppName Condition="'$(ApplicationTitle)' != ''">$(ApplicationTitle)</_EqAppName>
-            <!-- ALWAYS beside the build output, never beside the sources. In an outer multi-TFM
-                 pass TargetDir is empty, and a bundle written there lands in the project folder —
-                 where the next build reads its own obj/ back as source files and fails on
-                 duplicate assembly attributes. -->
-            <_EqBundleDir>$([MSBuild]::EnsureTrailingSlash('$(TargetDir)'))$(_EqAppName).app</_EqBundleDir>
             <_EqBundleId Condition="'$(EQuanticBundleId)' == ''">com.equantic.$(AssemblyName.ToLowerInvariant())</_EqBundleId>
             <_EqBundleId Condition="'$(EQuanticBundleId)' != ''">$(EQuanticBundleId)</_EqBundleId>
             <_EqIcns>$(_EqIconDir)/$(_EqAppName).icns</_EqIcns>
-        </PropertyGroup>
 
-        <Exec Condition="'$(EQuanticAppIconSource)' != ''"
-              Command="dotnet &quot;$(_EqIconToolDir)eqicon.dll&quot; --source &quot;$(EQuanticAppIconSource)&quot; --macos &quot;$(_EqIcns)&quot;"
-              StandardOutputImportance="normal" />
-
-        <Exec Command="dotnet &quot;$(_EqIconToolDir)eqicon.dll&quot; bundle --app &quot;$(_EqBundleDir)&quot; --exec &quot;$(AssemblyName)&quot; --name &quot;$(_EqAppName)&quot; --id &quot;$(_EqBundleId)&quot; --version &quot;$(Version)&quot; --icns &quot;$(_EqIcns)&quot; --capabilities &quot;$(TargetDir)$(TargetFileName)&quot;"
-              StandardOutputImportance="normal" />
-
-        <!--
-            The payload: what the app needs to RUN, and nothing else. Debug symbols and the runtime
-            packs for other operating systems are not payload — and they are not merely wasteful.
-            codesign refuses to sign a bundle with unsignable files under Contents/MacOS, so a
-            single stray .pdb leaves the app unsigned; and an unsigned app is refused by the very
-            capabilities that check who is asking. LocalAuthentication simply never showed its sheet
-            and never said why, which cost an afternoon to find.
-
-            runtimes/ is an ALLOWLIST (osx*, unix*), not a denylist: only RIDs a macOS process can
-            actually load belong in the bundle. The denylist this replaces named win/linux/android/
-            ios and let `browser-wasm` through — Microsoft.Data.Sqlite ships a static archive
-            (e_sqlite3.a) under it, which is not Mach-O, and codesign refused the ENTIRE bundle
-            (found by the OS Cleaner's F1 build). The next RID the ecosystem invents is excluded
-            here by construction instead of re-opening this.
-        -->
-        <ItemGroup>
-            <_EqBundlePayload Include="$(TargetDir)**/*"
-                              Exclude="$(TargetDir)$(_EqAppName).app/**/*;$(TargetDir)**/*.app/**/*;
-                                       $(TargetDir)**/*.pdb;
-                                       $(TargetDir)runtimes/**/*" />
-            <!--
-                The allowed runtimes ride a SEPARATE item rooted at runtimes/ — with the RID in the
-                include pattern itself (runtimes/osx*/**), %(RecursiveDir) starts AFTER the RID
-                folder, the copy drops the runtimes/osx-arm64/ segment, and two RIDs shipping the
-                same filename collide in the bundle. Rooting ** at runtimes/ keeps the RID inside
-                %(RecursiveDir); the filter is per-item metadata.
-            -->
-            <_EqRuntimesAll Include="$(TargetDir)runtimes/**/*" />
-            <_EqRuntimesPayload Include="@(_EqRuntimesAll)"
-                                Condition="$([System.String]::new('%(RecursiveDir)').StartsWith('osx')) or $([System.String]::new('%(RecursiveDir)').StartsWith('unix'))" />
-        </ItemGroup>
-        <!--
-            Contents/MacOS is REBUILT from the payload every time, not accreted: the copy alone
-            never removes anything, so a file the payload stopped including (a package dropped, a
-            RID newly excluded) stayed in the bundle forever — and kept failing codesign long
-            after the exclusion was fixed. Everything under MacOS comes from this copy, so
-            removing the directory first is exactly "the bundle is the payload".
-        -->
-        <RemoveDir Directories="$(_EqBundleDir)/Contents/MacOS" />
-        <Copy SourceFiles="@(_EqBundlePayload)"
-              DestinationFiles="@(_EqBundlePayload->'$(_EqBundleDir)/Contents/MacOS/%(RecursiveDir)%(Filename)%(Extension)')" />
-        <Copy SourceFiles="@(_EqRuntimesPayload)"
-              DestinationFiles="@(_EqRuntimesPayload->'$(_EqBundleDir)/Contents/MacOS/runtimes/%(RecursiveDir)%(Filename)%(Extension)')" />
-        <Exec Command="chmod +x &quot;$(_EqBundleDir)/Contents/MacOS/$(AssemblyName)&quot;" />
-
-        <!--
-            And SIGN it, ad hoc, under the bundle's own identifier. Without this the identity is
-            whatever the apphost was signed as — "apphost" — and a capability that asks who is
-            calling gets an answer that names nothing. Ad hoc is right for a development build: it
-            proves nothing about origin, which is honest, and it is what a local app needs to be
-            treated as an app at all. A shipped build re-signs with a real identity.
-
-            A signing failure FAILS THE BUILD. It used to be a warning, and the .app kept whatever
-            signature the previous build left — an identity that silently flips is how a TCC grant
-            (Full Disk Access) evaporates between builds, and nobody connects a lost permission to
-            a warning that scrolled past yesterday. A loud build is the cheap version of that hour.
-        -->
-        <!--
-            ENTITLEMENTS — what the app needs the SYSTEM to permit, read from its own
-            `[assembly: PhotonEntitlement(…)]` declarations. This is the release half of the
-            capability idea and it is invisible until release, which is what makes it dangerous: a
-            development build signs ad hoc, where the hardened runtime is not in force and nothing
-            needs permitting, so an app that JITs (a WASM engine, a scripting VM) runs perfectly for
-            months and is then killed with SIGKILL/CODESIGNING on the first machine that installs
-            the signed build. No catch sees it; the process is simply gone.
-        -->
-        <PropertyGroup>
             <!-- A real identity turns the hardened runtime on WITH it — decided here, before
                  anything reads it, because the entitlements below depend on the answer. It used to
                  be settled further down, next to the codesign call, so an app that set only
@@ -182,8 +118,17 @@
         </PropertyGroup>
 
         <Message Condition="'$(_EqRuntimeEntitlements)' != ''" Importance="normal"
-                 Text="eQuantic.UI: hardened runtime — the SDK is declaring what the .NET runtime itself needs ($(_EqRuntimeEntitlements)); your app declares only what its own code needs." />
+                 Text="eQuantic.UI: hardened runtime — the SDK is declaring what the .NET runtime itself needs ($(_EqRuntimeEntitlements)); your app declares only its own." />
 
+        <!--
+            ENTITLEMENTS — what the app needs the SYSTEM to permit, read from its own
+            `[assembly: PhotonEntitlement(…)]` declarations. This is the release half of the
+            capability idea and it is invisible until release, which is what makes it dangerous: a
+            development build signs ad hoc, where the hardened runtime is not in force and nothing
+            needs permitting, so an app that JITs (a WASM engine, a scripting VM) runs perfectly for
+            months and is then killed with SIGKILL/CODESIGNING on the first machine that installs
+            the signed build. No catch sees it; the process is simply gone.
+        -->
         <Exec Command="dotnet &quot;$(_EqIconToolDir)eqicon.dll&quot; entitlements --assembly &quot;$(TargetDir)$(TargetFileName)&quot; --plist &quot;$(_EqIconDir)/$(AssemblyName).entitlements&quot; --also &quot;$(_EqRuntimeEntitlements)&quot;"
               StandardOutputImportance="normal" />
 
@@ -207,15 +152,169 @@
              prevent, so say plainly when the two halves disagree rather than shipping a bundle whose
              declarations are decoration. -->
         <Warning Condition="Exists('$(_EqEntitlements)') AND '$(EQuanticHardenedRuntime)' != 'true'"
-                 Text="This app declares entitlements, but they are only consulted under the hardened runtime — set EQuanticSigningIdentity (which turns it on) before publishing, or the signed build will be killed where the development build ran." />
+                 Text="This app declares entitlements, but they are only consulted under the hardened runtime — set EQuanticSigningIdentity (which turns it on) or EQuanticHardenedRuntime=true, or the declarations do nothing." />
+    </Target>
 
-        <!-- And the other direction, which is worse because the build is green and the app is dead:
-             a framework-dependent .NET app under the hardened runtime cannot load Microsoft's
-             libhostfxr.dylib at all (library validation: "different Team IDs"), so it dies at LAUNCH,
-             before any code of yours runs. Measured on this repo's own sample, not inferred. A
-             self-contained or fully AOT app loads no foreign-team dylib and is exempt. -->
+    <!--
+        THE DEVELOPMENT BUNDLE, beside the build output: what `dotnet run` launches and what a
+        debugger attaches to. Ad-hoc signed, from the build's own files.
+    -->
+    <Target Name="EQuanticMacAppBundle" AfterTargets="Build"
+            DependsOnTargets="EQuanticResolveMacPackaging"
+            Condition="'$(_EqMacHead)' == 'true' AND Exists('$(_EqIconToolDir)eqicon.dll')">
+        <PropertyGroup>
+            <!-- ALWAYS beside the build output, never beside the sources. In an outer multi-TFM
+                 pass TargetDir is empty, and a bundle written there lands in the project folder —
+                 where the next build reads its own obj/ back as source files and fails on
+                 duplicate assembly attributes. -->
+            <_EqBundleDir>$([MSBuild]::EnsureTrailingSlash('$(TargetDir)'))$(_EqAppName).app</_EqBundleDir>
+        </PropertyGroup>
+
+        <!--
+            ANOTHER BUILD OF THIS APP IS NOT PAYLOAD OF THIS ONE. .NET nests its output
+            directories: a RID-specific build lands in `bin/<config>/<tfm>/<rid>/` and its publish
+            tree inside that again — both UNDER the plain build's own output directory. So a
+            developer who publishes for osx-arm64 and then builds again has an entire second copy of
+            the app inside the directory the development bundle is assembled from.
+
+            The failure is not quiet, which is the one mercy: codesign refuses the whole bundle over
+            the disk image it finds in there, and an ordinary `dotnet build` fails with a signing
+            error naming a file nobody put there.
+
+            Recognised by CONTENT rather than by name: a subdirectory holding this app's own
+            assembly is another build of it. A rule that matched "publish" or a RID-shaped name
+            instead would be guessing, and would take an app's own content folder with it.
+        -->
+        <ItemGroup>
+            <_EqOutputChild Include="$([System.IO.Directory]::GetDirectories('$(TargetDir)', '*', System.IO.SearchOption.TopDirectoryOnly))"
+                            Condition="Exists('$(TargetDir)')" />
+            <_EqOtherBuild Include="%(_EqOutputChild.Identity)"
+                           Condition="Exists('%(_EqOutputChild.Identity)/$(TargetFileName)')" />
+            <_EqOtherBuild Include="%(_EqOutputChild.Identity)/publish"
+                           Condition="Exists('%(_EqOutputChild.Identity)/publish')" />
+        </ItemGroup>
+        <PropertyGroup>
+            <_EqExcludeArgs>--exclude &quot;$([System.IO.Path]::GetFullPath('$(PublishDir)'))&quot;</_EqExcludeArgs>
+            <_EqExcludeArgs Condition="'@(_EqOtherBuild)' != ''">$(_EqExcludeArgs) --exclude &quot;@(_EqOtherBuild, '&quot; --exclude &quot;')&quot;</_EqExcludeArgs>
+        </PropertyGroup>
+
+        <Exec Condition="'$(EQuanticAppIconSource)' != ''"
+              Command="dotnet &quot;$(_EqIconToolDir)eqicon.dll&quot; --source &quot;$(EQuanticAppIconSource)&quot; --macos &quot;$(_EqIcns)&quot;"
+              StandardOutputImportance="normal" />
+
+        <!--
+            The bundle AND its payload in one call. What belongs inside is decided in C#
+            (MacAppPayload) rather than by a glob, because every one of those rules was learned from
+            a bundle that failed to sign, and a glob is where they cannot be tested.
+
+            The publish directory is excluded BY PATH: it lives under the build output, and a
+            build-output bundle that swallows it ships an entire second copy of the app inside
+            itself — 86 MB of it, measured on this repo's own desktop sample after one publish.
+        -->
+        <Exec Command="dotnet &quot;$(_EqIconToolDir)eqicon.dll&quot; bundle --app &quot;$(_EqBundleDir)&quot; --exec &quot;$(AssemblyName)&quot; --name &quot;$(_EqAppName)&quot; --id &quot;$(_EqBundleId)&quot; --version &quot;$(Version)&quot; --icns &quot;$(_EqIcns)&quot; --capabilities &quot;$(TargetDir)$(TargetFileName)&quot; --payload &quot;$(TargetDir)&quot; $(_EqExcludeArgs)"
+              StandardOutputImportance="normal" />
+        <Exec Command="chmod +x &quot;$(_EqBundleDir)/Contents/MacOS/$(AssemblyName)&quot;" />
+
+        <!--
+            And SIGN it, ad hoc, under the bundle's own identifier. Without this the identity is
+            whatever the apphost was signed as — "apphost" — and a capability that asks who is
+            calling gets an answer that names nothing. Ad hoc is right for a development build: it
+            proves nothing about origin, which is honest, and it is what a local app needs to be
+            treated as an app at all. A shipped build re-signs with a real identity.
+
+            A signing failure FAILS THE BUILD. It used to be a warning, and the .app kept whatever
+            signature the previous build left — an identity that silently flips is how a TCC grant
+            (Full Disk Access) evaporates between builds, and nobody connects a lost permission to
+            a warning that scrolled past yesterday. A loud build is the cheap version of that hour.
+        -->
         <Exec Command="codesign --force --deep --sign &quot;$(_EqSignIdentity)&quot; $(_EqHardenedArg) $(_EqEntitlementsArg) --identifier &quot;$(_EqBundleId)&quot; &quot;$(_EqBundleDir)&quot;"
               StandardOutputImportance="normal" />
+    </Target>
+
+    <!--
+        THE SHIPPED BUNDLE — the one `dotnet publish` produces, and the reason this target exists at
+        all.
+
+        Until it did, the .app was assembled from the BUILD output and `publish/` held loose files
+        with no bundle in it. Every publish decision therefore stopped at the bundle's door:
+        trimming, self-contained, single-file, AOT. Measured on this repo's desktop sample with
+        PublishTrimmed on: publish 23 MB, bundle 172 MB — the app you would ship was seven times the
+        app you asked for, and none of the trimming reached it.
+
+        The bundle lands INSIDE the publish directory, next to the loose files, which is where MAUI
+        puts its own and therefore where tooling already looks.
+    -->
+    <Target Name="EQuanticMacAppPackage" AfterTargets="Publish"
+            DependsOnTargets="EQuanticResolveMacPackaging"
+            Condition="'$(_EqMacHead)' == 'true' AND Exists('$(_EqIconToolDir)eqicon.dll')">
+        <PropertyGroup>
+            <_EqPublishDir>$([MSBuild]::EnsureTrailingSlash('$([System.IO.Path]::GetFullPath('$(PublishDir)'))'))</_EqPublishDir>
+            <_EqShipDir>$(_EqPublishDir)$(_EqAppName).app</_EqShipDir>
+            <_EqDmg>$(_EqPublishDir)$(_EqAppName).dmg</_EqDmg>
+            <_EqNotaryZip>$(_EqIconDir)/$(AssemblyName).notarize.zip</_EqNotaryZip>
+
+            <!-- Credentials, never the project's business to hold: either a notarytool keychain
+                 profile a developer stored once, or the three values a CI holds as secrets. Both
+                 spellings, because a laptop has a keychain and a build agent does not. -->
+            <_EqNotaryArgs Condition="'$(EQuanticNotaryProfile)' != ''">--keychain-profile &quot;$(EQuanticNotaryProfile)&quot;</_EqNotaryArgs>
+            <_EqNotaryArgs Condition="'$(_EqNotaryArgs)' == '' AND '$(EQuanticNotaryAppleId)' != '' AND '$(EQuanticNotaryTeamId)' != '' AND '$(EQuanticNotaryPassword)' != ''">--apple-id &quot;$(EQuanticNotaryAppleId)&quot; --team-id &quot;$(EQuanticNotaryTeamId)&quot; --password &quot;$(EQuanticNotaryPassword)&quot;</_EqNotaryArgs>
+        </PropertyGroup>
+
+        <Exec Condition="'$(EQuanticAppIconSource)' != ''"
+              Command="dotnet &quot;$(_EqIconToolDir)eqicon.dll&quot; --source &quot;$(EQuanticAppIconSource)&quot; --macos &quot;$(_EqIcns)&quot;"
+              StandardOutputImportance="normal" />
+
+        <Exec Command="dotnet &quot;$(_EqIconToolDir)eqicon.dll&quot; bundle --app &quot;$(_EqShipDir)&quot; --exec &quot;$(AssemblyName)&quot; --name &quot;$(_EqAppName)&quot; --id &quot;$(_EqBundleId)&quot; --version &quot;$(Version)&quot; --icns &quot;$(_EqIcns)&quot; --capabilities &quot;$(TargetDir)$(TargetFileName)&quot; --payload &quot;$(_EqPublishDir)&quot; --exclude &quot;$(_EqDmg)&quot;"
+              StandardOutputImportance="normal" />
+        <Exec Command="chmod +x &quot;$(_EqShipDir)/Contents/MacOS/$(AssemblyName)&quot;" />
+        <Exec Command="codesign --force --deep --sign &quot;$(_EqSignIdentity)&quot; $(_EqHardenedArg) $(_EqEntitlementsArg) --identifier &quot;$(_EqBundleId)&quot; &quot;$(_EqShipDir)&quot;"
+              StandardOutputImportance="normal" />
+
+        <!-- Ad hoc is fine on a laptop and is NOT distributable: Gatekeeper refuses it on any
+             machine that did not build it. Said once, at publish, where it is actionable. -->
+        <Warning Condition="'$(EQuanticSigningIdentity)' == ''"
+                 Text="This bundle is signed AD HOC, which Gatekeeper refuses on every machine but this one. Set EQuanticSigningIdentity to a Developer ID Application certificate to ship it." />
+
+        <!--
+            NOTARIZATION — Apple scanning the signed app and issuing a ticket, without which a
+            downloaded app is refused with "cannot be opened because the developer cannot be
+            verified". Three steps that are always the same three steps, so the SDK does them: zip
+            the way notarytool expects (ditto, keeping the bundle), submit and WAIT, then staple the
+            ticket into the bundle so it verifies with no network at all.
+        -->
+        <Message Condition="'$(_EqNotaryArgs)' != ''" Importance="high"
+                 Text="eQuantic.UI: submitting $(_EqAppName).app for notarization — Apple decides how long this takes." />
+        <Exec Condition="'$(_EqNotaryArgs)' != ''"
+              Command="ditto -c -k --keepParent &quot;$(_EqShipDir)&quot; &quot;$(_EqNotaryZip)&quot;" />
+        <Exec Condition="'$(_EqNotaryArgs)' != ''"
+              Command="xcrun notarytool submit &quot;$(_EqNotaryZip)&quot; $(_EqNotaryArgs) --wait"
+              StandardOutputImportance="high" />
+        <Exec Condition="'$(_EqNotaryArgs)' != ''"
+              Command="xcrun stapler staple &quot;$(_EqShipDir)&quot;"
+              StandardOutputImportance="normal" />
+        <Delete Condition="'$(_EqNotaryArgs)' != ''" Files="$(_EqNotaryZip)" />
+
+        <!-- Notarizing an AD-HOC signature cannot succeed — Apple has nothing to attach a ticket
+             to. Better to say which of the two is missing than to let notarytool answer it in its
+             own vocabulary five minutes later. -->
+        <Warning Condition="'$(_EqNotaryArgs)' != '' AND '$(EQuanticSigningIdentity)' == ''"
+                 Text="Notarization needs a real signature: set EQuanticSigningIdentity as well, or Apple has nothing to issue a ticket for." />
+
+        <!--
+            THE DISK IMAGE, when the app is distributed as one. Built from the stapled bundle, so
+            the ticket travels inside it and the app verifies offline the moment it is dragged out;
+            the image itself is signed with the same identity so the download is not a stranger.
+        -->
+        <Delete Condition="'$(EQuanticPackageFormat)' == 'Dmg'" Files="$(_EqDmg)" />
+        <Exec Condition="'$(EQuanticPackageFormat)' == 'Dmg'"
+              Command="hdiutil create -volname &quot;$(_EqAppName)&quot; -srcfolder &quot;$(_EqShipDir)&quot; -ov -format UDZO &quot;$(_EqDmg)&quot;"
+              StandardOutputImportance="normal" />
+        <Exec Condition="'$(EQuanticPackageFormat)' == 'Dmg' AND '$(EQuanticSigningIdentity)' != ''"
+              Command="codesign --force --sign &quot;$(_EqSignIdentity)&quot; &quot;$(_EqDmg)&quot;"
+              StandardOutputImportance="normal" />
+
+        <Message Importance="high" Text="eQuantic.UI: $(_EqShipDir)" />
+        <Message Condition="'$(EQuanticPackageFormat)' == 'Dmg'" Importance="high" Text="eQuantic.UI: $(_EqDmg)" />
     </Target>
 
     <!--

--- a/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
+++ b/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
@@ -253,7 +253,11 @@
             DependsOnTargets="EQuanticResolveMacPackaging"
             Condition="'$(_EqMacHead)' == 'true' AND Exists('$(_EqIconToolDir)eqicon.dll')">
         <PropertyGroup>
-            <_EqPublishDir>$([MSBuild]::EnsureTrailingSlash('$([System.IO.Path]::GetFullPath('$(PublishDir)'))'))</_EqPublishDir>
+            <!-- Two steps rather than one nested call. The nested form parses and works — this
+                 target published a signed bundle and a disk image with it — but a reader has to
+                 count quotes to be sure, and that is a poor reason to make anyone read carefully. -->
+            <_EqPublishDir>$([System.IO.Path]::GetFullPath('$(PublishDir)'))</_EqPublishDir>
+            <_EqPublishDir>$([MSBuild]::EnsureTrailingSlash('$(_EqPublishDir)'))</_EqPublishDir>
             <_EqShipDir>$(_EqPublishDir)$(_EqAppName).app</_EqShipDir>
             <_EqDmg>$(_EqPublishDir)$(_EqAppName).dmg</_EqDmg>
             <_EqNotaryZip>$(_EqIconDir)/$(AssemblyName).notarize.zip</_EqNotaryZip>

--- a/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
+++ b/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
@@ -192,9 +192,14 @@
                            Condition="Exists('%(_EqOutputChild.Identity)/$(TargetFileName)')" />
             <_EqOtherBuild Include="%(_EqOutputChild.Identity)/publish"
                            Condition="Exists('%(_EqOutputChild.Identity)/publish')" />
+            <_EqOtherBuild Include="$(TargetDir)publish" Condition="Exists('$(TargetDir)publish')" />
         </ItemGroup>
         <PropertyGroup>
-            <_EqExcludeArgs>--exclude &quot;$([System.IO.Path]::GetFullPath('$(PublishDir)'))&quot;</_EqExcludeArgs>
+            <!-- GUARDED: GetFullPath of an empty string is not "the current directory", it is
+                 MSB4184 — the whole build fails on a property that is normally set by the SDK and
+                 is not guaranteed to be. Nothing here needs PublishDir to exist; the sibling-build
+                 rule below finds a publish tree anyway. -->
+            <_EqExcludeArgs Condition="'$(PublishDir)' != ''">--exclude &quot;$([System.IO.Path]::GetFullPath('$(PublishDir)'))&quot;</_EqExcludeArgs>
             <_EqExcludeArgs Condition="'@(_EqOtherBuild)' != ''">$(_EqExcludeArgs) --exclude &quot;@(_EqOtherBuild, '&quot; --exclude &quot;')&quot;</_EqExcludeArgs>
         </PropertyGroup>
 

--- a/tests/eQuantic.UI.Compiler.Tests/Coverage/diagnostics.baseline.txt
+++ b/tests/eQuantic.UI.Compiler.Tests/Coverage/diagnostics.baseline.txt
@@ -34,6 +34,7 @@ EQ3001 eQuantic.UI.Native.Generators/PhotonProgramGenerator.cs
 EQ3002 eQuantic.UI.Native.Generators/PhotonProgramGenerator.cs
 EQ3003 eQuantic.UI.Native.Generators/CapabilityDeclarations.cs
 EQ3004 eQuantic.UI.Native.Generators/EntitlementDeclarations.cs
+EQ3005 eQuantic.UI.Native.Generators/BundleDeclarations.cs
 EQ3101 eQuantic.UI.Generators/AppFactorySurfaceGenerator.cs
 EQ3102 eQuantic.UI.Generators/AppFactorySurfaceGenerator.cs
 EQ3103 eQuantic.UI.Generators/FormModelGenerator.cs

--- a/tests/eQuantic.UI.Native.Engine.Tests/MacAppPackagingTests.cs
+++ b/tests/eQuantic.UI.Native.Engine.Tests/MacAppPackagingTests.cs
@@ -9,6 +9,9 @@ using FluentAssertions;
 [assembly: PhotonBundleKey("LSMinimumSystemVersion", "13.0", PhotonBundleValueKind.Text)]
 [assembly: PhotonBundleKey("", "acme", PhotonBundleValueKind.UrlScheme)]
 [assembly: PhotonBundleKey("", "acme-beta", PhotonBundleValueKind.UrlScheme)]
+// A key the FRAMEWORK writes itself, declared anyway — the app wins, and it appears once.
+[assembly: PhotonBundleKey("CFBundleDisplayName", "Acme Pro", PhotonBundleValueKind.Text)]
+[assembly: PhotonBundleKey("NSHighResolutionCapable", "false", PhotonBundleValueKind.Flag)]
 
 namespace eQuantic.UI.Native.Engine.Tests;
 
@@ -56,6 +59,36 @@ public class MacAppPackagingTests
             // whichever the parser reaches last, which is how a declaration silently loses.
             Occurrences(plist, "<key>LSMinimumSystemVersion</key>").Should().Be(1);
             Occurrences(plist, "<key>LSUIElement</key>").Should().Be(1);
+        }
+        finally
+        {
+            Directory.Delete(bundle, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// EVERY key the framework writes, not the two the first version of this consulted. A list of
+    /// "the ones the framework owns" is wrong the moment a key is added above it, and its failure
+    /// is silent — a plist with a key twice is not an error anywhere.
+    /// </summary>
+    [Fact]
+    public void ADeclarationBeatsAnyFrameworkKey_AndNoKeyIsWrittenTwice()
+    {
+        var bundle = Bundle();
+        try
+        {
+            MacAppBundle.Write(bundle, "Acme", "Acme", "com.acme.app", "1.2.3", null, ThisAssembly);
+            var plist = File.ReadAllText(Path.Combine(bundle, "Contents", "Info.plist"));
+
+            plist.Should().Contain("<key>CFBundleDisplayName</key>\n\t<string>Acme Pro</string>");
+            plist.Should().Contain("<key>NSHighResolutionCapable</key>\n\t<false/>");
+
+            // Not one key twice, anywhere in the document.
+            var keys = System.Text.RegularExpressions.Regex
+                .Matches(plist, @"<key>([^<]+)</key>")
+                .Select(match => match.Groups[1].Value)
+                .ToList();
+            keys.Should().OnlyHaveUniqueItems();
         }
         finally
         {

--- a/tests/eQuantic.UI.Native.Engine.Tests/MacAppPackagingTests.cs
+++ b/tests/eQuantic.UI.Native.Engine.Tests/MacAppPackagingTests.cs
@@ -1,0 +1,118 @@
+using eQuantic.UI.Build;
+using eQuantic.UI.Primitives;
+using FluentAssertions;
+
+// THIS assembly is the fixture, like the entitlements test beside it: the reader works off a
+// compiled PE file, so declaring here means the test reads exactly what an app's build would.
+[assembly: PhotonBundleKey("NSHumanReadableCopyright", "© 2026 Acme", PhotonBundleValueKind.Text)]
+[assembly: PhotonBundleKey("LSUIElement", "true", PhotonBundleValueKind.Flag)]
+[assembly: PhotonBundleKey("LSMinimumSystemVersion", "13.0", PhotonBundleValueKind.Text)]
+[assembly: PhotonBundleKey("", "acme", PhotonBundleValueKind.UrlScheme)]
+[assembly: PhotonBundleKey("", "acme-beta", PhotonBundleValueKind.UrlScheme)]
+
+namespace eQuantic.UI.Native.Engine.Tests;
+
+/// <summary>
+/// The three halves of shipping a macOS app that used to be unsayable: what the system reads about
+/// it, what goes inside the bundle, and what version it claims to be.
+/// </summary>
+public class MacAppPackagingTests
+{
+    private static string ThisAssembly => typeof(MacAppPackagingTests).Assembly.Location;
+
+    [Fact]
+    public void ReadsEveryKindTheAppDeclared()
+    {
+        var facts = BundleManifest.Read(ThisAssembly);
+
+        facts.Should().Contain(new BundleManifest.Fact(
+            "NSHumanReadableCopyright", "© 2026 Acme", BundleManifest.ValueKind.Text));
+        facts.Should().Contain(new BundleManifest.Fact(
+            "LSUIElement", "true", BundleManifest.ValueKind.Flag));
+        // The schemes keep the order they were declared in and are not keyed: they become one array.
+        facts.Where(fact => fact.Kind == BundleManifest.ValueKind.UrlScheme)
+             .Select(fact => fact.Value)
+             .Should().Equal("acme", "acme-beta");
+    }
+
+    [Fact]
+    public void AnAssemblyThatDeclaresNone_ReadsAsNone() =>
+        BundleManifest.Read(typeof(string).Assembly.Location).Should().BeEmpty();
+
+    [Fact]
+    public void ADeclaredValueBeatsTheFrameworksDefault_AndIsWrittenOnce()
+    {
+        var bundle = Bundle();
+        try
+        {
+            MacAppBundle.Write(bundle, "Acme", "Acme", "com.acme.app", "1.2.3", null, ThisAssembly);
+            var plist = File.ReadAllText(Path.Combine(bundle, "Contents", "Info.plist"));
+
+            // The framework writes 11.0 and false; this app said otherwise, and said it in C#.
+            plist.Should().Contain("<key>LSMinimumSystemVersion</key>\n\t<string>13.0</string>");
+            plist.Should().Contain("<key>LSUIElement</key>\n\t<true/>");
+
+            // ONCE each. A plist with a key twice is not an error anywhere — it simply means
+            // whichever the parser reaches last, which is how a declaration silently loses.
+            Occurrences(plist, "<key>LSMinimumSystemVersion</key>").Should().Be(1);
+            Occurrences(plist, "<key>LSUIElement</key>").Should().Be(1);
+        }
+        finally
+        {
+            Directory.Delete(bundle, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TheUrlsTheAppAnswersTo_BecomeTheArrayTheSystemReads()
+    {
+        var bundle = Bundle();
+        try
+        {
+            MacAppBundle.Write(bundle, "Acme", "Acme", "com.acme.app", "1.2.3", null, ThisAssembly);
+            var plist = File.ReadAllText(Path.Combine(bundle, "Contents", "Info.plist"));
+
+            plist.Should().Contain("<key>CFBundleURLTypes</key>");
+            plist.Should().Contain("<string>acme</string>");
+            plist.Should().Contain("<string>acme-beta</string>");
+            // One <dict> holding both schemes, not one entry each: they are the same app.
+            Occurrences(plist, "<key>CFBundleURLSchemes</key>").Should().Be(1);
+        }
+        finally
+        {
+            Directory.Delete(bundle, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Apple's version is one to three integers, and .NET's routinely is not — this repository's own
+    /// is <c>0.2.0-preview.46</c>, and it went into the plist verbatim until now. That bundle is
+    /// refused by notarization and by the App Store, in a vocabulary that names nothing you wrote.
+    /// </summary>
+    [Theory]
+    [InlineData("1.2.3", "1.2.3")]
+    [InlineData("0.2.0-preview.46", "0.2.0")]
+    [InlineData("1.0.0+sha.abc1234", "1.0.0")]
+    [InlineData("2.1", "2.1")]
+    [InlineData("1.2.3.4", "1.2.3")]      // Apple takes at most three
+    [InlineData("01.02", "1.2")]          // and no leading zeros
+    [InlineData("preview", "1.0.0")]      // nothing numeric at all: a version that is at least legal
+    [InlineData("", "1.0.0")]
+    public void TheVersionIsTheOnlyShapeAppleAccepts(string declared, string expected) =>
+        MacAppBundle.AppleVersion(declared).Should().Be(expected);
+
+    private static string Bundle()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"eq-{Guid.NewGuid():N}.app");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static int Occurrences(string text, string needle)
+    {
+        var count = 0;
+        for (var at = text.IndexOf(needle, StringComparison.Ordinal); at >= 0;
+             at = text.IndexOf(needle, at + needle.Length, StringComparison.Ordinal)) count++;
+        return count;
+    }
+}

--- a/tests/eQuantic.UI.Native.Engine.Tests/MacAppPayloadTests.cs
+++ b/tests/eQuantic.UI.Native.Engine.Tests/MacAppPayloadTests.cs
@@ -1,0 +1,163 @@
+using eQuantic.UI.Build;
+using FluentAssertions;
+
+namespace eQuantic.UI.Native.Engine.Tests;
+
+/// <summary>
+/// What goes inside <c>Contents/MacOS</c>. Every rule here was learned from a bundle that failed to
+/// sign or an app that failed to launch, and every one of them lived in an MSBuild glob where none
+/// of them could be tested.
+/// <para>
+/// The stakes are higher than "a few extra megabytes": <c>codesign</c> refuses a bundle containing
+/// a file it cannot sign, and it refuses the WHOLE bundle. One stray file leaves the app unsigned,
+/// and an unsigned app is quietly refused by the capabilities that check who is asking.
+/// </para>
+/// </summary>
+public class MacAppPayloadTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"eq-payload-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private void Given(params string[] relativePaths)
+    {
+        foreach (var relative in relativePaths)
+        {
+            var path = Path.Combine(_root, relative.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, "x");
+        }
+    }
+
+    private IReadOnlyList<string> Selected(params string[] excluded) =>
+        MacAppPayload.Select(_root, excluded).Select(path => path.Replace(Path.DirectorySeparatorChar, '/')).ToList();
+
+    [Fact]
+    public void TheAppsOwnFilesAreThePayload()
+    {
+        Given("Acme", "Acme.dll", "appsettings.json", "es/Acme.resources.dll");
+
+        Selected().Should().Equal("Acme", "Acme.dll", "appsettings.json", "es/Acme.resources.dll");
+    }
+
+    [Fact]
+    public void DebugSymbolsAreNot()
+    {
+        Given("Acme.dll", "Acme.pdb", "Third.Party.pdb");
+
+        Selected().Should().Equal("Acme.dll");
+    }
+
+    /// <summary>
+    /// An ALLOWLIST, not a denylist. The denylist this replaces named win/linux/android/ios and let
+    /// <c>browser-wasm</c> through — Microsoft.Data.Sqlite ships a static archive under it, which is
+    /// not Mach-O, and codesign refused the entire bundle.
+    /// </summary>
+    [Fact]
+    public void OnlyRuntimesAMacProcessCanLoad()
+    {
+        Given(
+            "runtimes/osx-arm64/native/libe_sqlite3.dylib",
+            "runtimes/osx-x64/native/libe_sqlite3.dylib",
+            "runtimes/unix/lib/net10.0/System.Data.dll",
+            "runtimes/win-x64/native/e_sqlite3.dll",
+            "runtimes/browser-wasm/nativeassets/net10.0/e_sqlite3.a",
+            "runtimes/linux-x64/native/libe_sqlite3.so");
+
+        Selected().Should().Equal(
+            "runtimes/osx-arm64/native/libe_sqlite3.dylib",
+            "runtimes/osx-x64/native/libe_sqlite3.dylib",
+            "runtimes/unix/lib/net10.0/System.Data.dll");
+    }
+
+    /// <summary>
+    /// Two RIDs shipping the same file name must not collide. The bug this pins is subtle: rooting
+    /// the glob at <c>runtimes/osx*/**</c> makes the recursive part start AFTER the RID folder, so
+    /// both copies land on the same path inside the bundle and one silently wins.
+    /// </summary>
+    [Fact]
+    public void TwoRuntimeIdentifiersKeepTheirOwnFolders()
+    {
+        Given("runtimes/osx-arm64/native/lib.dylib", "runtimes/osx-x64/native/lib.dylib");
+
+        Selected().Should().HaveCount(2).And.OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void ABundleInsideThePayloadIsOutput_NeverInput()
+    {
+        Given("Acme.dll", "Acme.app/Contents/MacOS/Acme", "Acme.app/Contents/Info.plist");
+
+        Selected().Should().Equal("Acme.dll");
+    }
+
+    /// <summary>
+    /// The publish directory lives UNDER the build output, so a build-output bundle that does not
+    /// exclude it ships an entire second copy of the app inside itself — 86 MB of it, measured on
+    /// this repository's own desktop sample after a single publish.
+    /// </summary>
+    [Fact]
+    public void ThePublishDirectoryIsNotPayloadOfTheBuild()
+    {
+        Given("Acme.dll", "publish/Acme.dll", "publish/appsettings.json");
+
+        Selected(Path.Combine(_root, "publish")).Should().Equal("Acme.dll");
+    }
+
+    /// <summary>
+    /// And it is excluded BY PATH, never by name: an app whose own data folder is called "publish"
+    /// still ships it. The caller knows where the publish directory is; a guess does not.
+    /// </summary>
+    [Fact]
+    public void ADirectoryMerelyCalledPublishIsStillPayload()
+    {
+        Given("Acme.dll", "content/publish/template.html");
+
+        Selected().Should().Contain("content/publish/template.html");
+    }
+
+    /// <summary>
+    /// The disk image lands BESIDE the app, in the publish directory, so the next publish copies it
+    /// into the bundle — and codesign refuses the whole bundle over it, because a .dmg is a
+    /// subcomponent it cannot sign. Found by publishing twice, which is the only way to find it: a
+    /// single clean publish writes the image after the bundle and passes.
+    /// </summary>
+    [Fact]
+    public void TheDiskImageIsNotPayloadOfTheNextBundle()
+    {
+        Given("Acme.dll", "Acme.dmg");
+
+        Selected(Path.Combine(_root, "Acme.dmg")).Should().Equal("Acme.dll");
+    }
+
+    /// <summary>And a file exclusion is the file, not a prefix: excluding <c>Acme.dmg</c> must not
+    /// take <c>Acme.dmg.manifest</c> with it.</summary>
+    [Fact]
+    public void ExcludingAFileTakesOnlyThatFile()
+    {
+        Given("Acme.dmg", "Acme.dmg.manifest");
+
+        Selected(Path.Combine(_root, "Acme.dmg")).Should().Equal("Acme.dmg.manifest");
+    }
+
+    [Fact]
+    public void PopulateRebuildsTheBundleRatherThanToppingItUp()
+    {
+        Given("Acme.dll", "Stale.dll");
+        var bundle = Path.Combine(_root, "out.app");
+        MacAppPayload.Populate(_root, bundle).Should().Be(2);
+
+        // The file leaves the payload — a package dropped, a RID newly excluded. A copy alone never
+        // removes anything, so the stale file stayed in the bundle forever and kept failing
+        // codesign long after the exclusion that should have removed it was fixed.
+        File.Delete(Path.Combine(_root, "Stale.dll"));
+        MacAppPayload.Populate(_root, bundle).Should().Be(1);
+
+        File.Exists(Path.Combine(bundle, "Contents", "MacOS", "Stale.dll")).Should().BeFalse();
+        File.Exists(Path.Combine(bundle, "Contents", "MacOS", "Acme.dll")).Should().BeTrue();
+    }
+}

--- a/tests/eQuantic.UI.Web.Tests/WikiVersionMarkTests.cs
+++ b/tests/eQuantic.UI.Web.Tests/WikiVersionMarkTests.cs
@@ -75,17 +75,27 @@ public class WikiVersionMarkTests
 
         var commits = Git(root, $"log --all --reverse --format=%H -S\"{search}\"{path}")
             .Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        if (commits.Length == 0) return null;
 
-        var tags = Git(root, $"tag --contains {commits[0]}")
-            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
-            .Where(tag => tag.StartsWith("v0.", StringComparison.Ordinal))
-            .Select(tag => (Tag: tag, Order: PreviewOrder(tag)))
-            .Where(entry => entry.Order >= 0)
-            .OrderBy(entry => entry.Order)
-            .ToList();
+        // The first commit a RELEASE contains, not simply the first commit. Every change reaches
+        // main as a SQUASH, so the branch commit that introduced a symbol is older than the commit
+        // that shipped it and no tag will ever contain it. Reading `commits[0]` alone therefore
+        // answered "not released yet" for every symbol whose branch still exists on the remote —
+        // and null is the answer this guard reads as "nothing to check", so the newest marks, the
+        // ones most likely to be wrong, were the ones silently skipped.
+        foreach (var commit in commits)
+        {
+            var tags = Git(root, $"tag --contains {commit}")
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Where(tag => tag.StartsWith("v0.", StringComparison.Ordinal))
+                .Select(tag => (Tag: tag, Order: PreviewOrder(tag)))
+                .Where(entry => entry.Order >= 0)
+                .OrderBy(entry => entry.Order)
+                .ToList();
 
-        return tags.Count == 0 ? null : tags[0].Tag[1..];
+            if (tags.Count > 0) return tags[0].Tag[1..];
+        }
+
+        return null;
     }
 
     /// <summary>Sorts preview.9 BEFORE preview.10 — the whole point of the check is off-by-one


### PR DESCRIPTION
## The gap this closes

The macOS `.app` was assembled from the BUILD output, and `dotnet publish` produced a directory of
loose files with no bundle in it. So every publish decision stopped at the bundle's door — trimming,
self-contained, single-file, AOT — and the artifact a developer would ship was the one the SDK had
never applied any of them to.

Measured on this repo's own desktop sample with `PublishTrimmed`:

| | before | after |
|---|---|---|
| `publish/` | 23 MB, no bundle | 23 MB **+ the `.app`** |
| the `.app` | 172 MB, from build output | 23 MB, from publish output |
| disk image | — | 9.8 MB, signed, mounts, app inside verifies |
| trim warnings | 5 | 0 |

This is W5 from `docs/DESKTOP-PLAN.md`, sequenced first among the independents there. Its acceptance
is "a notarized, stapled bundle from `dotnet publish`" — three of those four words are proven here,
and the fourth is stated honestly below.

## What an app author writes

Nothing new, unless they want one of the plist facts that used to be unreachable:

```csharp
builder.Bundle
       .Copyright("© 2026 Acme")
       .Category(AppCategory.Utilities)
       .MinimumSystemVersion("13.0")
       .Agent()                        // menu-bar only: Apple calls this LSUIElement
       .UrlScheme("acme");
```

The same journey the other two platform-fact families already take — a fluent call, an assembly
attribute from the generator, the platform's file from the build. Typed where a string would be a
platform incantation (`AppCategory.Utilities`, not `public.app-category.utilities`), with a narrow
escape hatch (`Key`/`Flag`) because Apple owns that key space and adds to it.

Shipping is MSBuild properties named like .NET's own:

```xml
<EQuanticSigningIdentity>Developer ID Application: Acme (TEAMID)</EQuanticSigningIdentity>
<EQuanticNotaryProfile>acme</EQuanticNotaryProfile>
<EQuanticPackageFormat>Dmg</EQuanticPackageFormat>
```

## Four things that were quietly wrong

- **Packaging output was payload.** The publish tree lives under the build output, so the
  development bundle swallowed an entire second copy of the app (86 MB). .NET nests those
  directories, so a RID build sits in there too. And the disk image lands beside the app, so the
  NEXT publish copied it into `Contents/MacOS` — codesign then refuses the whole bundle over a
  subcomponent it cannot sign. That last one only appears when you publish twice.
- **A trimmed app did not run.** Four defects, each the trimmer reading the same evidence the design
  relies on and concluding the opposite: the shell nothing references in code was removed; the
  runner and providers are built from a Type on an attribute; the root component is built by the
  container; and `PhotonOptions` was bound by reflection, so the app came up with every option at
  its default — a window that opens, ignores every setting, and never says why.
- **The version was not a version.** Apple's is one to three integers; this repository's own is
  `0.2.0-preview.46`, and it went into the plist verbatim. That bundle is refused by notarization
  and by the App Store, in a vocabulary that names nothing you wrote.
- **A wiki version mark on squash-merged work was never checked.** The guard took the first commit
  containing a symbol — which, under squash merges, is a branch commit no tag will ever contain, and
  a null answer is the one it reads as "nothing to check". So the newest marks were the skipped ones.

## What is NOT proven

**Notarization has never completed here.** The steps run in order and fail loudly on a profile that
does not exist — `ditto`, `notarytool submit --wait`, `stapler staple` — but nobody on this machine
holds a Developer ID, so no bundle in this PR has an Apple ticket. That is the one line of W5's
acceptance still owed, and it needs a certificate rather than more code.

**`UrlScheme` is half a feature, deliberately.** Declaring it makes macOS launch the app for
`acme://…`, which is real and useful — but nothing DELIVERS the URL to the app yet: `kAEGetURL`
handling is W4's, and the macOS shell has none today. So an app can be opened by a link and cannot
read it. The declaration ships because the plist half is the half this SDK owns and the two would
otherwise land in the wrong order (a handler for a scheme no app can declare). The delivery seam is
the next slice, and this note is here so nobody discovers the gap by writing the handler side first.

Two consequences worth naming rather than hiding:

- `AppCategory` and `PhotonBundleValueKind` are public enums of Primitives, so the enum-union
  generator mirrors them into the runtime's `enums.generated.ts`. They are erased types with no
  runtime cost, but they are not vocabulary. Left as is: the alternative rules for excluding them
  all risk dropping unions the runtime depends on.
- The desktop sample is published TRIMMED from now on, deliberately — it is where those seams show,
  and nothing else in the repo exercises them.

## Verification

- `dotnet build -c Release` on the whole solution: 0 errors (this caught the Android `MSB4096`).
- `eQuantic.UI.Native.Engine.Tests`: 1092 passed, including 22 new ones over the payload rules, the
  manifest, the plist and the version.
- `eQuantic.UI.Compiler.Tests`: 835 passed (EQ3005 documented and baselined).
- `eQuantic.UI.Web.Tests`: 617 passed.
- Clean publish of the desktop sample: `.app` + signed `.dmg`, zero IL warnings, image mounts and
  the app inside it verifies, and the app RUNS — 110 accessibility elements, IME probe, frames
  presented, identical to the untrimmed build.
