### PR TITLE
✨ feat: the deep link arrives, and an app can ask a person for a file

### DIFF
--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -96,6 +96,13 @@ hit-testing seam the headless-browser instrument proposal has been waiting for.
 
 The largest slice, all of it generic:
 
+**Started (2026-09-03).** The two the plan sequences early are in: `IDeepLinks` delivers the URL
+for the scheme W5 made declarable (`kAEGetURL`, installed before the run loop), and `IFileDialogs`
+wraps NSOpenPanel/NSSavePanel. One thing the live test taught, which is now in the contract's own
+docs: `Launch` is NOT readable in a constructor on macOS. AppleEvents are delivered by the run loop
+and the run loop starts after the first tree is built, so a cold launch reaches a SUBSCRIBER and
+finds the property still null a moment earlier. An app that does both is right everywhere.
+
 - Native menu bar (`NSMenu`, declarative) + context menus (right-click is not even delivered today)
 - Status item (tray) + an auxiliary panel window (`NSPanel`) — closes W-B7 for the real use case;
   general multi-window can wait
@@ -180,6 +187,27 @@ W4 (shell)      ──── partial early (file dialogs + deep links), rest aft
 What tripped a fresh consumer on their FIRST build — none blocking, all resolved at the call
 site. Recorded because each cost someone a build cycle, and the fix (rename, new API, doc line,
 editor suggestion) is a decision, not an oversight. Newest first.
+
+- **`ICanvasPainter` is a narrow window onto a display list that has more** (2026-09-03, OS Cleaner
+  sunburst + bubbles). Three reports in one day, and the third made the first two into one finding:
+  the painter draws no TEXT, takes a colour where the engine takes a PAINT, and draws no TEXTURES.
+  Each was met by redesigning around it, and the consumer judged two of the three redesigns better
+  — but they were choices made without a choice.
+  - *Text* is the deep one. There is no rotated text anywhere in Photon, `Text` included: the raster
+    measures an ink box and draws it upright. Giving the painter text is one thing; text along an
+    arc needs rotation in the rasterizer, and they are separate tickets so neither hides the other.
+  - *Gradient* looked like the cheap one and is NOT, which is worth recording because the wrong
+    estimate went out before it was checked. `Paint.Radial` exists and the shader honours it, but
+    its ramp starts at the CENTRE (`Sdf.slang`: `t = clamp(distance / radius, 0, 1)`) — there is no
+    inner radius, so a two-stop gradient ACROSS a band is not expressible. Extrapolating the stops
+    closes the arithmetic and dies on the representation: `Color` is a byte per channel, so the
+    extrapolated endpoints saturate exactly when the band is thin, which is every outer ring of a
+    sunburst. It needs an inner radius in the radial paint: a shader change with Reference↔Metal↔
+    Vulkan parity goldens behind it, W1-sized.
+  - *Texture* is decoration and they are content with the approximation.
+  - The consumer's own finding on the workaround is the part worth keeping: approximating that
+    gradient with TWO concentric bands LIES — the boundary reads as an extra ring, so a uniform disk
+    appears to have eight levels when it has four. Five bands is their floor, pinned by a test.
 
 - **`SizeValue` has no Fraction** (2026-08-26, OS Cleaner F1): width proportional to the parent —
   usage/size bars, a common data-app pattern — is done today with `Flexible` weights sharing

--- a/samples/PhotonDesktop/Studio/StudioShell.cs
+++ b/samples/PhotonDesktop/Studio/StudioShell.cs
@@ -44,17 +44,10 @@ public sealed class StudioShell : StatefulComponent
 
         // A LINK INTO THE APP. `builder.Bundle.UrlScheme("equantic-studio")` is what makes macOS
         // launch this app for equantic-studio://…; this is the other half — reading what it was
-        // launched with, and hearing the ones that arrive while it runs.
-        //
-        // Both halves, because a URL arrives at two moments and an app that handles one is broken
-        // half the time. Printed rather than shown: this is the sample's live proof, and `open
-        // equantic-studio://hello` from a terminal is how it is checked.
-        if (deepLinks is not null)
-        {
-            if (deepLinks.Launch is { } launched)
-                Console.WriteLine($"[photon] launched by {launched}");
-            _deepLink = deepLinks.Subscribe(url => Console.WriteLine($"[photon] opened by {url}"));
-        }
+        // launched with, and hearing the ones that arrive while it runs. Kept, subscribed in
+        // OnMount: the reconciler builds a fresh instance every pass and keeps the retained one, so
+        // a subscription started HERE is started again for an instance that is then thrown away.
+        _deepLinks = deepLinks;
         // The light/dark hand arrives like any capability. Seed from whatever the host opened
         // with, so the toggle never starts out of step with the window.
         _themeSwitch = themeSwitch;
@@ -183,9 +176,11 @@ public sealed class StudioShell : StatefulComponent
     private readonly IThemeController? _themeSwitch;
     private readonly ITextClipboard? _clipboard;
 
+    private readonly IDeepLinks? _deepLinks;
+
     /// <summary>Held so the app stops listening when the shell goes — the same contract every
     /// capability subscription has.</summary>
-    private readonly IDisposable? _deepLink;
+    private IDisposable? _deepLink;
     private Density _density = Density.Comfortable;
 
     // The inspector drives the Buttons section's live specimen. Loading and Disabled are
@@ -206,6 +201,32 @@ public sealed class StudioShell : StatefulComponent
 
     /// <summary>Section-local demo state, so every control on screen is really interactive.</summary>
     private readonly SectionState _demo = new();
