### PR TITLE
🐛 fix: [ServerOnly] is answered for the TYPE, not for one declaration of it

### DIFF
--- a/src/eQuantic.UI.Compiler/CodeGen/Extensions/AttributeSyntaxExtensions.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Extensions/AttributeSyntaxExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace eQuantic.UI.Compiler.CodeGen.Extensions;
+
+/// <summary>
+/// Recognising an attribute by NAME when the model cannot be asked — the fallback the parser uses in
+/// standalone CompileSource, where nothing resolves and the text is all there is.
+/// </summary>
+public static class AttributeSyntaxExtensions
+{
+    /// <summary>
+    /// True when this attribute is <paramref name="simpleName"/> in any of the spellings C# allows:
+    /// bare (<c>[ServerOnly]</c>), with the suffix (<c>[ServerOnlyAttribute]</c>), or qualified to any
+    /// depth (<c>[eQuantic.UI.Primitives.ServerOnly]</c>, <c>[global::…ServerOnlyAttribute]</c>).
+    /// <para>
+    /// Three call sites compared <c>Name.ToString()</c> for exact equality, and each of them missed
+    /// the qualified form — an author who writes the namespace out, which is common exactly where
+    /// two namespaces both offer the name, got a module emitted for a type they had marked
+    /// server-only. One rule, one place: the LAST segment decides, with or without <c>Attribute</c>.
+    /// </para>
+    /// </summary>
+    public static bool IsNamed(this AttributeSyntax attribute, string simpleName)
+    {
+        var name = attribute.Name switch
+        {
+            QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+            AliasQualifiedNameSyntax aliased => aliased.Name.Identifier.Text,
+            SimpleNameSyntax simple => simple.Identifier.Text,
+            _ => attribute.Name.ToString(),
+        };
+        return name == simpleName || name == simpleName + "Attribute";
+    }
+}

--- a/src/eQuantic.UI.Compiler/Parser/ComponentParser.cs
+++ b/src/eQuantic.UI.Compiler/Parser/ComponentParser.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using eQuantic.UI.Compiler.CodeGen;
+using eQuantic.UI.Compiler.CodeGen.Extensions;
 using eQuantic.UI.Compiler.Models;
 using eQuantic.UI.Compiler.Services;
 
@@ -480,7 +481,7 @@ public class ComponentParser
     /// <para>
     /// Asked of the SYMBOL, which unifies partial declarations, and not of the declaration in hand.
     /// The syntactic form answered per file, so a partial class spread across six files was
-    /// unmutable: C# rejects the attribute on more than one declaration (CS0579, "Duplicate
+    /// impossible to silence: C# rejects the attribute on more than one declaration (CS0579, "Duplicate
     /// 'ServerOnly' attribute"), and one declaration silenced only its own — a consumer measured
     /// four of five EQ1006 warnings surviving, with no way at all to silence them short of merging
     /// the files. A type is server-only or it is not; which file says so is not the transpiler's
@@ -504,12 +505,12 @@ public class ComponentParser
             return true;
 
         return classDecl.AttributeLists.SelectMany(list => list.Attributes)
-            .Any(attribute => attribute.Name.ToString() is "ServerOnly" or "ServerOnlyAttribute");
+            .Any(attribute => attribute.IsNamed("ServerOnly"));
     }
 
     private static bool IsServerOnly(MethodDeclarationSyntax method) =>
         method.AttributeLists.SelectMany(list => list.Attributes)
-            .Any(attribute => attribute.Name.ToString() is "ServerOnly" or "ServerOnlyAttribute");
+            .Any(attribute => attribute.IsNamed("ServerOnly"));
 
     private void ParseMethods(ClassDeclarationSyntax classDecl, ComponentDefinition definition)
     {
@@ -547,7 +548,7 @@ public class ComponentParser
             // emitter writes from definition.ServerActions. Transpiling the body here shipped
             // server code (DbContexts, Stopwatches, the compiler itself) into the browser.
             if (method.AttributeLists.SelectMany(a => a.Attributes)
-                .Any(a => a.Name.ToString() is "ServerAction" or "ServerActionAttribute")) continue;
+                .Any(a => a.IsNamed("ServerAction"))) continue;
 
             var methodName = method.Identifier.Text;
             if (methodName == "CreateState") continue;

--- a/src/eQuantic.UI.Compiler/Parser/ComponentParser.cs
+++ b/src/eQuantic.UI.Compiler/Parser/ComponentParser.cs
@@ -474,11 +474,38 @@ public class ComponentParser
     /// server surface (an SSR prefetch's HttpClient, EF, the request's services). The counterpart of
     /// <c>[ServerAction]</c>, which keeps the method callable FROM the browser through an RPC stub.
     /// </summary>
