### PR TITLE
🔧 chore: 0.2.0-preview.49

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.48</Version>
+        <Version>0.2.0-preview.49</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
The version bump for 0.2.0-preview.49 — one line, as the release rule says.

What ships since 0.2.0-preview.48: #83 (eQuantic.UI.Core dissolved into the assemblies that owned its parts), #84 and #85 (four things consumers found on .48; `[ServerOnly]` answered for the type), #86 (`IWorkspace`; `IFileDialogs`/`IClipboard` stop answering false in silence when AppKit is not loaded), #87 (two things a consumer reads before writing a component), #88 (the build tools are edges of the build graph; EQ4001/EQ4002 name a missing tool).

The migration notes go in the tag itself: `v0.2.0-preview.49` is created as an annotated tag on this PR's merge commit, its message being the notes (`--cleanup=whitespace`, so the markdown headers survive). Nothing else changes in this PR.