+
+    /// <summary>
+    /// Both halves of a deep link, which is the point: a URL arrives at two very different moments
+    /// and an app that handles one is broken half the time. `Launch` answers what started this
+    /// process — and on macOS it is still null here, because AppleEvents are delivered by the run
+    /// loop and the run loop starts after this build. So the subscription is what actually catches
+    /// a cold launch, and reading `Launch` is what answers the question later.
+    /// <para>
+    /// Printed rather than shown: this is the sample's live proof, and
+    /// <c>open equantic-studio://hello</c> from a terminal is how it is checked.
+    /// </para>
+    /// </summary>
+    protected override void OnMount()
+    {
+        if (_deepLinks is null) return;
+        if (_deepLinks.Launch is { } launched) Console.WriteLine($"[photon] launched by {launched}");
+        _deepLink = _deepLinks.Subscribe(url => Console.WriteLine($"[photon] opened by {url}"));
+    }
+
+    /// <summary>The other half of the pair, which ships with it — without this every mount is a
+    /// leak.</summary>
+    protected override void OnUnmount()
+    {
+        _deepLink?.Dispose();
+        _deepLink = null;
+    }
 
     public override VisualNode Build(ComponentContext context)
     {

--- a/samples/PhotonDesktop/Studio/StudioShell.cs
+++ b/samples/PhotonDesktop/Studio/StudioShell.cs
@@ -37,9 +37,24 @@ public sealed class StudioShell : StatefulComponent
     public StudioShell(IConfiguration configuration, IPhotoLibrary? library = null,
         IBiometrics? biometrics = null, INetworkStatus? network = null, IMotionSensor? motion = null,
         ILocation? location = null, ICamera? camera = null, IThemeController? themeSwitch = null,
-        ITextClipboard? clipboard = null, ICultureController? culture = null)
+        ITextClipboard? clipboard = null, ICultureController? culture = null,
+        IDeepLinks? deepLinks = null)
     {
         _clipboard = clipboard;
+
+        // A LINK INTO THE APP. `builder.Bundle.UrlScheme("equantic-studio")` is what makes macOS
+        // launch this app for equantic-studio://…; this is the other half — reading what it was
+        // launched with, and hearing the ones that arrive while it runs.
+        //
+        // Both halves, because a URL arrives at two moments and an app that handles one is broken
+        // half the time. Printed rather than shown: this is the sample's live proof, and `open
+        // equantic-studio://hello` from a terminal is how it is checked.
+        if (deepLinks is not null)
+        {
+            if (deepLinks.Launch is { } launched)
+                Console.WriteLine($"[photon] launched by {launched}");
+            _deepLink = deepLinks.Subscribe(url => Console.WriteLine($"[photon] opened by {url}"));
+        }
         // The light/dark hand arrives like any capability. Seed from whatever the host opened
         // with, so the toggle never starts out of step with the window.
         _themeSwitch = themeSwitch;
@@ -167,6 +182,10 @@ public sealed class StudioShell : StatefulComponent
     private ThemeMode _mode = ThemeMode.Light;
     private readonly IThemeController? _themeSwitch;
     private readonly ITextClipboard? _clipboard;
+
+    /// <summary>Held so the app stops listening when the shell goes — the same contract every
+    /// capability subscription has.</summary>
+    private readonly IDisposable? _deepLink;
     private Density _density = Density.Comfortable;
 
     // The inspector drives the Buttons section's live specimen. Loading and Disabled are

--- a/src/eQuantic.UI.Native.Shell.Apple/AppleDeepLinks.cs
+++ b/src/eQuantic.UI.Native.Shell.Apple/AppleDeepLinks.cs
@@ -1,0 +1,88 @@
+using System.Runtime.InteropServices;
+using eQuantic.UI.Primitives;
+using static eQuantic.UI.Native.Shell.Apple.ObjC;
+
+namespace eQuantic.UI.Native.Shell.Apple;
+
+/// <summary>
+/// The URLs an Apple platform hands an app that is already running, delivered as an APPLE EVENT of
+/// all things — the mechanism is from 1993 and it is still the only one macOS has.
+/// <para>
+/// The handler is installed EARLY and once, before the app finishes launching, because a cold
+/// launch delivers its URL within milliseconds of the process starting: an app that installs the
+/// handler when its first screen mounts has already missed it. So the URL is BUFFERED here and
+/// answered by <see cref="Launch"/> on demand, rather than delivered to whoever happens to be
+/// listening at the time.
+/// </para>
+/// <para>
+/// Registered through the runtime like every other Apple delegate in this assembly
+/// (<c>objc_allocateClassPair</c> + <c>class_addMethod</c>), because an AppleEvent handler is a
+/// target and a SELECTOR — there is no block-taking form of it, which is why this could not simply
+/// use <see cref="ObjCBlock"/>.
+/// </para>
+/// </summary>
+public static class AppleDeepLinks
+{
+    // 'GURL' and '----', as the four-character codes AppleEvents are addressed by. Spelled from
+    // their characters rather than as magic numbers, because that is what they ARE and because a
+    // typo in a hex literal here produces a handler that is simply never called.
+    private static readonly uint InternetEventClass = FourCharCode("GURL");
+    private static readonly uint GetUrlEventId = FourCharCode("GURL");
+    private static readonly uint KeyDirectObject = FourCharCode("----");
+
+    private delegate void HandleUrlEvent(IntPtr self, IntPtr cmd, IntPtr eventDescriptor, IntPtr reply);
+
+    private static readonly object Gate = new();
+    private static DeepLinkRelay? _relay;
+    private static HandleUrlEvent? _onUrl;          // kept alive for the runtime's sake
+    private static IntPtr _handlerClass;
+    private static IntPtr _handler;
+
+    /// <summary>
+    /// Installs the handler and returns the relay behind it. Called by the shell BEFORE the run
+    /// loop starts — the whole point is to be listening before the launch event arrives, and
+    /// nothing an app writes can be early enough. Idempotent: the second caller gets the first
+    /// caller's relay, which is what makes the container's registration safe.
+    /// </summary>
+    public static DeepLinkRelay Install()
+    {
+        lock (Gate)
+        {
+            if (_relay is not null) return _relay;
+            _relay = new DeepLinkRelay();
+
+            _handlerClass = objc_allocateClassPair(objc_getClass("NSObject"), "EQDeepLinkHandler", 0);
+            _onUrl = static (_, _, descriptor, _) => Deliver(descriptor);
+            class_addMethod(_handlerClass, sel_registerName("handleURLEvent:withReplyEvent:"),
+                Marshal.GetFunctionPointerForDelegate(_onUrl), "v@:@@");
+            objc_registerClassPair(_handlerClass);
+
+            _handler = Send(Send(_handlerClass, Sel("alloc")), Sel("init"));
+
+            var manager = Send(objc_getClass("NSAppleEventManager"), Sel("sharedAppleEventManager"));
+            SendVoid(manager, Sel("setEventHandler:andSelector:forEventClass:andEventID:"),
+                _handler, sel_registerName("handleURLEvent:withReplyEvent:"),
+                InternetEventClass, GetUrlEventId);
+
+            return _relay;
+        }
+    }
+
+    /// <summary>The one line of interop: an AppleEvent's direct object, as text. Everything that
+    /// happens to it afterwards is <see cref="DeepLinkRelay"/>'s, where it can be tested.</summary>
+    private static void Deliver(IntPtr descriptor)
+    {
+        if (descriptor == IntPtr.Zero) return;
+        var direct = Send(descriptor, Sel("paramDescriptorForKeyword:"), KeyDirectObject);
+        if (direct == IntPtr.Zero) return;
+
+        DeepLinkRelay? relay;
+        lock (Gate) relay = _relay;
+        relay?.Offer(FromNSString(Send(direct, Sel("stringValue"))));
+    }
+
+    /// <summary>Four characters, most significant first — the layout an OSType has had since
+    /// before any of this was a framework.</summary>
+    internal static uint FourCharCode(string code) =>
+        ((uint)code[0] << 24) | ((uint)code[1] << 16) | ((uint)code[2] << 8) | code[3];
+}

--- a/src/eQuantic.UI.Native.Shell.Apple/ObjC.cs
+++ b/src/eQuantic.UI.Native.Shell.Apple/ObjC.cs
@@ -127,6 +127,18 @@ public static partial class ObjC
     public static partial IntPtr Send(IntPtr receiver, IntPtr selector,
         CGRect rect, ulong options, IntPtr owner, IntPtr userInfo);
 
+    // The shape NSAppleEventManager wants: a target, a selector, and two four-character codes.
+    // An AEEventClass and an AEEventID are UInt32, and passing them as anything wider puts the code
+    // in the wrong half of the register on a big-endian reading of the same four bytes — they are
+    // literally the characters 'GURL', so a wrong width is a handler that is never called.
+    [LibraryImport(ObjCLib, EntryPoint = "objc_msgSend")]
+    public static partial void SendVoid(IntPtr receiver, IntPtr selector,
+        IntPtr handler, IntPtr handlerSelector, uint eventClass, uint eventId);
+
+    /// <summary>An AppleEvent parameter, by its four-character keyword.</summary>
+    [LibraryImport(ObjCLib, EntryPoint = "objc_msgSend")]
+    public static partial IntPtr Send(IntPtr receiver, IntPtr selector, uint keyword);
+
     [LibraryImport(ObjCLib, EntryPoint = "objc_msgSend")]
     public static partial void SendVoid(IntPtr receiver, IntPtr selector);
 

--- a/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacFileDialogs.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacFileDialogs.cs
@@ -1,0 +1,147 @@
+using eQuantic.UI.Primitives;
+using static eQuantic.UI.Native.Shell.Apple.ObjC;
+
+namespace eQuantic.UI.Native.Shell.MacOS;
+
+/// <summary>
+/// NSOpenPanel and NSSavePanel, which are the Mac's answer to every one of these questions and the
+/// only way a sandboxed app is handed something it was not given.
+/// <para>
+/// A panel is MODAL and main-thread-only: <c>runModal</c> spins its own run loop until the person
+/// answers, and one opened from a worker thread does not open at all — it simply never appears,
+/// with no error anywhere. So every call marshals through <see cref="IUiDispatcher"/> first, which
+/// is exactly the seam that exists for this.
+/// </para>
+/// </summary>
+public sealed class MacFileDialogs : IFileDialogs
+{
+    private const long ModalResponseOk = 1;
+
+    /// <inheritdoc />
+    public Task<string?> PickFile(string? title, IReadOnlyList<FileFilter>? filters, string? startIn) =>
+        OnUiThread(() => Open(title, filters, startIn, folders: false, multiple: false) is [var one, ..] ? one : null);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<string>> PickFiles(string? title, IReadOnlyList<FileFilter>? filters,
+        string? startIn) =>
+        OnUiThread<IReadOnlyList<string>>(() => Open(title, filters, startIn, folders: false, multiple: true));
+
+    /// <inheritdoc />
+    public Task<string?> PickFolder(string? title, string? startIn) =>
+        OnUiThread(() => Open(title, null, startIn, folders: true, multiple: false) is [var one, ..] ? one : null);
+
+    /// <inheritdoc />
+    public Task<string?> PickSavePath(string? suggestedName, string? title,
+        IReadOnlyList<FileFilter>? filters, string? startIn) =>
+        OnUiThread(() => Save(suggestedName, title, filters, startIn));
+
+    private static List<string> Open(string? title, IReadOnlyList<FileFilter>? filters, string? startIn,
+        bool folders, bool multiple)
+    {
+        var panel = Send(objc_getClass("NSOpenPanel"), Sel("openPanel"));
+        if (panel == IntPtr.Zero) return [];
+
+        SendVoid(panel, Sel("setCanChooseFiles:"), !folders);
+        SendVoid(panel, Sel("setCanChooseDirectories:"), folders);
+        SendVoid(panel, Sel("setAllowsMultipleSelection:"), multiple);
+        // A folder picker must NOT resolve an alias to its target: "choose the folder" means the
+        // one that was clicked.
+        SendVoid(panel, Sel("setResolvesAliases:"), !folders);
+        Configure(panel, title, filters, startIn);
+
+        if (SendLong(panel, Sel("runModal")) != ModalResponseOk) return [];
+
+        var urls = Send(panel, Sel("URLs"));
+        var count = (long)SendULong(urls, Sel("count"));
+        var chosen = new List<string>((int)count);
+        for (long index = 0; index < count; index++)
+        {
+            if (FromNSString(Send(Send(urls, Sel("objectAtIndex:"), index), Sel("path"))) is { Length: > 0 } path)
+                chosen.Add(path);
+        }
+
+        return chosen;
+    }
+
+    private static string? Save(string? suggestedName, string? title, IReadOnlyList<FileFilter>? filters,
+        string? startIn)
+    {
+        var panel = Send(objc_getClass("NSSavePanel"), Sel("savePanel"));
+        if (panel == IntPtr.Zero) return null;
+
+        if (!string.IsNullOrWhiteSpace(suggestedName))
+            SendVoid(panel, Sel("setNameFieldStringValue:"), NSString(suggestedName));
+        Configure(panel, title, filters, startIn);
+
+        return SendLong(panel, Sel("runModal")) != ModalResponseOk
+            ? null
+            : FromNSString(Send(Send(panel, Sel("URL")), Sel("path")));
+    }
+
+    private static void Configure(IntPtr panel, string? title, IReadOnlyList<FileFilter>? filters,
+        string? startIn)
+    {
+        // `message` and not `title`: a Mac panel's title bar is the app's, and the sentence a
+        // person actually reads is the message above the file list. Setting `title` instead puts
+        // the text where nobody looks.
+        if (!string.IsNullOrWhiteSpace(title)) SendVoid(panel, Sel("setMessage:"), NSString(title));
+
+        if (!string.IsNullOrWhiteSpace(startIn) && Directory.Exists(startIn))
+        {
+            var url = Send(objc_getClass("NSURL"), Sel("fileURLWithPath:"), NSString(startIn));
+            if (url != IntPtr.Zero) SendVoid(panel, Sel("setDirectoryURL:"), url);
+        }
+
+        if (ContentTypes(filters) is { } types) SendVoid(panel, Sel("setAllowedContentTypes:"), types);
+    }
+
+    /// <summary>
+    /// The extensions as UTTypes, or null when there is nothing to restrict. UTType and not the old
+    /// <c>allowedFileTypes</c>: that one has been deprecated since macOS 12 and takes the same
+    /// strings, so the only thing the deprecated call would buy is a warning later.
+    /// <para>
+    /// An extension the system does not know produces a NULL type, and a null inside the array is a
+    /// crash rather than a lenient dialog — so unknown ones are dropped, and a filter list that
+    /// drops to nothing restricts nothing rather than restricting everything away.
+    /// </para>
+    /// </summary>
+    private static IntPtr? ContentTypes(IReadOnlyList<FileFilter>? filters)
+    {
+        if (filters is null || filters.Count == 0) return null;
+
+        var utType = objc_getClass("UTType");
+        if (utType == IntPtr.Zero) return null;
+
+        var types = Send(objc_getClass("NSMutableArray"), Sel("array"));
+        foreach (var extension in filters
+                     .SelectMany(filter => filter.Extensions)
+                     .Select(extension => extension.TrimStart('.').Trim())
+                     .Where(extension => extension.Length > 0)
+                     .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var type = Send(utType, Sel("typeWithFilenameExtension:"), NSString(extension));
+            if (type != IntPtr.Zero) SendVoid(types, Sel("addObject:"), type);
+        }
+
+        return (long)SendULong(types, Sel("count")) > 0 ? types : null;
+    }
+
+    /// <summary>
+    /// Runs the panel where AppKit allows one. Already on the UI thread, it runs INLINE — a modal
+    /// posted to the next frame would deadlock a caller that awaits it from inside an event handler,
+    /// because the frame that would run it is the one waiting.
+    /// </summary>
+    private static Task<T> OnUiThread<T>(Func<T> work)
+    {
+        if (UiDispatcher.Current is not { IsOnUiThread: false } dispatcher)
+            return Task.FromResult(work());
+
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        dispatcher.Post(() =>
+        {
+            try { completion.SetResult(work()); }
+            catch (Exception error) { completion.SetException(error); }
+        });
+        return completion.Task;
+    }
+}

--- a/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacOSCapabilities.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacOSCapabilities.cs
@@ -32,5 +32,12 @@ public sealed class MacOSCapabilities : IPhotonCapabilities
         // The platform's vault, for what IAppStorage must never hold. Keychain on both Apple
         // platforms — one realization, because SecItem* is one API on both.
         services.TryAddSingleton<ISecretStore, AppleSecretStore>();
+        // The URLs this app is opened WITH. Registered as the INSTANCE the shell already installed:
+        // the AppleEvent handler has to be listening before the app finishes launching, so the
+        // object exists before the container does, and asking the container to build a second one
+        // would give the app a listener that hears nothing.
+        services.TryAddSingleton<IDeepLinks>(_ => AppleDeepLinks.Install());
+        // Asking a PERSON for a file — the one way a sandboxed app touches what it was not given.
+        services.TryAddSingleton<IFileDialogs, MacFileDialogs>();
     }
 }