-    /// <summary>The class-level form: <c>[ServerOnly]</c> on a static helper or a plain class says
-    /// the whole type stays on the server, and the parser emits no module for it.</summary>
-    private static bool IsServerOnly(ClassDeclarationSyntax classDecl) =>
-        classDecl.AttributeLists.SelectMany(list => list.Attributes)
+    /// <summary>
+    /// The class-level form: <c>[ServerOnly]</c> on a static helper or a plain class says the whole
+    /// type stays on the server, and the parser emits no module for it.
+    /// <para>
+    /// Asked of the SYMBOL, which unifies partial declarations, and not of the declaration in hand.
+    /// The syntactic form answered per file, so a partial class spread across six files was
+    /// unmutable: C# rejects the attribute on more than one declaration (CS0579, "Duplicate
+    /// 'ServerOnly' attribute"), and one declaration silenced only its own — a consumer measured
+    /// four of five EQ1006 warnings surviving, with no way at all to silence them short of merging
+    /// the files. A type is server-only or it is not; which file says so is not the transpiler's
+    /// business.
+    /// </para>
+    /// <para>
+    /// Falls back to the syntax when the model cannot be asked — standalone CompileSource has no
+    /// references, so the attribute resolves to an error symbol there and its NAME is all there is.
+    /// That is the repo's rule: a name heuristic is legal only where the model has nothing to say.
+    /// </para>
+    /// </summary>
+    private bool IsServerOnly(ClassDeclarationSyntax classDecl)
+    {
+        // Both spellings: with the reference resolved the symbol is `ServerOnlyAttribute`, and in a
+        // compilation without it the attribute binds to an error symbol carrying the name as
+        // WRITTEN. The second is the playground's world, and a type that says it stays on the
+        // server must be believed there too.
+        if (TryGetSemanticModel(classDecl.SyntaxTree)?.GetDeclaredSymbol(classDecl) is { } symbol
+            && symbol.GetAttributes()
+                .Any(a => a.AttributeClass?.Name is "ServerOnly" or "ServerOnlyAttribute"))
+            return true;
+
+        return classDecl.AttributeLists.SelectMany(list => list.Attributes)
             .Any(attribute => attribute.Name.ToString() is "ServerOnly" or "ServerOnlyAttribute");
+    }
 
     private static bool IsServerOnly(MethodDeclarationSyntax method) =>
         method.AttributeLists.SelectMany(list => list.Attributes)

--- a/tests/eQuantic.UI.Compiler.Tests/ServerOnlyAcrossPartialsTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/ServerOnlyAcrossPartialsTests.cs
@@ -67,4 +67,34 @@ public class ServerOnlyAcrossPartialsTests
             dir.Delete(recursive: true);
         }
     }
+
+    /// <summary>
+    /// The syntax-only fallback — no model at all — has to recognise the attribute however C# lets
+    /// it be spelled. Exact comparison of <c>Name.ToString()</c> missed the qualified form, and an
+    /// author writes the namespace out exactly where two namespaces both offer the name.
+    /// <para>
+    /// This goes through the PARSER directly, with no provider set, because that is the only way to
+    /// reach the fallback: <c>ComponentCompiler</c> always installs one, and even without references
+    /// the symbol path answers first — an unresolved attribute binds to an error symbol that still
+    /// carries the last segment written. Through the compiler, this test passed against the very
+    /// bug it exists to catch. Through the bare parser it fails against it.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [InlineData("[ServerOnly]")]
+    [InlineData("[ServerOnlyAttribute]")]
+    [InlineData("[eQuantic.UI.Primitives.ServerOnly]")]
+    [InlineData("[eQuantic.UI.Primitives.ServerOnlyAttribute]")]
+    [InlineData("[global::eQuantic.UI.Primitives.ServerOnly]")]
+    public void ServerOnly_IsRecognisedInEverySpelling_WithoutAModel(string spelling)
+    {
+        var parser = new eQuantic.UI.Compiler.Parser.ComponentParser(); // no provider: syntax only
+        var definitions = parser.ParseSource($$"""
+            namespace App;
+            {{spelling}}
+            public sealed class Seed { public string Books() => "books"; }
+            """, "Seed.cs").ToList();
+
+        definitions.Should().BeEmpty($"{spelling} says the type never crosses, in any spelling");
+    }
 }

