### PR TITLE
✨ feat: the app can hand something to the system, and a capability stops lying

### DIFF
--- a/docs/DESKTOP-PLAN.md
+++ b/docs/DESKTOP-PLAN.md
@@ -103,6 +103,15 @@ docs: `Launch` is NOT readable in a constructor on macOS. AppleEvents are delive
 and the run loop starts after the first tree is built, so a cold launch reaches a SUBSCRIBER and
 finds the property still null a moment earlier. An app that does both is right everywhere.
 
+`IWorkspace` followed (reveal in Finder, open a file, open a URL), and finding it work took finding
+why it did not: every one of its answers was FALSE, including revealing a folder that plainly
+exists. `objc_getClass` on a framework nobody loaded answers nil, a message to nil is a silent
+no-op, and the zero it returns is indistinguishable from the system declining. `MacFileDialogs` had
+the same hole and was worse for it — a panel that never opened looks exactly like a panel someone
+closed. Both go through one `AppKit.Class(name)` now, which loads before it looks. It works inside
+a running app either way, because the runner loads AppKit as its first act, and that is precisely
+what kept it invisible.
+
 - Native menu bar (`NSMenu`, declarative) + context menus (right-click is not even delivered today)
 - Status item (tray) + an auxiliary panel window (`NSPanel`) — closes W-B7 for the real use case;
   general multi-window can wait
@@ -138,8 +147,20 @@ them the trimmer reading the same evidence the design relies on and concluding t
 - **A notarized bundle has never been produced.** The steps run in order and fail loudly on a
   credential that does not exist, but nobody on this machine holds a Developer ID. This is the one
   line of the acceptance below still open, and it needs a certificate.