--- a/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacOSCapabilities.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacOSCapabilities.cs
@@ -32,10 +32,10 @@ public sealed class MacOSCapabilities : IPhotonCapabilities
         // The platform's vault, for what IAppStorage must never hold. Keychain on both Apple
         // platforms — one realization, because SecItem* is one API on both.
         services.TryAddSingleton<ISecretStore, AppleSecretStore>();
-        // The URLs this app is opened WITH. Registered as the INSTANCE the shell already installed:
-        // the AppleEvent handler has to be listening before the app finishes launching, so the
-        // object exists before the container does, and asking the container to build a second one
-        // would give the app a listener that hears nothing.
+        // The URLs this app is opened WITH. The runner installs the handler as its FIRST act, well
+        // before the run loop that delivers AppleEvents; Install() is idempotent, so whichever of
+        // the two runs first — the runner, or the first app that resolves this — the other gets the
+        // same relay. Building a second one here would give the app a listener that hears nothing.
         services.TryAddSingleton<IDeepLinks>(_ => AppleDeepLinks.Install());
         // Asking a PERSON for a file — the one way a sandboxed app touches what it was not given.
         services.TryAddSingleton<IFileDialogs, MacFileDialogs>();

--- a/src/eQuantic.UI.Native.Shell.MacOS/MacOSPhotonRunner.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/MacOSPhotonRunner.cs
@@ -28,6 +28,14 @@ public sealed class MacOSPhotonRunner : IPhotonRunner
                 + "needs no window at all.");
         }
 
