### PR TITLE
🔧 chore: 0.2.0-preview.47

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.46</Version>
+        <Version>0.2.0-preview.47</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
Three changes since `v0.2.0-preview.46`, and together they are the release where a
Photon app becomes something you can actually hand to somebody.

**#74 — an icon pack ships the glyphs an app names.** A pack was one static constructor,
so it shipped whole: 14.5 MB of DLL to draw five glyphs. Expression-bodied properties are
separate method bodies and the IL trimmer can drop the ones nobody names — pack DLL
14,558,720 → 7,680 bytes, a publish 35,256 KB → 20,952 KB.

**#75 — the app comes from `dotnet publish`.** The `.app` was assembled from the BUILD
output and `publish/` held loose files with no bundle in it, so every publish decision
stopped at the bundle's door: trimming, self-contained, single-file, AOT. Measured on this
repo's own sample with trimming on — publish 23 MB, bundle 172 MB. With it: the Info.plist
declared in C# (`builder.Bundle.Copyright(…).Category(…).Agent().UrlScheme(…)`),
notarization (`ditto` → `notarytool submit --wait` → `stapler staple`), and
`EQuanticPackageFormat=Dmg`. Trimming had to be made to WORK for any of it to mean
anything — four defects, all of them the trimmer reading the same evidence the design
relies on and concluding the opposite.

**#76 — the deep link arrives, and an app can ask a person for a file.** `IDeepLinks`
delivers the URL for the scheme #75 made declarable, and `IFileDialogs` wraps
NSOpenPanel/NSSavePanel.

## Two things this release does NOT contain, stated because they read like it might

- **No bundle has actually been notarized.** The steps run in order and fail loudly on a
  credential that does not exist; nobody has a *Developer ID Application* certificate yet.
  It is the one line of W5's acceptance still open, and it needs a certificate rather than
  code.
- **The file dialogs were never driven live.** A modal panel needs a person to answer it.
  They are wired, registered, and unproven by anything but a compiler.

## Verification

`dotnet build -c Release` across the solution: 0 errors. Native.Engine 1107, Compiler 835,
Web 617. The desktop sample publishes trimmed to a 23 MB signed `.app` plus a 9.8 MB signed
disk image, and the app launches from it — same 110 accessibility elements, same frames
presented.