--- a/tests/eQuantic.UI.Compiler.Tests/ServerOnlyAcrossPartialsTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/ServerOnlyAcrossPartialsTests.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using System.Linq;
+using eQuantic.UI.Compiler;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace eQuantic.UI.Compiler.Tests;
+
+/// <summary>
+/// <c>[ServerOnly]</c> describes a TYPE, so it has to be answered for the type — not for whichever
+/// declaration of it the parser happens to be holding.
+/// <para>
+/// The syntactic form answered per file, and that made a partial class spread across files
+/// impossible to silence. C# unifies attributes across partials and rejects a second one
+/// (CS0579, "Duplicate 'ServerOnly' attribute"), so an author cannot mark them all; and one
+/// declaration silenced only its own, so the others still emitted a module and still warned. A
+/// consumer measured four of five EQ1006 warnings surviving, with no way out short of merging six
+/// files that were separate on purpose — one per library.
+/// </para>
+/// </summary>
+public class ServerOnlyAcrossPartialsTests
+{
+    [Fact]
+    public void ServerOnlyOnOneDeclaration_SilencesEveryPartOfTheType()
+    {
+        var dir = Directory.CreateTempSubdirectory("eq-partials");
+        try
+        {
+            // The attribute is legal on exactly ONE of the declarations. This is not a style
+            // choice the author could make differently — the compiler refuses the second.
+            File.WriteAllText(Path.Combine(dir.FullName, "Seed.Books.cs"), """
+                using eQuantic.UI.Core;
+                namespace App;
+                [ServerOnly]
+                public sealed partial class Seed { public string Books() => "books"; }
+                """);
+            File.WriteAllText(Path.Combine(dir.FullName, "Seed.Films.cs"), """
+                namespace App;
+                public sealed partial class Seed { public string Films() => "films"; }
+                """);
+            File.WriteAllText(Path.Combine(dir.FullName, "Seed.Music.cs"), """
+                namespace App;
+                public sealed partial class Seed { public string Music() => "music"; }
+                """);
+
+            // The SDK build hands eqc the project's whole compilation, which is what makes the
+            // symbol see every partial. Without it there is one model per file and the symbol knows
+            // only the declaration in front of it — the very blindness this test is about.
+            var files = Directory.GetFiles(dir.FullName, "*.cs");
+            var project = CSharpCompilation.Create(
+                "PartialsProbe",
+                files.Select(f => CSharpSyntaxTree.ParseText(File.ReadAllText(f), path: f)),
+                new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
+
+            var compiler = new ComponentCompiler();
+            compiler.SetProjectCompilation(project);
+            var emitted = compiler.CompileDirectory(dir.FullName).ToList();
+
+            emitted.Should().BeEmpty(
+                "the type is server-only, so no declaration of it earns a module — which file "
+                + "carries the attribute is not the transpiler's business");
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
A consumer has a `sealed partial class` split across six files — one per library it seeds — carrying
five EQ1006 warnings. The advice they were given (mine) was to mark all six declarations
`[ServerOnly]`.

**That advice was impossible, and they measured why.** C# unifies attributes across partial
declarations and rejects a second one:

```
error CS0579: Duplicate 'ServerOnly' attribute
```

The build does not even reach the transpiler. And with the attribute on **one** declaration it
compiles but silences only that one — four of the five warnings survived. So the type could not be
silenced at all, short of merging six files that are separate on purpose.

## The cause

`IsServerOnly` read `classDecl.AttributeLists` — the syntax of whichever declaration the parser
happened to be holding. But `[ServerOnly]` describes a **type**: which file carries it is not the
transpiler's business.

It now asks the **symbol**, which unifies partials, and falls back to the syntax when the model
cannot be asked — the repo's standing rule that a name heuristic is legal only where the model has
nothing to say, and standalone `CompileSource` has no references at all.

## One detail worth keeping

Both spellings are accepted from the symbol. With the reference resolved it is
`ServerOnlyAttribute`; in a compilation without it the attribute binds to an **error symbol carrying
the name as written**, `ServerOnly`. That is the playground's world, and a type that says it stays
on the server must be believed there too.

Found by instrumenting the parser rather than by guessing — the symbol was resolving correctly all
along, and the name test was simply too narrow. Worth saying because the first fix looked right and
did nothing.

## The test

Builds a real three-file partial and hands the compiler the project's whole compilation, since that
is what makes a symbol see every part — one model per file is precisely the blindness being fixed.
Verified to fail against the syntactic predicate.

Every .NET suite green; samples build.