+        // BEFORE anything else, and before the run loop exists: a cold launch delivers its URL as
+        // an AppleEvent within milliseconds of the process starting, so the handler has to be
+        // listening already. Installing it when a component first asks for IDeepLinks is installing
+        // it after the only delivery that mattered. Idempotent — the container hands out this same
+        // instance.
+        AppKit.LoadFrameworks();
+        Shell.Apple.AppleDeepLinks.Install();
+
         var options = app.Options;
 
         // The platform's locale, copied onto .NET BEFORE anything renders (screenshots included):

--- a/src/eQuantic.UI.Primitives/Devices/IDeepLinks.cs
+++ b/src/eQuantic.UI.Primitives/Devices/IDeepLinks.cs
@@ -21,7 +21,6 @@ namespace eQuantic.UI.Primitives;
 /// reads it, in the one line the two-callers shape asks for.</item>
 /// </list>
 /// <para>
-/// <para>
 /// SUBSCRIBE if you must not miss it. <see cref="Launch"/> is not readable in a constructor on
 /// macOS, measured rather than assumed: the launch URL arrives as an AppleEvent, AppleEvents are
 /// delivered BY the run loop, and the run loop starts after the first tree is built. A cold launch
@@ -106,9 +105,10 @@ public sealed class DeepLinkRelay : IDeepLinks
         Action<Uri>[] listeners;
         lock (_gate)
         {
-            // The FIRST one is the launch URL. It is answered by Launch rather than delivered,
-            // because on a cold start nothing is subscribed yet — the app that will read it does
-            // not exist when this runs.
+            // The FIRST one is the launch URL, whoever else also hears it. Recording it is what
+            // lets an app ASK later what it was opened with — including the app that heard it
+            // through a subscription a moment ago and wants to answer the question again on a
+            // screen built after.
             _launch ??= url;
             listeners = [.. _listeners];
         }