-- **`IAppUpdater` is not started.** It is the last piece of W5 and the natural next slice, and the
-  acceptance ("installed and relaunched by the minimal updater") depends on it.
+- **`IAppUpdater` is not started.** It is the last piece of W5, and the acceptance ("installed and
+  relaunched by the minimal updater") depends on it.
+
+  **It comes AFTER the certificate, and that ordering is a decision rather than a queue.** A
+  consumer proposed it as a new track, reasonably: the SDK already knows how to sign, notarize,
+  staple and build the disk image, so the app knows how to be born and not how to grow. The pieces
+  are ours and the design is not hard. What decides the order is the `verify` step: it verifies a
+  SIGNATURE, and no bundle has ever carried a real one. Building the updater first means shipping
+  a security step that has never once said no — the same shape as the consumer's own best finding
+  this week, where an error card rendered as a perfectly valid 42 KB PNG and their render script
+  went green on a broken section. An instrument that cannot fail is not an instrument.
+
+  So: certificate, then the updater, and then W5's acceptance closes with a measurement instead of
+  an intention.
 
 **Handed to W4.** `builder.Bundle.UrlScheme("acme")` now declares the scheme, so macOS launches the
 app for `acme://…` — and nothing delivers the URL, because `kAEGetURL` handling is W4's and the

--- a/src/eQuantic.UI.Native.Shell.MacOS/AppKit.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/AppKit.cs
@@ -16,6 +16,29 @@ internal static partial class AppKit
 
     internal static void LoadFrameworks() => dlopen(AppKitFramework, 2 /* RTLD_NOW */);
 
+    /// <summary>
+    /// An AppKit class, with the framework LOADED first — the only way anything here should reach
+    /// for one.
+    /// <para>
+    /// `objc_getClass` on a framework that is not loaded answers NIL, and a message to nil is a
+    /// silent no-op that returns zero. So a capability written without this does not throw and does
+    /// not log: it answers false, or null, or "the person cancelled", and every one of those is a
+    /// legitimate answer it might have given for real. `MacWorkspace.Reveal("/Applications")`
+    /// returning false is what found it, and `MacFileDialogs` had the same hole — a picker that
+    /// never opened was indistinguishable from a picker someone closed.
+    /// </para>
+    /// <para>
+    /// It works anyway inside a running app, because the runner loads AppKit as its first act. That
+    /// is exactly what makes it dangerous: the bug is invisible until a capability is used from a
+    /// test, a tool, or any process that has no window.
+    /// </para>
+    /// </summary>
+    internal static IntPtr Class(string name)
+    {
+        LoadFrameworks();
+        return Shell.Apple.ObjC.objc_getClass(name);
+    }
+
     // ---- The run loop, so a frame can be drawn from INSIDE someone else's loop -----------------
 
     /// <summary>

--- a/src/eQuantic.UI.Native.Shell.MacOS/AppKit.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/AppKit.cs
@@ -17,8 +17,11 @@ internal static partial class AppKit
     internal static void LoadFrameworks() => dlopen(AppKitFramework, 2 /* RTLD_NOW */);
 
     /// <summary>
-    /// An AppKit class, with the framework LOADED first — the only way anything here should reach
-    /// for one.
+    /// An Objective-C class by name, with AppKit — and everything AppKit links, which is Foundation
+    /// and UniformTypeIdentifiers among others — LOADED first. So it is the right door for
+    /// <c>NSURL</c> and <c>UTType</c> too, not only for <c>NSOpenPanel</c>: the classes this shell
+    /// reaches for all arrive through that one load, and the only way anything here should reach
+    /// for one is this.
     /// <para>
     /// `objc_getClass` on a framework that is not loaded answers NIL, and a message to nil is a
     /// silent no-op that returns zero. So a capability written without this does not throw and does

--- a/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacFileDialogs.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacFileDialogs.cs
@@ -38,7 +38,7 @@ public sealed class MacFileDialogs : IFileDialogs
     private static List<string> Open(string? title, IReadOnlyList<FileFilter>? filters, string? startIn,
         bool folders, bool multiple)
     {
-        var panel = Send(objc_getClass("NSOpenPanel"), Sel("openPanel"));
+        var panel = Send(AppKit.Class("NSOpenPanel"), Sel("openPanel"));
         if (panel == IntPtr.Zero) return [];
 
         SendVoid(panel, Sel("setCanChooseFiles:"), !folders);
@@ -66,7 +66,7 @@ public sealed class MacFileDialogs : IFileDialogs
     private static string? Save(string? suggestedName, string? title, IReadOnlyList<FileFilter>? filters,
         string? startIn)
     {
-        var panel = Send(objc_getClass("NSSavePanel"), Sel("savePanel"));
+        var panel = Send(AppKit.Class("NSSavePanel"), Sel("savePanel"));
         if (panel == IntPtr.Zero) return null;
 
         if (!string.IsNullOrWhiteSpace(suggestedName))
@@ -88,7 +88,7 @@ public sealed class MacFileDialogs : IFileDialogs
 
         if (!string.IsNullOrWhiteSpace(startIn) && Directory.Exists(startIn))
         {
-            var url = Send(objc_getClass("NSURL"), Sel("fileURLWithPath:"), NSString(startIn));
+            var url = Send(AppKit.Class("NSURL"), Sel("fileURLWithPath:"), NSString(startIn));
             if (url != IntPtr.Zero) SendVoid(panel, Sel("setDirectoryURL:"), url);
         }
 
@@ -109,10 +109,10 @@ public sealed class MacFileDialogs : IFileDialogs
     {
         if (filters is null || filters.Count == 0) return null;
 
-        var utType = objc_getClass("UTType");
+        var utType = AppKit.Class("UTType");
         if (utType == IntPtr.Zero) return null;
 
-        var types = Send(objc_getClass("NSMutableArray"), Sel("array"));
+        var types = Send(AppKit.Class("NSMutableArray"), Sel("array"));
         foreach (var extension in filters
                      .SelectMany(filter => filter.Extensions)
                      .Select(extension => extension.TrimStart('.').Trim())

--- a/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacOSCapabilities.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacOSCapabilities.cs
@@ -39,5 +39,7 @@ public sealed class MacOSCapabilities : IPhotonCapabilities
         services.TryAddSingleton<IDeepLinks>(_ => AppleDeepLinks.Install());
         // Asking a PERSON for a file — the one way a sandboxed app touches what it was not given.
         services.TryAddSingleton<IFileDialogs, MacFileDialogs>();
+        // And the other direction: handing a path or a URL to the system. NSWorkspace.
+        services.TryAddSingleton<IWorkspace, MacWorkspace>();
     }
 }

--- a/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacWorkspace.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacWorkspace.cs
@@ -17,19 +17,24 @@ public sealed class MacWorkspace : IWorkspace
     /// <inheritdoc />
     public bool Reveal(string path)
     {
+        Rooted(path);
+        // A file OR a folder: a folder is the common case here, and File.Exists alone says no to one.
+        if (!File.Exists(path) && !Directory.Exists(path)) return false;
         // `selectFile:inFileViewerRootedAtPath:` with an EMPTY root is the documented way to say
         // "wherever it lives" — a root of the file's own directory opens a second window rooted
         // there instead, which is not what "show me where this is" means.
-        if (!Exists(path)) return false;
         return SendBool(Workspace(), Sel("selectFile:inFileViewerRootedAtPath:"),
-            NSString(Full(path)), NSString(""));
+            NSString(path), NSString(""));
     }
 
     /// <inheritdoc />
     public bool OpenFile(string path)
     {
-        if (!Exists(path)) return false;
-        var url = Send(AppKit.Class("NSURL"), Sel("fileURLWithPath:"), NSString(Full(path)));
+        Rooted(path);
+        // A FILE, as the contract says. `openURL:` on a folder would open it in Finder, which is
+        // Reveal's job and not this one's — and a caller who meant Reveal would never find out.
+        if (!File.Exists(path)) return false;
+        var url = Send(AppKit.Class("NSURL"), Sel("fileURLWithPath:"), NSString(path));
         return url != IntPtr.Zero && SendBool(Workspace(), Sel("openURL:"), url);
     }
 
@@ -37,6 +42,12 @@ public sealed class MacWorkspace : IWorkspace
     public bool OpenUrl(Uri url)
     {
         ArgumentNullException.ThrowIfNull(url);
+        // A relative Uri is not something the system declined — no system could ever have been
+        // asked. Answering false would send the developer looking at LaunchServices for a mistake
+        // that is in their own call, which is the exact shape of lie this class exists to avoid.
+        if (!url.IsAbsoluteUri)
+            throw new ArgumentException("A URL to open must be absolute — nothing can route "
+                + $"\"{url.OriginalString}\" without a scheme.", nameof(url));
         // AbsoluteUri and not ToString(): the second gives back what the app typed, and a space or
         // an accent that was never percent-encoded produces a null NSURL and a silent no-op.
         var native = Send(AppKit.Class("NSURL"), Sel("URLWithString:"), NSString(url.AbsoluteUri));
@@ -51,18 +62,36 @@ public sealed class MacWorkspace : IWorkspace
     /// exactly like "the system declined" and is not. Found by a probe that revealed /Applications
     /// and was told no.
     /// </summary>
+    /// <inheritdoc />
+    public bool CanOpen(Uri url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+        if (!url.IsAbsoluteUri) return false;
+        // `URLForApplicationToOpenURL:` is the QUERY form of openURL: — nil when nothing claims the
+        // scheme, and no dialog either way. The action form puts up "There is no application set to
+        // open the URL…" on the person's screen, which is exactly what a check must not do.
+        var native = Send(AppKit.Class("NSURL"), Sel("URLWithString:"), NSString(url.AbsoluteUri));
+        return native != IntPtr.Zero
+            && Send(Workspace(), Sel("URLForApplicationToOpenURL:"), native) != IntPtr.Zero;
+    }
+
     private static IntPtr Workspace() => Send(AppKit.Class("NSWorkspace"), Sel("sharedWorkspace"));
 
-    /// <summary>A file OR a directory: a folder is the common case for Reveal, and
-    /// <see cref="File.Exists(string)"/> alone answers false for one.</summary>
-    private static bool Exists(string path) =>
-        !string.IsNullOrWhiteSpace(path) && (File.Exists(path) || Directory.Exists(path));
-
     /// <summary>
-    /// Absolute, because NSWorkspace resolves a relative path against the PROCESS's working
-    /// directory — which for an app launched from Finder is <c>/</c>, and for the same app launched
-    /// from a terminal is wherever the terminal was. The same click would work while developing and
-    /// fail once installed.
+    /// A relative path is refused, not resolved. Resolving it — here or in NSWorkspace — means
+    /// against the PROCESS's working directory, which for an app launched from Finder is <c>/</c>
+    /// and for the same app launched from a terminal is wherever the terminal was: the same click
+    /// works while developing and fails once installed. The first version of this called
+    /// <see cref="Path.GetFullPath(string)"/> and claimed to avoid that; it does the same thing.
+    /// The paths an app holds come from a scan or a picker and are absolute, so a relative one is
+    /// a mistake in the call, and it is named as one.
     /// </summary>
-    private static string Full(string path) => Path.GetFullPath(path);
+    private static void Rooted(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        if (!Path.IsPathRooted(path))
+            throw new ArgumentException($"\"{path}\" is relative. A path handed to the system must "
+                + "be absolute — resolved against a working directory it would point somewhere "
+                + "different in Finder than in a terminal.", nameof(path));
+    }
 }

--- a/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacWorkspace.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacWorkspace.cs
@@ -66,7 +66,13 @@ public sealed class MacWorkspace : IWorkspace
     public bool CanOpen(Uri url)
     {
         ArgumentNullException.ThrowIfNull(url);
-        if (!url.IsAbsoluteUri) return false;
+        // The same rule as OpenUrl, or the two would disagree about the same argument: a relative
+        // Uri is nobody's to route, so it is the caller's mistake and not a "no" from the system.
+        // The first version of this returned false here, which is precisely the confusion the
+        // contract forbids — written one method up, by the same hand.
+        if (!url.IsAbsoluteUri)
+            throw new ArgumentException("A URL to check must be absolute — nothing can route "
+                + $"\"{url.OriginalString}\" without a scheme.", nameof(url));
         // `URLForApplicationToOpenURL:` is the QUERY form of openURL: — nil when nothing claims the
         // scheme, and no dialog either way. The action form puts up "There is no application set to
         // open the URL…" on the person's screen, which is exactly what a check must not do.

--- a/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacWorkspace.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/Devices/MacWorkspace.cs
@@ -1,0 +1,68 @@
+using eQuantic.UI.Primitives;
+using static eQuantic.UI.Native.Shell.Apple.ObjC;
+
+namespace eQuantic.UI.Native.Shell.MacOS;
+
+/// <summary>
+/// <c>NSWorkspace</c>, which is the Mac's one answer to every one of these and has been since
+/// before any of this was a framework.
+/// <para>
+/// Each call answers with what NSWorkspace answered, unchanged. A false here means the system
+/// declined — the path vanished, no app claims the scheme — and inventing an exception for it would
+/// turn an ordinary outcome into one every call site has to guard.
+/// </para>
+/// </summary>
+public sealed class MacWorkspace : IWorkspace
+{
+    /// <inheritdoc />
+    public bool Reveal(string path)
+    {
+        // `selectFile:inFileViewerRootedAtPath:` with an EMPTY root is the documented way to say
+        // "wherever it lives" — a root of the file's own directory opens a second window rooted
+        // there instead, which is not what "show me where this is" means.
+        if (!Exists(path)) return false;
+        return SendBool(Workspace(), Sel("selectFile:inFileViewerRootedAtPath:"),
+            NSString(Full(path)), NSString(""));
+    }
+
+    /// <inheritdoc />
+    public bool OpenFile(string path)
+    {
+        if (!Exists(path)) return false;
+        var url = Send(AppKit.Class("NSURL"), Sel("fileURLWithPath:"), NSString(Full(path)));
+        return url != IntPtr.Zero && SendBool(Workspace(), Sel("openURL:"), url);
+    }
+
+    /// <inheritdoc />
+    public bool OpenUrl(Uri url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+        // AbsoluteUri and not ToString(): the second gives back what the app typed, and a space or
+        // an accent that was never percent-encoded produces a null NSURL and a silent no-op.
+        var native = Send(AppKit.Class("NSURL"), Sel("URLWithString:"), NSString(url.AbsoluteUri));
+        return native != IntPtr.Zero && SendBool(Workspace(), Sel("openURL:"), native);
+    }
+
+    /// <summary>
+    /// The shared workspace, with AppKit LOADED first. Nothing here can assume the runner already
+    /// did it: a capability is resolved from the container and the container is built before the
+    /// window, and a test or a tool may hold one with no window at all. Without the dlopen,
+    /// <c>AppKit.Class("NSWorkspace")</c> answers nil and every method returns false — which looks
+    /// exactly like "the system declined" and is not. Found by a probe that revealed /Applications
+    /// and was told no.
+    /// </summary>
+    private static IntPtr Workspace() => Send(AppKit.Class("NSWorkspace"), Sel("sharedWorkspace"));
+
+    /// <summary>A file OR a directory: a folder is the common case for Reveal, and
+    /// <see cref="File.Exists(string)"/> alone answers false for one.</summary>
+    private static bool Exists(string path) =>
+        !string.IsNullOrWhiteSpace(path) && (File.Exists(path) || Directory.Exists(path));
+
+    /// <summary>
+    /// Absolute, because NSWorkspace resolves a relative path against the PROCESS's working
+    /// directory — which for an app launched from Finder is <c>/</c>, and for the same app launched
+    /// from a terminal is wherever the terminal was. The same click would work while developing and
+    /// fail once installed.
+    /// </summary>
+    private static string Full(string path) => Path.GetFullPath(path);
+}

--- a/src/eQuantic.UI.Native.Shell.MacOS/MacClipboard.cs
+++ b/src/eQuantic.UI.Native.Shell.MacOS/MacClipboard.cs
@@ -15,7 +15,7 @@ namespace eQuantic.UI.Native.Shell.MacOS;
 internal sealed class MacClipboard : ITextClipboard
 {
     private static IntPtr General() =>
-        Send(objc_getClass("NSPasteboard"), Sel("generalPasteboard"));
+        Send(AppKit.Class("NSPasteboard"), Sel("generalPasteboard"));
 
     public string? Read() =>
         FromNSString(Send(General(), Sel("stringForType:"), NSString("public.utf8-plain-text")));

--- a/src/eQuantic.UI.Primitives/Devices/IWorkspace.cs
+++ b/src/eQuantic.UI.Primitives/Devices/IWorkspace.cs
@@ -16,6 +16,12 @@ namespace eQuantic.UI.Primitives;
 /// to, and "nothing happened" is the one outcome a person cannot diagnose.
 /// </para>
 /// <para>
+/// The line between the two is WHO was wrong. False means the SYSTEM declined something that could
+/// have been asked. An argument the system could never have been handed — a relative path, a
+/// relative URL, null — is the caller's mistake and THROWS, because answering false to it would
+/// send the developer looking at the operating system for a bug that is in their own call.
+/// </para>
+/// <para>
 /// It opens what the APP names, never what a document does. Everything here reaches outside the
 /// app's own window, so a URL that arrived in content — a link in a rendered document, a value that
 /// came back from a server — is the app's to decide about before it gets here. The capability does
@@ -51,5 +57,20 @@ public interface IWorkspace
     /// </summary>
     /// <returns>False when the URL is not one the system can route, which includes the ordinary
     /// case of a scheme no installed app claims.</returns>
+    /// <remarks>
+    /// False is NOT silent for an unclaimed scheme. macOS answers false AND shows the person a
+    /// dialog of its own — "There is no application set to open the URL…", with a button to search
+    /// the App Store. That is the right thing for a link a person clicked, and the wrong thing for a
+    /// check: an app that wants to know whether <c>acme://</c> has a handler must ask with
+    /// <see cref="CanOpen"/>, not by trying. Measured by trying, on a desk that was not expecting
+    /// the dialog.
+    /// </remarks>
     bool OpenUrl(Uri url);
+
+    /// <summary>
+    /// Whether something on this machine claims the URL's scheme — a QUESTION, with no side effect.
+    /// The way to decide whether to show a "Open in Acme" button at all, rather than showing it and
+    /// letting the system explain to the person that Acme is not installed.
+    /// </summary>
+    bool CanOpen(Uri url);
 }

--- a/src/eQuantic.UI.Primitives/Devices/IWorkspace.cs
+++ b/src/eQuantic.UI.Primitives/Devices/IWorkspace.cs
@@ -1,0 +1,55 @@
+namespace eQuantic.UI.Primitives;
+
+/// <summary>
+/// Handing something to the SYSTEM to deal with — a folder to show the person, a link to open, a
+/// file to hand to whatever owns that kind of file.
+/// <para>
+/// The counterpart of <see cref="IFileDialogs"/>, which asks a person for a path. This is what an
+/// app does once it HAS one and the next step is not its own: a disk scanner that found the
+/// offender and offers "Show in Finder", a settings screen linking to its own privacy page, a
+/// report the app just wrote and the person wants to read in their spreadsheet.
+/// </para>
+/// <para>
+/// Every method answers whether the system took it. False is an ordinary answer, not a failure to
+/// catch: a path may have been deleted between the scan and the click, and a URL scheme may have no
+/// app behind it on this machine. An app that has to catch to find out is an app that will forget
+/// to, and "nothing happened" is the one outcome a person cannot diagnose.
+/// </para>
+/// <para>
+/// It opens what the APP names, never what a document does. Everything here reaches outside the
+/// app's own window, so a URL that arrived in content — a link in a rendered document, a value that
+/// came back from a server — is the app's to decide about before it gets here. The capability does
+/// not judge, which is exactly why the judging has to happen at the call site.
+/// </para>
+/// <para>
+/// DESKTOP for now. A phone has the ideas — a share sheet, a document provider — and they are not
+/// these ones, and a capability that answered "revealed it in Finder" on a phone would be lying in
+/// a way the compiler cannot see.
+/// </para>
+/// </summary>
+public interface IWorkspace
+{
+    /// <summary>
+    /// Shows the person where a file or folder IS, selected in the system's file browser — not
+    /// opened. The distinction matters: a disk tool offering "Show in Finder" for a 4 GB cache
+    /// folder must not open it, and a person who asked where something lives has not asked for its
+    /// contents.
+    /// </summary>
+    /// <returns>False when the path no longer exists, which between a scan and a click is ordinary.</returns>
+    bool Reveal(string path);
+
+    /// <summary>
+    /// Hands a file to whatever the system says owns that kind of file — the app's own report in
+    /// the person's spreadsheet, a log in their editor.
+    /// </summary>
+    /// <returns>False when the path is gone, or nothing on this machine claims it.</returns>
+    bool OpenFile(string path);
+
+    /// <summary>
+    /// Opens a URL in whatever handles its scheme: a browser for <c>https</c>, a mail client for
+    /// <c>mailto</c>, another app for its own scheme.
+    /// </summary>
+    /// <returns>False when the URL is not one the system can route, which includes the ordinary
+    /// case of a scheme no installed app claims.</returns>
+    bool OpenUrl(Uri url);
+}


### PR DESCRIPTION
## `IWorkspace`

The other half of `IFileDialogs`. That one asks a person for a path; this one hands a path back to
the system — the thing a disk scanner does after it found the offender, or a settings screen does
with a link to its own privacy page.

```csharp
Workspace.Reveal(folder);              // show me where it IS, selected, not opened
Workspace.OpenFile(reportPath);        // hand it to whatever owns that kind of file
Workspace.OpenUrl(new Uri("https://…"));
```

Each answers whether the system took it. False is an ordinary answer and not an exception: a path
can vanish between a scan and a click, and a scheme can have nothing behind it on this machine. An
app that has to catch to find that out is an app that will forget to.

## The bug the live proof found, which is the better half of this PR

The proof was meant to be a closed loop, and it was: a probe called `OpenUrl` on the sample's own
URL scheme, LaunchServices routed it, and the running app logged it through `IDeepLinks`. Two
capabilities, one measurement.

But the first run answered **false to everything**, including revealing `/Applications`.

`objc_getClass` on a framework nobody loaded answers nil. A message to nil is a silent no-op that
returns zero. And zero here is indistinguishable from the system declining — so the capability did
not throw, did not log, and gave an answer it might legitimately have given.

**`MacFileDialogs` had the same hole**, and it is worse there: it shipped in 0.2.0-preview.47 and
.48, and a panel that never opened is indistinguishable from a panel someone closed. `MacClipboard`
too. All three now reach an AppKit class through one `AppKit.Class(name)`, which loads before it
looks and carries the whole story in its doc comment so the next one written does not repeat it.

It works anyway inside a running app, because the runner loads AppKit as its first act. That is
exactly what kept it invisible: the failure only appears from a test, a tool, or any process with
no window — which is where a probe lives and where a unit test would have lived.

## Also: the `IAppUpdater` ordering, recorded as a decision

A consumer proposed the updater as a new track. It is not — `docs/DESKTOP-PLAN.md` already scopes it
inside W5 and it was written down as owed when W5 closed. What the plan now records is the ORDER
and why: it comes after the certificate, because its `verify` step verifies a signature no bundle
has ever carried, and a security step that has never once said no is not one.

## Verification

- The probe, live: `Reveal("/Applications")` true, `Reveal(missing)` false, `OpenFile(missing)`
  false, `OpenUrl` on the sample's scheme true and delivered, `OpenUrl` on an unclaimed scheme
  false. Probe deleted.
- Solution in Release: 0 errors. Native.Engine: 1107 passed. Both desktop samples build.

**No unit test, deliberately.** Pinning this needs `Shell.MacOS` referenced from a test assembly
that today runs everywhere and references no platform shell, and the thing worth pinning — that a
capability answers truthfully when AppKit is not loaded — only fails on macOS. Saying that is
better than a test that runs nowhere it matters. The live probe is the proof, and what it found is
in `AppKit.Class`'s doc comment where the next author will read it.