### PR TITLE
📝 docs: three things a consumer reads before writing their first component

### DIFF
--- a/src/eQuantic.UI.Components/Breadcrumb.cs
+++ b/src/eQuantic.UI.Components/Breadcrumb.cs
@@ -2,7 +2,7 @@ using eQuantic.UI.Primitives;
 
 namespace eQuantic.UI.Components;
 
-/// <summary>One step of a <see cref="Breadcrumb"/>. A crumb with no <see cref="Href"/> is not a link
+/// <summary>One step of a <see cref="Breadcrumb"/>. A crumb with no <see cref="Crumb.Destination"/> is not a link
 /// — the last crumb is where you already are, and a link to here is a lie.</summary>
 public sealed record Crumb(string Label, string? Destination = null);
 

--- a/src/eQuantic.UI.Primitives/Nodes/CanvasNode.cs
+++ b/src/eQuantic.UI.Primitives/Nodes/CanvasNode.cs
@@ -74,6 +74,12 @@ public interface ICanvasPainter
 /// canvas is not an escape hatch into arbitrary drawing; it is the same nine commands, addressed
 /// directly.
 /// </para>
+/// <para>
+/// The painter does not rotate. For a thin shape that has to READ as turning — confetti, a coin, a
+/// card on edge — animate its WIDTH instead: a rectangle that narrows to almost nothing and opens
+/// again reads as paper seen edge-on, and does so with the physics a flat rotation lacks. A
+/// consumer found this beat the SVG rotate it replaced.
+/// </para>
 /// </summary>
 public sealed class Canvas : VisualNode
 {

--- a/src/eQuantic.UI.Primitives/Nodes/UiComponent.cs
+++ b/src/eQuantic.UI.Primitives/Nodes/UiComponent.cs
@@ -146,12 +146,19 @@ public abstract class StatelessComponent : UiComponent
 }
 
 /// <summary>
-/// A component with internal state mutated through <see cref="SetState"/> — the web SDK's contract.
-/// v1 caveat (pre-reconciler): state lives on the component INSTANCE, so it persists where the
-/// instance persists — the retained root a host holds, or children a parent retains in fields.
-/// Instance-per-build children lose state; positional state retention arrives with the reconciler
-/// (plan W6), and parity with the web's `CreateState`/`ComponentState` split is resolved at the
-/// Core unification.
+/// A component with internal state, mutated through <see cref="SetState"/>. State lives as fields on
+/// the instance, and the instance is RETAINED across the parent's rebuilds by position (same type,
+/// same key) — so a counter keeps counting while the page around it re-renders.
+/// <para>
+/// THE THING TO KNOW BEFORE YOUR FIRST PARAMETERIZED CONSTRUCTOR: the parent's <c>Build</c> still
+/// runs <c>new YourComponent(args)</c> every time, but that fresh instance is NOT the one that
+/// renders. The retained one does — and it learns about the fresh arguments only through
+/// <see cref="UiComponent.AdoptConfig"/>, whose default copies nothing. Leave it alone and the
+/// retained instance shows its FIRST configuration forever: a mood set at frame one, a root folder
+/// that never changes when you navigate. Override <c>AdoptConfig</c> to copy the constructor/init
+/// props across; state fields stay yours. Three components in one consumer app shipped this bug
+/// before the rule was written here.
+/// </para>
 /// </summary>
 public abstract class StatefulComponent : UiComponent
 {

--- a/src/eQuantic.UI.Primitives/Vector/VectorPath.cs
+++ b/src/eQuantic.UI.Primitives/Vector/VectorPath.cs
@@ -72,6 +72,13 @@ public readonly record struct VectorTransform(float A, float B, float C, float D
 /// elevate exactly, and arcs convert through the SVG F.6.5 endpoint→center parameterization split
 /// into ≤90° cubic segments. Numbers follow SVG lexing (".5.5", "1-2", compact arc flags).
 /// <para>
+/// A COMMA IS A SEPARATOR, NEVER A DECIMAL POINT. That is SVG's grammar, so <c>122,5</c> parses as
+/// two numbers — 122 and 5 — with no error anywhere. The trap is on the C# side: a path assembled
+/// with <c>float.ToString()</c> under a culture that writes decimals with a comma (pt, de, fr…)
+/// produces exactly that, and only on machines set to that culture. Format with
+/// <see cref="System.Globalization.CultureInfo.InvariantCulture"/>, always.
+/// </para>
+/// <para>
 /// Malformed data returns what parsed so far: a drawing renders best-effort and never throws at
 /// draw time, because a figure with one bad subpath is still worth showing.
 /// </para>


### PR DESCRIPTION
All three came from OS Cleaner adopting 0.2.0-preview.48, and all three were **measured** before being
reported. No code changes.

## `StatefulComponent` described a world that no longer exists

Its summary said *"v1 caveat (pre-reconciler)"*, that positional retention *"arrives with the
reconciler (plan W6)"*, and that parity is *"resolved at the Core unification"*. Three futures, all
in the past: `AdoptConfig` **is** the reconciler's hook, and Core dissolved in #83.

Rewritten for what is true now — and it leads with the one thing that cost the consumer three
components: the parent's `Build` still runs `new X(args)` every time, but the **retained** instance
is the one that renders, and it learns the fresh arguments only through `AdoptConfig`, whose
default copies nothing. Their mascot kept the mood of frame one (serene and green with the disk at
94%); their tree view kept its first root folder when navigating. The XML on `AdoptConfig` already
said this clearly — but nobody reads `AdoptConfig` first. They read `StatefulComponent`.

## `VectorPath.Parse`: a comma is a separator, never a decimal point

SVG grammar, so `122,5` parses as **two numbers** with no error anywhere. The parser is right. The
trap is on the C# side — a path assembled with `float.ToString()` under pt/de/fr — and it bites only
on machines set to that culture. The lexing paragraph now says so, and says `InvariantCulture`.

## `Canvas`: the painter does not rotate, and the good substitute is width

A rectangle that narrows to almost nothing and opens again reads as paper seen edge-on, with the
physics a flat rotation lacks. The consumer found it beat the SVG rotate it replaced. It belongs
where the next person looks for a rotate that is not there.

## Verification

Primitives builds with the same 20 pre-existing XML warnings as `main`, none of them in these three
files.