--- a/src/eQuantic.UI.Primitives/Devices/IDeepLinks.cs
+++ b/src/eQuantic.UI.Primitives/Devices/IDeepLinks.cs
@@ -1,0 +1,133 @@
+namespace eQuantic.UI.Primitives;
+
+/// <summary>
+/// The URLs this app is opened WITH — a licence e-mail's <c>acme://activate?key=…</c>, a link back
+/// from a browser sign-in, a colleague pasting a link to one screen of the app.
+/// <para>
+/// The declaration half already exists: <c>builder.Bundle.UrlScheme("acme")</c> writes the manifest
+/// entry that makes the operating system launch this app for that scheme. This is the other half —
+/// the app READING what it was launched with. Without it a deep link opens the app at its front
+/// door and the URL is silently dropped, which looks to a user exactly like a broken link.
+/// </para>
+/// <para>
+/// Two ways in, because a URL arrives at two very different moments and an app that handles only
+/// one is broken half the time:
+/// </para>
+/// <list type="bullet">
+/// <item><see cref="Launch"/> — the URL that STARTED this process, buffered and answered on demand.
+/// Reading it twice gives the same answer, and it keeps answering for the life of the app.</item>
+/// <item><see cref="Subscribe"/> — every URL from now on, for the app that is already running when
+/// the link is clicked. <see cref="Launch"/> is NOT replayed here: a subscriber that also wants it
+/// reads it, in the one line the two-callers shape asks for.</item>
+/// </list>
+/// <para>
+/// <para>
+/// SUBSCRIBE if you must not miss it. <see cref="Launch"/> is not readable in a constructor on
+/// macOS, measured rather than assumed: the launch URL arrives as an AppleEvent, AppleEvents are
+/// delivered BY the run loop, and the run loop starts after the first tree is built. A cold launch
+/// therefore reaches a subscriber and finds <see cref="Launch"/> still null a moment earlier. The
+/// property is for asking later — "what was this app opened with" — and the subscription is for
+/// acting on it. An app that does both is right on every platform, which is why the sample does.
+/// </para>
+/// <para>
+/// A URL the app cannot make sense of is still delivered. Deciding what an unknown host or path
+/// means is the app's, and a capability that silently swallowed what it did not recognise would be
+/// deciding on the app's behalf and leaving no evidence.
+/// </para>
+/// <para>
+/// The callback may arrive on any thread the platform chooses; a component's <c>SetState</c>
+/// already marshals through <see cref="IUiDispatcher"/>.
+/// </para>
+/// <para>
+/// PHOTON ONLY, deliberately. On the web a "deep link" is just the address bar, and the router
+/// already owns it — offering a second, weaker way to read the same thing would be a capability
+/// that exists to be symmetrical rather than to be used.
+/// </para>
+/// </summary>
+public interface IDeepLinks
+{
+    /// <summary>
+    /// The URL this app was launched with, or null when it was started normally. Answers from a
+    /// buffer and never blocks, so it is safe to read inside a Build.
+    /// </summary>
+    Uri? Launch { get; }
+
+    /// <summary>
+    /// Starts listening for the URLs that arrive from now on. Disposing stops it; disposing twice
+    /// is fine. <see cref="Launch"/> is not replayed — read it if you want it.
+    /// </summary>
+    IDisposable Subscribe(Action<Uri> onOpened);
+}
+
+/// <summary>
+/// The BUFFERING and the fan-out, which every platform needs and none of them does differently.
+/// <para>
+/// A shell feeds it whatever its own mechanism produced — an AppleEvent's direct object on macOS,
+/// <c>application:openURL:</c> on iOS, an Intent's data on Android — and this decides the rest:
+/// what the launch URL was, who hears about the later ones, and what to do with a string that is
+/// not a URL at all.
+/// </para>
+/// <para>
+/// Separated from the platform because the interesting part is not the plumbing. "The FIRST URL is
+/// the launch URL and is answered rather than delivered" is a rule with a test; reading a
+/// descriptor is a line of interop with none.
+/// </para>
+/// </summary>
+public sealed class DeepLinkRelay : IDeepLinks
+{
+    private readonly Lock _gate = new();
+    private readonly List<Action<Uri>> _listeners = [];
+    private Uri? _launch;
+
+    /// <inheritdoc />
+    public Uri? Launch
+    {
+        get { lock (_gate) return _launch; }
+    }
+
+    /// <inheritdoc />
+    public IDisposable Subscribe(Action<Uri> onOpened)
+    {
+        ArgumentNullException.ThrowIfNull(onOpened);
+        lock (_gate) _listeners.Add(onOpened);
+        return new Subscription(this, onOpened);
+    }
+
+    /// <summary>
+    /// A URL the platform just handed over. Returns whether it was one at all: a string that does
+    /// not parse is DROPPED rather than passed on, because <see cref="IDeepLinks"/> promises a
+    /// <see cref="Uri"/> and inventing one would be worse than saying no. Anything that parses is
+    /// delivered even if the app will not recognise it — that is the app's decision to make.
+    /// </summary>
+    public bool Offer(string? text)
+    {
+        if (!Uri.TryCreate(text?.Trim(), UriKind.Absolute, out var url)) return false;
+
+        Action<Uri>[] listeners;
+        lock (_gate)
+        {
+            // The FIRST one is the launch URL. It is answered by Launch rather than delivered,
+            // because on a cold start nothing is subscribed yet — the app that will read it does
+            // not exist when this runs.
+            _launch ??= url;
+            listeners = [.. _listeners];
+        }
+
+        // OUTSIDE the lock: a listener that subscribes or disposes from inside its own callback is
+        // an ordinary thing for a component to do while it is being torn down.
+        foreach (var listener in listeners) listener(url);
+        return true;
+    }
+
+    private sealed class Subscription(DeepLinkRelay relay, Action<Uri> listener) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            lock (relay._gate) relay._listeners.Remove(listener);
+        }
+    }
+}

