### PR TITLE
🔧 chore: 0.2.0-preview.48

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.47</Version>
+        <Version>0.2.0-preview.48</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
One change since `v0.2.0-preview.47`, and it is the largest deletion this project
has made: **#77 removed the pre-write-once component model, on both sides of the
compiler.**

This is a BREAKING release, and the first one where that word means something. It
is deliberate: the SDK is preview, every consumer is one of our own projects, and
the moment to do this is now rather than after 1.0.

## What is gone

From `eQuantic.UI.Core`:

- `StatelessComponent` / `StatefulComponent` built on `HtmlElement`, `ComponentState`,
  `ComponentState<T>`, `InputComponent<T>` — the component model that predates write-once
- `IIconProvider`, `SvgElement`, `ComponentAttribute`
- `Styling/Colors.cs`, `Styling/Animations.cs`, `Styling/EQ.cs` — CSS values as strings, which
  the product principle rules out and which had no consumer

From the runtime, the TypeScript half of the same model (260 lines of `core/component.ts`);
from the templates, the three `content/` trees that authored against it and were never packaged.

Nothing here had a live consumer. The templates that ship (`equantic-app`, `equantic-native`)
were already write-once, and the ones removed were reachable only by opening the folder — which
is worse than dead, because a reader learns the wrong model from them.

## Verification

The whole point of a deletion this size is that nothing notices, so:

- `dotnet build -c Release` across the solution: 0 errors.
- Compiler 833, Web 617, Native.Engine 1107, Server 153 — all green.
- **All three samples build.** CI does not build them and they are not in the `.sln`, so a
  solution build proves nothing about a consumer; this is the check that does.

## What consumers have to do

Nothing, unless they were using one of the removed types — see the Upgrading page, which gains
its first entry with real substance. The short version: an app authored write-once is untouched.