--- a/src/eQuantic.UI.Primitives/Devices/IFileDialogs.cs
+++ b/src/eQuantic.UI.Primitives/Devices/IFileDialogs.cs
@@ -1,0 +1,67 @@
+namespace eQuantic.UI.Primitives;
+
+/// <summary>
+/// One entry in a picker's format list — the label a person reads and the extensions it stands for.
+/// <para>
+/// Extensions WITHOUT the dot ("png", not ".png"): the platforms disagree about the dot and every
+/// one of them is happy to accept a filter that matches nothing, so the framework normalizes rather
+/// than letting a leading dot silently empty a dialog.
+/// </para>
+/// </summary>
+/// <param name="Label">What the person reads: "Images", "Spreadsheets".</param>
+/// <param name="Extensions">The extensions it covers.</param>
+public sealed record FileFilter(string Label, params string[] Extensions);
+
+/// <summary>
+/// Asking a PERSON for a file, a set of files, a folder, or a place to save — the one way a
+/// sandboxed app is allowed to touch anything it was not given, and the reason
+/// <c>PhotonEntitlements.UserSelectedFiles</c> exists.
+/// <para>
+/// Every method answers with a PATH, and null when the person cancelled. Cancelling is an ordinary
+/// answer rather than an exception: a person closing a dialog has not failed at anything, and an
+/// app that has to catch to find out is an app that will forget to.
+/// </para>
+/// <para>
+/// The dialogs are MODAL, which is the platform's decision and not this contract's — a Mac panel
+/// runs its own loop until it is answered. The task therefore completes when the person does. Call
+/// from anywhere: the realization marshals to the UI thread itself, because a panel opened from a
+/// worker thread on macOS does not open at all.
+/// </para>
+/// <para>
+/// A path is good for THIS RUN. On a sandboxed app the permission a person granted by choosing a
+/// file does not survive a relaunch — that needs a security-scoped bookmark, which is a different
+/// currency and is not offered here yet. An app that wants to reopen last time's file must ask
+/// again, and one that stores the path and reads it on next launch will be refused with no
+/// explanation. Said here because the failure appears only after shipping, only when sandboxed.
+/// </para>
+/// <para>
+/// DESKTOP for now, deliberately. A phone's document picker returns a security-scoped URL rather
+/// than a path, and a capability that answered "a path" on one platform and "a thing that looks
+/// like a path and is not" on another would be worse than one that says where it applies.
+/// </para>
+/// </summary>
+public interface IFileDialogs
+{
+    /// <summary>One file, or null if the person cancelled.</summary>
+    /// <param name="title">The sentence at the top of the panel — say what the file is FOR.</param>
+    /// <param name="filters">What may be chosen. Empty means anything.</param>
+    /// <param name="startIn">The folder to open at. Ignored when it does not exist.</param>
+    Task<string?> PickFile(string? title = null, IReadOnlyList<FileFilter>? filters = null,
+        string? startIn = null);
+
+    /// <summary>Several files. EMPTY when the person cancelled — never null, because a caller that
+    /// is about to loop should not have to ask twice.</summary>
+    Task<IReadOnlyList<string>> PickFiles(string? title = null,
+        IReadOnlyList<FileFilter>? filters = null, string? startIn = null);
+
+    /// <summary>One folder, or null if the person cancelled.</summary>
+    Task<string?> PickFolder(string? title = null, string? startIn = null);
+
+    /// <summary>
+    /// Where to save, or null if the person cancelled. The path may name a file that does not exist
+    /// yet, which is the point; the platform has already asked about overwriting by the time this
+    /// answers.
+    /// </summary>
+    Task<string?> PickSavePath(string? suggestedName = null, string? title = null,
+        IReadOnlyList<FileFilter>? filters = null, string? startIn = null);
+}

--- a/tests/eQuantic.UI.Native.Engine.Tests/DeepLinkRelayTests.cs
+++ b/tests/eQuantic.UI.Native.Engine.Tests/DeepLinkRelayTests.cs
@@ -1,0 +1,183 @@
+using eQuantic.UI.Primitives;
+using FluentAssertions;
+
+namespace eQuantic.UI.Native.Engine.Tests;
+
+/// <summary>
+/// What a deep link DOES once a platform has produced one. The plumbing differs on every target —
+/// an AppleEvent on macOS, <c>application:openURL:</c> on iOS, an Intent on Android — and none of
+/// them differs in what happens next, which is why the rules live here where they can be tested.
+/// </summary>
+public class DeepLinkRelayTests
+{
+    [Fact]
+    public void TheFirstUrlIsTheLaunchUrl_AndIsAnsweredRatherThanDelivered()
+    {
+        var relay = new DeepLinkRelay();
+        relay.Launch.Should().BeNull("an app started normally was launched with nothing");
+
+        relay.Offer("acme://activate?key=abc").Should().BeTrue();
+
+        relay.Launch.Should().Be(new Uri("acme://activate?key=abc"));
+    }
+
+    /// <summary>
+    /// The trap this exists to close: on a cold start the URL arrives before any component does, so
+    /// a relay that only DELIVERED would hand it to nobody. Reading it later must still work, and
+    /// must keep working — a component is torn down and rebuilt, and each rebuild reads again.
+    /// </summary>
+    [Fact]
+    public void TheLaunchUrlSurvivesBeingRead()
+    {
+        var relay = new DeepLinkRelay();
+        relay.Offer("acme://one");
+
+        relay.Launch.Should().Be(new Uri("acme://one"));
+        relay.Launch.Should().Be(new Uri("acme://one"));
+    }
+
+    /// <summary>And it is the FIRST one, not the latest: a link clicked while the app runs did not
+    /// launch it.</summary>
+    [Fact]
+    public void ALaterUrlDoesNotBecomeTheLaunchUrl()
+    {
+        var relay = new DeepLinkRelay();
+        relay.Offer("acme://first");
+        relay.Offer("acme://second");
+
+        relay.Launch.Should().Be(new Uri("acme://first"));
+    }
+
+    [Fact]
+    public void ASubscriberHearsEveryUrlFromWhenItSubscribed()
+    {
+        var relay = new DeepLinkRelay();
+        var heard = new List<Uri>();
+        using var subscription = relay.Subscribe(heard.Add);
+
+        relay.Offer("acme://one");
+        relay.Offer("acme://two");
+
+        heard.Should().Equal(new Uri("acme://one"), new Uri("acme://two"));
+    }
+
+    /// <summary>
+    /// The launch URL is NOT replayed on subscribe. Two subscribers would otherwise disagree about
+    /// whether they had seen it — the first one would, the second would not — and the app would act
+    /// on the same link twice.
+    /// </summary>
+    [Fact]
+    public void SubscribingDoesNotReplayTheLaunchUrl()
+    {
+        var relay = new DeepLinkRelay();
+        relay.Offer("acme://launch");
+
+        var heard = new List<Uri>();
+        using var subscription = relay.Subscribe(heard.Add);
+
+        heard.Should().BeEmpty();
+        relay.Launch.Should().Be(new Uri("acme://launch"), "reading it is how you get it");
+    }
+
+    [Fact]
+    public void DisposingStopsDelivery_AndDisposingTwiceIsFine()
+    {
+        var relay = new DeepLinkRelay();
+        var heard = new List<Uri>();
+        var subscription = relay.Subscribe(heard.Add);
+
+        relay.Offer("acme://before");
+        subscription.Dispose();
+        subscription.Dispose();
+        relay.Offer("acme://after");
+
+        heard.Should().ContainSingle().Which.Should().Be(new Uri("acme://before"));
+    }
+
+    /// <summary>
+    /// A component that unsubscribes from inside its own callback is an ordinary thing — it is what
+    /// "handle the first link and stop listening" looks like. Delivering under the lock would
+    /// deadlock on it.
+    /// </summary>
+    [Fact]
+    public void AListenerMayUnsubscribeFromInsideItsOwnCallback()
+    {
+        var relay = new DeepLinkRelay();
+        var heard = new List<Uri>();
+        IDisposable? subscription = null;
+        subscription = relay.Subscribe(url =>
+        {
+            heard.Add(url);
+            subscription!.Dispose();
+        });
+
+        relay.Offer("acme://one");
+        relay.Offer("acme://two");
+
+        heard.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// What is not a URL is DROPPED rather than passed on — the contract promises a Uri, and
+    /// inventing one is worse than saying no. The answer says which happened, so a shell can log it.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a url")]
+    public void WhatIsNotAUrlIsDropped(string? text)
+    {
+        var relay = new DeepLinkRelay();
+        var heard = new List<Uri>();
+        using var subscription = relay.Subscribe(heard.Add);
+
+        relay.Offer(text).Should().BeFalse();
+
+        heard.Should().BeEmpty();
+        relay.Launch.Should().BeNull("a string that is not a URL did not launch anything either");
+    }
+
+    /// <summary>
+    /// A URL the app will not RECOGNISE is still delivered. Deciding what an unknown host means is
+    /// the app's, and a relay that swallowed what it did not know would be deciding on the app's
+    /// behalf and leaving no evidence.
+    /// </summary>
+    [Fact]
+    public void AUrlTheAppMayNotRecogniseIsStillDelivered()
+    {
+        var relay = new DeepLinkRelay();
+        var heard = new List<Uri>();
+        using var subscription = relay.Subscribe(heard.Add);
+
+        relay.Offer("acme://something-nobody-implemented/yet?with=params").Should().BeTrue();
+
+        heard.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A rooted PATH parses — .NET reads it as an implicit file URI — so it is delivered as one
+    /// rather than dropped. Documented rather than forbidden: a `file:` link is a real deep link on
+    /// a desktop, and a rule that rejected it to keep this test tidy would reject that too.
+    /// </summary>
+    [Fact]
+    public void ARootedPathArrivesAsAFileUrl()
+    {
+        var relay = new DeepLinkRelay();
+
+        relay.Offer("/Users/someone/file.txt").Should().BeTrue();
+
+        relay.Launch!.Scheme.Should().Be("file");
+        relay.Launch!.AbsolutePath.Should().Be("/Users/someone/file.txt");
+    }
+
+    [Fact]
+    public void SurroundingWhitespaceIsNotPartOfTheUrl()
+    {
+        var relay = new DeepLinkRelay();
+
+        relay.Offer("  acme://trimmed  ").Should().BeTrue();
+
+        relay.Launch.Should().Be(new Uri("acme://trimmed"));
+    }
+}


### PR DESCRIPTION
## What this closes

The last release made a URL scheme declarable — `builder.Bundle.UrlScheme("acme")` writes the
manifest entry that makes macOS **launch** the app for `acme://…` — and nothing delivered the URL.
A link opened the app at its front door and dropped what it was carrying, which to the person who
clicked it is indistinguishable from a broken link. I shipped that half deliberately and said so in
#75; this is the other half.

With it, the two things `docs/DESKTOP-PLAN.md` sequences early in W4:

```csharp
// what the app was opened WITH
if (deepLinks.Launch is { } url) Activate(url);
using var _ = deepLinks.Subscribe(Activate);

// and what it asks a person for
var folder = await dialogs.PickFolder("Choose a folder to scan");
var report = await dialogs.PickSavePath("report.csv", filters: [new FileFilter("Spreadsheets", "csv")]);
```

## What the live test changed

**`Launch` is not readable in a constructor on macOS.** Measured, not assumed: AppleEvents are
delivered *by* the run loop and the run loop starts after the first tree is built, so a cold launch
reaches a **subscriber** and finds the property still null a moment earlier. The contract now says
so, both halves are documented for what they are — subscribe to act, read to ask later — and the
sample does both, which is right on every platform.

That is the whole reason the buffering and fan-out live in `DeepLinkRelay` rather than inside the
interop: macOS, iOS and Android all need those rules and none of them does them differently, and
"the FIRST URL is the launch URL and is answered rather than delivered" is a rule with a test.
Reading an AppleEvent descriptor is one line with no test worth writing.

## Verification

**The deep link is proven live, both ways.**

- *Warm* — the sample running, then `open "equantic-studio://hello?from=terminal"` from a terminal:
  one process before, one after (so it was delivered, not a second launch), and the app logged
  `[photon] opened by equantic-studio://hello/?from=terminal`.
- *Cold* — a probe copy of the bundle with its own scheme and identifier, registered with Launch
  Services, with the app NOT running: `open "eq-cold-probe://activate?key=abc123"` started it and it
  logged the URL. This is the run that showed `Launch` empty at construction time and taught the
  paragraph above. The probe is removed and unregistered.
- 14 tests over the relay: the launch URL survives being read, a later URL does not replace it,
  subscribing does not replay it, disposing stops delivery and twice is fine, a listener may
  unsubscribe from inside its own callback, what is not a URL is dropped, what the app may not
  recognise is still delivered.

**The file dialogs are wired and registered, and not driven live.** A modal panel needs a person to
answer it, and nothing here can click Open — so the honest statement is that the plumbing compiles,
the capability resolves, and the first real proof will come from an app with a human in front of it.
The consumer building a disk scanner needs `PickFolder` and is the natural first prover.

- `dotnet build -c Release` across the solution: 0 errors.
- `eQuantic.UI.Native.Engine.Tests`: 1107 passed.

## Also

`docs/DESKTOP-PLAN.md` records W4's start, and the friction ledger gains the three `ICanvasPainter`
reports that arrived while this was being written — no text, a colour where the engine takes a
paint, no textures. The middle one is worth reading before anyone estimates it: it looks like
exposing a parameter that already exists and it is not. `Paint.Radial`'s ramp starts at the CENTRE,
so a two-stop gradient *across* a band is not expressible; extrapolating the stops closes the
arithmetic and dies on the representation, because `Color` is a byte per channel and the
extrapolated endpoints saturate exactly when the band is thin. I had already told the consumer it
was cheap before checking, and corrected it.