### PR TITLE
📝 docs: the build-flow documentation describes the tree as it is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,13 +100,16 @@ src/
 ├── eQuantic.UI.Server/         # ASP.NET Core SSR, Server Actions, metadata and assets
 ├── eQuantic.UI.Compiler/       # Roslyn-based C# to JavaScript transpiler (the library)
 ├── eQuantic.Build/             # eqc — the transpiler CLI the SDK runs; ships as tools/net10.0/eqc.dll
-├── eQuantic.UI.Native.Build/   # eqicon — vectors, app icons, manifests; ships as tools/net10.0/eqicon.dll
 ├── eQuantic.UI.Generators/     # Source generator: the declarative factory surface for an app's own components
 ├── eQuantic.UI.Sdk/            # MSBuild SDK for web apps (Sdk.props, Sdk.targets, Resources/boot.ts)
-├── eQuantic.UI.Sdk.Native/     # MSBuild SDK for device apps (macOS, iOS, Android)
 ├── eQuantic.UI.Runtime/        # TypeScript browser runtime (reconciler, state, events) → runtime.js
 ├── eQuantic.UI.Runtime.*/      # Embedded Bun, one package per OS+arch (Osx64, OsxArm64, Win64, WinArm64, Linux64, LinuxArm64)
-├── eQuantic.UI.Native.*/       # Photon: Engine (+ Metal, Vulkan, Reference), Framework, Hosting, Components, Shell.*
+├── eQuantic.UI.Native.*/       # PHOTON, the native track: Engine (+ .Metal/.Vulkan/.Reference backends),
+│                               # Framework, Components, Hosting, Build (eqicon — vectors, app icons, manifests;
+│                               # ships as tools/net10.0/eqicon.dll), Generators, and the shells —
+│                               # Shell.Apple (shared Apple code), Shell.MacOS, Shell.iOS, Shell.Android,
+│                               # Shell.Windows (Win32 + DirectWrite/Direct2D/WIC; Vulkan or the Reference backend)
+├── eQuantic.UI.Sdk.Native/     # MSBuild SDK for Photon apps: picks the shell per TFM and, on desktop, per host OS
 ├── eQuantic.UI.Templates/      # dotnet new equantic-app / equantic-native
 ├── eQuantic.UI.Codegen/        # Writers for generated files (one CodeWriter, one writer per file type)
 ├── eQuantic.UI.Web.Build/      # Generators of the runtime's TypeScript twins (design system, enum unions, icons, SDK strings)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ targeted it never ran and is gone.
 src/
 ├── eQuantic.UI.Primitives/     # Abstract visual vocabulary, tokens and the contract attributes (zero deps)
 ├── eQuantic.UI.Components/     # WRITE-ONCE component library (authored against Primitives; realized per target)
+├── eQuantic.UI.Charts/         # WRITE-ONCE chart library (BarChart…): runtime-provided like Components, colour from IAppTheme.Data
 ├── eQuantic.UI.Web/            # WEB REALIZER + the DOM escape hatch (HtmlElement, HtmlNode, ClassBuilder)
 ├── eQuantic.UI.Server/         # ASP.NET Core SSR, Server Actions, metadata and assets
 ├── eQuantic.UI.Compiler/       # Roslyn-based C# to JavaScript transpiler (the library)
@@ -114,7 +115,7 @@ src/
 ├── eQuantic.UI.Codegen/        # Writers for generated files (one CodeWriter, one writer per file type)
 ├── eQuantic.UI.Web.Build/      # Generators of the runtime's TypeScript twins (design system, enum unions, icons, SDK strings)
 ├── eQuantic.UI.Design*/        # The visual editor's design host
-└── eQuantic.UI.<Pack>/         # Icon catalogs (Lucide, Heroicons, …), Charts*, Gtm, Images, Lottie, Email, Material
+└── eQuantic.UI.<Pack>/         # Icon catalogs (Lucide, Heroicons, …), Charts.ChartJs/.ApexCharts, Gtm, Images, Lottie, Email, Material
 ```
 
 ### Package Architecture (Self-Contained Design)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ All commits must be authored solely by the repository owner without any co-autho
 
 ## Project Overview
 
-**eQuantic.UI** is a Flutter-inspired component-based UI framework for .NET that compiles C# components directly to optimized JavaScript at build time (not WASM). It provides type-safe, HTML-native components with a minimal runtime (~49KB).
+**eQuantic.UI** is a Flutter-inspired component-based UI framework for .NET that compiles C# components directly to optimized JavaScript at build time (not WASM). It provides type-safe, HTML-native components with a small runtime (its gzip size is measured by the site's build and not quoted here — it changes every release).
 
 ### Core Principles
 
@@ -53,9 +53,9 @@ The TypeScript runtime is built using **embedded Bun** (bundled in platform-spec
 cd src/eQuantic.UI.Runtime
 
 # Build TypeScript runtime (using embedded Bun - auto-extracted if needed)
-# macOS:   uses src/eQuantic.UI.Runtime.Osx64/tools/bun/bun-darwin
-# Linux:   uses src/eQuantic.UI.Runtime.Linux64/tools/bun/bun-linux
-# Windows: uses src/eQuantic.UI.Runtime.Win64/tools/bun/bun.exe
+# macOS:   src/eQuantic.UI.Runtime.OsxArm64 (Apple Silicon) or .Osx64 — tools/bun/bun-darwin
+# Linux:   src/eQuantic.UI.Runtime.LinuxArm64 or .Linux64 — tools/bun/bun-linux
+# Windows: src/eQuantic.UI.Runtime.WinArm64 or .Win64 — tools/bun/bun.exe
 
 # Run TypeScript tests
 npm run test           # vitest
@@ -65,36 +65,28 @@ npm run lint           # eslint
 npm run format         # prettier
 ```
 
-### Bootstrap Build (required before first build)
+### Development Workflow (building the samples)
 
-The SDK depends on other packages. Run these in order before a full solution build:
-
-```bash
-dotnet pack src/eQuantic.UI.Components/eQuantic.UI.Components.csproj --configuration Release
-dotnet pack src/eQuantic.UI.Server/eQuantic.UI.Server.csproj --configuration Release
-dotnet pack src/eQuantic.UI.Sdk/eQuantic.UI.Sdk.csproj --configuration Release
-```
-
-### Development Workflow (rebuilding with samples)
-
-When making changes to the framework and testing with samples, the full build chain must be rebuilt:
+The samples build against the framework PROJECTS, never against packages. `Sdk.props` sees the source
+tree beside it (`IsEQuanticDevMode`) and swaps every `PackageReference` for a `ProjectReference`;
+`Sdk.targets` runs the `eqc` and `eqicon` the graph just built (`_EqSourceTree`). The two tools are
+`ProjectReference` edges with `ReferenceOutputAssembly=false`, so a cold `dotnet build` orders them
+itself — no bootstrap pack, no local feed, no cache step between an edit and the sample that shows it:
 
 ```bash
-# Option 1: Use the dev-rebuild script (recommended)
-./scripts/dev-rebuild.sh              # Rebuilds all and tests with CounterApp
-./scripts/dev-rebuild.sh TodoListApp  # Specify different sample
-
-# Option 2: Manual steps
-cd src/eQuantic.UI.Runtime && npm run build  # If TypeScript changed
-dotnet pack -c Release                        # Pack all packages
-dotnet msbuild -t:ClearEQuanticCache          # Clear NuGet cache (eQuantic only)
-cd samples/CounterApp && dotnet restore --force && dotnet build
-
-# Option 3: Clear only NuGet cache
-dotnet msbuild -t:ClearEQuanticCache
+dotnet build samples/DefaultUIDashboard   # web; PhotonDesktop and WalletMobile are the native heads
 ```
 
-**Why is this needed?** The samples use NuGet packages (like a real consumer would). Changes to the framework must flow through: source → pack → NuGet cache → restore → build sample.
+`runtime.js` in a source-tree build is `src/eQuantic.UI.Runtime/dist/index.js`, which the Runtime
+project's `GenerateRuntimeBundle` target regenerates with the embedded bun (from
+`src/eQuantic.UI.Sdk/Resources/boot.ts`) whenever a runtime `.ts` changed — part of the same graph.
+
+To validate a change through the REAL consumer path — packages, `global.json`, restore — pack a local
+feed and consume it from an app; `dotnet msbuild -t:ClearEQuanticCache` clears every `equantic.*`
+package from the NuGet cache between repacks. The recipe is the wiki's
+[BuildFlow](https://github.com/equantic/equantic-ui/wiki/BuildFlow) page, "Consuming an unreleased
+SDK from local packages". `artifacts/packages/` is part of neither flow: the Debug auto-pack that once
+targeted it never ran and is gone.
 
 ## Architecture
 
@@ -102,18 +94,24 @@ dotnet msbuild -t:ClearEQuanticCache
 
 ```
 src/
-├── eQuantic.UI.Web/          # WEB REALIZER + the DOM escape hatch (HtmlElement, HtmlNode)
-├── eQuantic.UI.Primitives/  # Abstract visual vocabulary + design tokens (zero deps)
-├── eQuantic.UI.Components/  # WRITE-ONCE component library (authored against Primitives; realized per target)
-├── eQuantic.UI.Web.Components/  # Legacy web-only set (deprecated; dies piece by piece)
-├── eQuantic.UI.Compiler/    # Roslyn-based C# to JavaScript transpiler
-├── eQuantic.UI.Sdk/         # MSBuild SDK for project integration
-├── eQuantic.UI.Server/      # ASP.NET Core SSR and Server Actions
-├── eQuantic.UI.Runtime/     # TypeScript browser runtime (reconciler, state, events)
-├── eQuantic.UI.Runtime.*/   # Platform-specific Bun bundles (Osx64, Win64, Linux64)
-├── eQuantic.UI.Tailwind/    # Tailwind CSS integration
-├── eQuantic.UI.CLI/         # Developer CLI tools
-└── eQuantic.Build/          # MSBuild tasks
+├── eQuantic.UI.Primitives/     # Abstract visual vocabulary, tokens and the contract attributes (zero deps)
+├── eQuantic.UI.Components/     # WRITE-ONCE component library (authored against Primitives; realized per target)
+├── eQuantic.UI.Web/            # WEB REALIZER + the DOM escape hatch (HtmlElement, HtmlNode, ClassBuilder)
+├── eQuantic.UI.Server/         # ASP.NET Core SSR, Server Actions, metadata and assets
+├── eQuantic.UI.Compiler/       # Roslyn-based C# to JavaScript transpiler (the library)
+├── eQuantic.Build/             # eqc — the transpiler CLI the SDK runs; ships as tools/net10.0/eqc.dll
+├── eQuantic.UI.Native.Build/   # eqicon — vectors, app icons, manifests; ships as tools/net10.0/eqicon.dll
+├── eQuantic.UI.Generators/     # Source generator: the declarative factory surface for an app's own components
+├── eQuantic.UI.Sdk/            # MSBuild SDK for web apps (Sdk.props, Sdk.targets, Resources/boot.ts)
+├── eQuantic.UI.Sdk.Native/     # MSBuild SDK for device apps (macOS, iOS, Android)
+├── eQuantic.UI.Runtime/        # TypeScript browser runtime (reconciler, state, events) → runtime.js
+├── eQuantic.UI.Runtime.*/      # Embedded Bun, one package per OS+arch (Osx64, OsxArm64, Win64, WinArm64, Linux64, LinuxArm64)
+├── eQuantic.UI.Native.*/       # Photon: Engine (+ Metal, Vulkan, Reference), Framework, Hosting, Components, Shell.*
+├── eQuantic.UI.Templates/      # dotnet new equantic-app / equantic-native
+├── eQuantic.UI.Codegen/        # Writers for generated files (one CodeWriter, one writer per file type)
+├── eQuantic.UI.Web.Build/      # Generators of the runtime's TypeScript twins (design system, enum unions, icons, SDK strings)
+├── eQuantic.UI.Design*/        # The visual editor's design host
+└── eQuantic.UI.<Pack>/         # Icon catalogs (Lucide, Heroicons, …), Charts*, Gtm, Images, Lottie, Email, Material
 ```
 
 ### Package Architecture (Self-Contained Design)
@@ -122,28 +120,28 @@ eQuantic.UI follows a **self-contained package architecture** where each package
 
 **Key Packages:**
 
-- **eQuantic.UI.Runtime** - Packages `runtime.js` (~49KB) at `tools/runtime/runtime.js`
+- **eQuantic.UI.Runtime** - Packages `runtime.js` at `tools/runtime/runtime.js`
 - **eQuantic.UI.Components** - Packages C# source files at `tools/source/*.cs` for compiler type resolution
-- **eQuantic.UI.Sdk** - Orchestrates build, references other packages via `$(PkgeQuantic_UI_*)` NuGet properties
+- **eQuantic.UI.Sdk** - Orchestrates build, references other packages via `$(PkgeQuantic_UI_*)` NuGet properties, ships `eqc` and `eqicon` under `tools/net10.0/`
 
 **Design Principles:**
 
 1. ✅ Each package is self-contained (no embedding of other packages' artifacts)
 2. ✅ SDK references packages via NuGet-generated `$(Pkg*)` properties
-3. ✅ Enables independent versioning (e.g., Runtime 0.1.3 + SDK 0.1.2)
+3. ✅ Reads whatever version NuGet resolved — the packages ship at ONE version and the SDK pins its siblings to its own
 4. ✅ No artifact duplication across packages
 5. ✅ Clear interfaces between packages
 
 **Example Resolution:**
 
 ```xml
-<!-- Auto-generated by NuGet in obj/*.nuget.g.props -->
-<PkgeQuantic_UI_Runtime>~/.nuget/packages/equantic.ui.runtime/0.1.2</PkgeQuantic_UI_Runtime>
-<PkgeQuantic_UI_Components>~/.nuget/packages/equantic.ui.components/0.1.2</PkgeQuantic_UI_Components>
+<!-- Auto-generated by NuGet in obj/*.nuget.g.props — only for a PackageReference with GeneratePathProperty="true" -->
+<PkgeQuantic_UI_Runtime>~/.nuget/packages/equantic.ui.runtime/<version></PkgeQuantic_UI_Runtime>
+<PkgeQuantic_UI_Components>~/.nuget/packages/equantic.ui.components/<version></PkgeQuantic_UI_Components>
 
-<!-- Used in Sdk.targets -->
-<_RuntimeSource>$(PkgeQuantic_UI_Runtime)/tools/runtime/runtime.js</_RuntimeSource>
-<_ComponentsSource>$(PkgeQuantic_UI_Components)/tools/source</_ComponentsSource>
+<!-- Used in Sdk.targets; beside a source tree no $(Pkg*) is set and the tree's dist/ and sources are the fallback -->
+<_RuntimeSourcePath>$(PkgeQuantic_UI_Runtime)/tools/runtime/runtime.js</_RuntimeSourcePath>
+<_StandardComponentsDir>$(PkgeQuantic_UI_Components)/tools/source</_StandardComponentsDir>
 ```
 
 See [wiki/PackageArchitecture](https://github.com/equantic/equantic-ui/wiki/PackageArchitecture) for complete documentation.
@@ -155,11 +153,11 @@ dotnet build
     ↓
 MSBuild: CompileEQuanticUI (BeforeTargets="Build")
     ↓
-1. Roslyn parse /Pages/**/*.cs + Components source from $(PkgeQuantic_UI_Components)
+1. Roslyn parse /Pages/**/*.cs + Components source from $(PkgeQuantic_UI_Components) (or src/eQuantic.UI.Components beside a source tree)
 2. Detect StatefulComponent/StatelessComponent classes
 3. Generate TypeScript intermediate (.ts files)
 4. Invoke embedded Bun for bundling
-5. CopyEQuanticRuntime: Copy runtime.js from $(PkgeQuantic_UI_Runtime)
+5. CopyEQuanticRuntime: Copy runtime.js + equantic.css from $(PkgeQuantic_UI_Runtime) (or the tree's dist/index.js)
 6. Output: wwwroot/_equantic/
    ├─ runtime.js (from Runtime package)
    └─ *.js (compiled components)
@@ -221,10 +219,21 @@ src/
 
 ### Bundle Strategy
 
-1. **Core Runtime** (`/_equantic/runtime.js` ~15kb): Virtual DOM, events, state, server actions bridge
-2. **Component Library** (`/_equantic/widgets.js` ~30kb): Standard components
-3. **Page Bundles** (`/_equantic/pages/*.js`): Per-route lazy loading
-4. **Shared Chunks** (`/_equantic/chunks/`): Automatic code splitting
+What a build actually writes under `wwwroot/_equantic/` (sizes are measured by the site's build, not
+quoted here):
+
+1. **runtime.js** — virtual DOM, events, state, the server-actions bridge AND the shared component
+   library, whose transpiled modules ship INSIDE it (`[RuntimeProvided]`); eqc routes
+   `using eQuantic.UI.Components` imports there rather than emitting a per-app copy. The page reaches
+   it as the bare module `@equantic/runtime` through the shell's import map, and the Server serves its
+   own embedded copy at that route
+2. **`<Component>.js` + `.js.map`** — one module per page or component, flat (a hash suffix
+   disambiguates types that share a name). `boot.ts` imports the page's module dynamically on
+   navigation, so per-route lazy loading falls out of the module graph — there is no `pages/` folder
+   and no chunk splitting
+3. **equantic.css** — the base styles, copied from the Runtime package beside runtime.js
+4. **strings/`<culture>`.json** — the culture catalogs, when the app has `.resx`
+5. **icons/** — the app icon sizes and the web manifest, when an `AppIcon` is declared
 
 ## Component Attributes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,9 +57,10 @@ to `aria-label` and never to `alt`, and `KeyModifiers.Alt` — the KEY — carri
 
 ### What the developer's csproj says
 
-`<Project Sdk="eQuantic.UI.Sdk">` and nothing else. No `PackageReference` — the SDK adds Core,
-Components, Web, Server, Runtime and the right embedded-bun package itself. The developer writes
-one only to opt IN to something extra, an icon pack being the usual case.
+`<Project Sdk="eQuantic.UI.Sdk">` and nothing else. No `PackageReference` — the SDK adds
+Primitives, Components, Web, Server, Runtime, the Generators analyzer and the right embedded-bun
+package itself. The developer writes one only to opt IN to something extra, an icon pack being the
+usual case.
 
 That is why the bun ships as per-OS, per-architecture packages (`eQuantic.UI.Runtime.Osx64`,
 `.WinArm64`, …) selected by condition in `Sdk.props`: bundling is a build-time need the developer
@@ -168,9 +169,9 @@ The TypeScript runtime is built using **embedded Bun** (bundled in platform-spec
 cd src/eQuantic.UI.Runtime
 
 # Build TypeScript runtime (using embedded Bun - auto-extracted if needed)
-# macOS:   uses src/eQuantic.UI.Runtime.Osx64/tools/bun/bun-darwin
-# Linux:   uses src/eQuantic.UI.Runtime.Linux64/tools/bun/bun-linux
-# Windows: uses src/eQuantic.UI.Runtime.Win64/tools/bun/bun.exe
+# macOS:   src/eQuantic.UI.Runtime.OsxArm64 (Apple Silicon) or .Osx64 — tools/bun/bun-darwin
+# Linux:   src/eQuantic.UI.Runtime.LinuxArm64 or .Linux64 — tools/bun/bun-linux
+# Windows: src/eQuantic.UI.Runtime.WinArm64 or .Win64 — tools/bun/bun.exe
 
 # Run TypeScript tests
 npm run test           # vitest
@@ -199,36 +200,28 @@ The `metallib` step additionally needs the Xcode Metal Toolchain
 (`xcodebuild -downloadComponent MetalToolchain`); without it the script warns and leaves the
 committed `metallib` untouched.
 
-### Bootstrap Build (required before first build)
+### Development Workflow (building the samples)
 
-The SDK depends on other packages. Run these in order before a full solution build:
-
-```bash
-dotnet pack src/eQuantic.UI.Components/eQuantic.UI.Components.csproj --configuration Release
-dotnet pack src/eQuantic.UI.Server/eQuantic.UI.Server.csproj --configuration Release
-dotnet pack src/eQuantic.UI.Sdk/eQuantic.UI.Sdk.csproj --configuration Release
-```
-
-### Development Workflow (rebuilding with samples)
-
-When making changes to the framework and testing with samples, the full build chain must be rebuilt:
+The samples build against the framework PROJECTS, never against packages. `Sdk.props` sees the source
+tree beside it (`IsEQuanticDevMode`) and swaps every `PackageReference` for a `ProjectReference`;
+`Sdk.targets` runs the `eqc` and `eqicon` the graph just built (`_EqSourceTree`). The two tools are
+`ProjectReference` edges with `ReferenceOutputAssembly=false`, so a cold `dotnet build` orders them
+itself — no bootstrap pack, no local feed, no cache step between an edit and the sample that shows it:
 
 ```bash
-# Option 1: Use the dev-rebuild script (recommended)
-./scripts/dev-rebuild.sh              # Rebuilds all and tests with CounterApp
-./scripts/dev-rebuild.sh TodoListApp  # Specify different sample
-
-# Option 2: Manual steps
-cd src/eQuantic.UI.Runtime && npm run build  # If TypeScript changed
-dotnet pack -c Release                        # Pack all packages
-dotnet msbuild -t:ClearEQuanticCache          # Clear NuGet cache (eQuantic only)
-cd samples/CounterApp && dotnet restore --force && dotnet build
-
-# Option 3: Clear only NuGet cache
-dotnet msbuild -t:ClearEQuanticCache
+dotnet build samples/DefaultUIDashboard   # web; PhotonDesktop and WalletMobile are the native heads
 ```
 
-**Why is this needed?** The samples use NuGet packages (like a real consumer would). Changes to the framework must flow through: source → pack → NuGet cache → restore → build sample.
+`runtime.js` in a source-tree build is `src/eQuantic.UI.Runtime/dist/index.js`, which the Runtime
+project's `GenerateRuntimeBundle` target regenerates with the embedded bun (from
+`src/eQuantic.UI.Sdk/Resources/boot.ts`) whenever a runtime `.ts` changed — part of the same graph.
+
+To validate a change through the REAL consumer path — packages, `global.json`, restore — pack a local
+feed and consume it from an app; `dotnet msbuild -t:ClearEQuanticCache` clears every `equantic.*`
+package from the NuGet cache between repacks. The recipe is the wiki's
+[BuildFlow](https://github.com/equantic/equantic-ui/wiki/BuildFlow) page, "Consuming an unreleased
+SDK from local packages". `artifacts/packages/` is part of neither flow: the Debug auto-pack that once
+targeted it never ran and is gone.
 
 ## Architecture
 
@@ -236,23 +229,28 @@ dotnet msbuild -t:ClearEQuanticCache
 
 ```
 src/
-├── eQuantic.UI.Native.*/    # PHOTON, the native track: Engine (+ .Metal/.Vulkan/.Reference backends),
-│                            # Framework, Components, Hosting, Build (eqicon), Generators, and the shells —
-│                            # Shell.Apple (shared Apple code), Shell.MacOS, Shell.iOS, Shell.Android,
-│                            # Shell.Windows (Win32 + DirectWrite/Direct2D/WIC; Vulkan or the Reference backend)
-├── eQuantic.UI.Sdk.Native/  # MSBuild SDK for Photon apps: picks the shell per TFM and, on desktop, per host OS
-├── eQuantic.UI.Web/          # WEB REALIZER + the DOM escape hatch (HtmlElement, HtmlNode)
-├── eQuantic.UI.Primitives/  # Abstract visual vocabulary + design tokens (zero deps)
-├── eQuantic.UI.Components/  # WRITE-ONCE component library (authored against Primitives; realized per target)
-├── eQuantic.UI.Charts/      # WRITE-ONCE chart library (BarChart…): runtime-provided like Components, colour from IAppTheme.Data
-├── eQuantic.UI.Compiler/    # Roslyn-based C# to JavaScript transpiler
-├── eQuantic.UI.Sdk/         # MSBuild SDK for project integration
-├── eQuantic.UI.Server/      # ASP.NET Core SSR and Server Actions
-├── eQuantic.UI.Runtime/     # TypeScript browser runtime (reconciler, state, events)
-├── eQuantic.UI.Runtime.*/   # Platform-specific Bun bundles (Osx64, Win64, Linux64)
-├── eQuantic.UI.Tailwind/    # Tailwind CSS integration
-├── eQuantic.UI.CLI/         # Developer CLI tools
-└── eQuantic.Build/          # MSBuild tasks
+├── eQuantic.UI.Primitives/     # Abstract visual vocabulary, tokens and the contract attributes (zero deps)
+├── eQuantic.UI.Components/     # WRITE-ONCE component library (authored against Primitives; realized per target)
+├── eQuantic.UI.Charts/         # WRITE-ONCE chart library (BarChart…): runtime-provided like Components, colour from IAppTheme.Data
+├── eQuantic.UI.Web/            # WEB REALIZER + the DOM escape hatch (HtmlElement, HtmlNode, ClassBuilder)
+├── eQuantic.UI.Server/         # ASP.NET Core SSR, Server Actions, metadata and assets
+├── eQuantic.UI.Compiler/       # Roslyn-based C# to JavaScript transpiler (the library)
+├── eQuantic.Build/             # eqc — the transpiler CLI the SDK runs; ships as tools/net10.0/eqc.dll
+├── eQuantic.UI.Generators/     # Source generator: the declarative factory surface for an app's own components
+├── eQuantic.UI.Sdk/            # MSBuild SDK for web apps (Sdk.props, Sdk.targets, Resources/boot.ts)
+├── eQuantic.UI.Runtime/        # TypeScript browser runtime (reconciler, state, events) → runtime.js
+├── eQuantic.UI.Runtime.*/      # Embedded Bun, one package per OS+arch (Osx64, OsxArm64, Win64, WinArm64, Linux64, LinuxArm64)
+├── eQuantic.UI.Native.*/       # PHOTON, the native track: Engine (+ .Metal/.Vulkan/.Reference backends),
+│                               # Framework, Components, Hosting, Build (eqicon — vectors, app icons, manifests;
+│                               # ships as tools/net10.0/eqicon.dll), Generators, and the shells —
+│                               # Shell.Apple (shared Apple code), Shell.MacOS, Shell.iOS, Shell.Android,
+│                               # Shell.Windows (Win32 + DirectWrite/Direct2D/WIC; Vulkan or the Reference backend)
+├── eQuantic.UI.Sdk.Native/     # MSBuild SDK for Photon apps: picks the shell per TFM and, on desktop, per host OS
+├── eQuantic.UI.Templates/      # dotnet new equantic-app / equantic-native
+├── eQuantic.UI.Codegen/        # Writers for generated files (one CodeWriter, one writer per file type)
+├── eQuantic.UI.Web.Build/      # Generators of the runtime's TypeScript twins (design system, enum unions, icons, SDK strings)
+├── eQuantic.UI.Design*/        # The visual editor's design host
+└── eQuantic.UI.<Pack>/         # Icon catalogs (Lucide, Heroicons, …), Charts.ChartJs/.ApexCharts, Gtm, Images, Lottie, Email, Material
 ```
 
 ### Package Architecture (Self-Contained Design)
@@ -263,26 +261,26 @@ eQuantic.UI follows a **self-contained package architecture** where each package
 
 - **eQuantic.UI.Runtime** - Packages `runtime.js` at `tools/runtime/runtime.js`
 - **eQuantic.UI.Components** - Packages C# source files at `tools/source/*.cs` for compiler type resolution
-- **eQuantic.UI.Sdk** - Orchestrates build, references other packages via `$(PkgeQuantic_UI_*)` NuGet properties
+- **eQuantic.UI.Sdk** - Orchestrates build, references other packages via `$(PkgeQuantic_UI_*)` NuGet properties, ships `eqc` and `eqicon` under `tools/net10.0/`
 
 **Design Principles:**
 
 1. ✅ Each package is self-contained (no embedding of other packages' artifacts)
 2. ✅ SDK references packages via NuGet-generated `$(Pkg*)` properties
-3. ✅ Enables independent versioning (e.g., Runtime 0.1.3 + SDK 0.1.2)
+3. ✅ Reads whatever version NuGet resolved — the packages ship at ONE version and the SDK pins its siblings to its own
 4. ✅ No artifact duplication across packages
 5. ✅ Clear interfaces between packages
 
 **Example Resolution:**
 
 ```xml
-<!-- Auto-generated by NuGet in obj/*.nuget.g.props -->
-<PkgeQuantic_UI_Runtime>~/.nuget/packages/equantic.ui.runtime/0.1.2</PkgeQuantic_UI_Runtime>
-<PkgeQuantic_UI_Components>~/.nuget/packages/equantic.ui.components/0.1.2</PkgeQuantic_UI_Components>
+<!-- Auto-generated by NuGet in obj/*.nuget.g.props — only for a PackageReference with GeneratePathProperty="true" -->
+<PkgeQuantic_UI_Runtime>~/.nuget/packages/equantic.ui.runtime/<version></PkgeQuantic_UI_Runtime>
+<PkgeQuantic_UI_Components>~/.nuget/packages/equantic.ui.components/<version></PkgeQuantic_UI_Components>
 
-<!-- Used in Sdk.targets -->
-<_RuntimeSource>$(PkgeQuantic_UI_Runtime)/tools/runtime/runtime.js</_RuntimeSource>
-<_ComponentsSource>$(PkgeQuantic_UI_Components)/tools/source</_ComponentsSource>
+<!-- Used in Sdk.targets; beside a source tree no $(Pkg*) is set and the tree's dist/ and sources are the fallback -->
+<_RuntimeSourcePath>$(PkgeQuantic_UI_Runtime)/tools/runtime/runtime.js</_RuntimeSourcePath>
+<_StandardComponentsDir>$(PkgeQuantic_UI_Components)/tools/source</_StandardComponentsDir>
 ```
 
 See [wiki/PackageArchitecture](https://github.com/equantic/equantic-ui/wiki/PackageArchitecture) for complete documentation.
@@ -294,11 +292,11 @@ dotnet build
     ↓
 MSBuild: CompileEQuanticUI (BeforeTargets="Build")
     ↓
-1. Roslyn parse /Pages/**/*.cs + Components source from $(PkgeQuantic_UI_Components)
+1. Roslyn parse /Pages/**/*.cs + Components source from $(PkgeQuantic_UI_Components) (or src/eQuantic.UI.Components beside a source tree)
 2. Detect StatefulComponent/StatelessComponent classes
 3. Generate TypeScript intermediate (.ts files)
 4. Invoke embedded Bun for bundling
-5. CopyEQuanticRuntime: Copy runtime.js from $(PkgeQuantic_UI_Runtime)
+5. CopyEQuanticRuntime: Copy runtime.js + equantic.css from $(PkgeQuantic_UI_Runtime) (or the tree's dist/index.js)
 6. Output: wwwroot/_equantic/
    ├─ runtime.js (from Runtime package)
    └─ *.js (compiled components)
@@ -402,10 +400,21 @@ src/
 
 ### Bundle Strategy
 
-1. **Core Runtime** (`/_equantic/runtime.js` ~15kb): Virtual DOM, events, state, server actions bridge
-2. **Component Library** (`/_equantic/widgets.js` ~30kb): Standard components
-3. **Page Bundles** (`/_equantic/pages/*.js`): Per-route lazy loading
-4. **Shared Chunks** (`/_equantic/chunks/`): Automatic code splitting
+What a build actually writes under `wwwroot/_equantic/` (sizes are measured by the site's build, not
+quoted here):
+
+1. **runtime.js** — virtual DOM, events, state, the server-actions bridge AND the shared component
+   library, whose transpiled modules ship INSIDE it (`[RuntimeProvided]`); eqc routes
+   `using eQuantic.UI.Components` imports there rather than emitting a per-app copy. The page reaches
+   it as the bare module `@equantic/runtime` through the shell's import map, and the Server serves its
+   own embedded copy at that route
+2. **`<Component>.js` + `.js.map`** — one module per page or component, flat (a hash suffix
+   disambiguates types that share a name). `boot.ts` imports the page's module dynamically on
+   navigation, so per-route lazy loading falls out of the module graph — there is no `pages/` folder
+   and no chunk splitting
+3. **equantic.css** — the base styles, copied from the Runtime package beside runtime.js
+4. **strings/`<culture>`.json** — the culture catalogs, when the app has `.resx`
+5. **icons/** — the app icon sizes and the web manifest, when an `AppIcon` is declared
 
 ## Component Attributes
 

--- a/artifacts/packages/.gitkeep
+++ b/artifacts/packages/.gitkeep
@@ -1,3 +1,4 @@
-# The local NuGet source NuGet.config declares. A Debug build fills it; a fresh clone must still
-# HAVE it, because NuGet refuses to restore against a source that is not there (NU1301) — which is
-# every CI job, and was two separate red builds before this file existed.
+# The local NuGet source nuget.config declares. Nothing in a source-tree build fills it any more —
+# the Debug auto-pack that once did never ran, and went in #88 — but a fresh clone must still HAVE
+# it, because NuGet refuses to restore against a source that is not there (NU1301) — which is every
+# CI job, and was two separate red builds before this file existed.

--- a/docs/COMPILE-TIME-EVALUATION-INDEX.md
+++ b/docs/COMPILE-TIME-EVALUATION-INDEX.md
@@ -56,16 +56,19 @@ generic pieces (`ClassBuilder`, `[CompileTimeEvaluate]`) are what remains.
 
 ## Implementation Status
 
-### ✅ Completed
+### ✅ Completed, and still here
 
-- [x] `[CompileTimeEvaluate]` attribute in Core
-- [x] `TailwindClass` struct with implicit operators
-- [x] Complete typed object implementation (Display, Flex, Bg, Text, etc.)
-- [x] Helper methods (Dark, Hover, Responsive, etc.)
-- [x] `ClassBuilder` in Core (framework-agnostic)
-- [x] Simplified `TWBuilder` (no inheritance code smell)
+- [x] `[CompileTimeEvaluate]` attribute, in `eQuantic.UI.Web.Styling`
+- [x] `ClassBuilder` (framework-agnostic), in `eQuantic.UI.Web.Styling`
 - [x] Comprehensive documentation
 - [x] Examples and use cases
+
+### 🗑 Completed, then removed with the Tailwind adapter (0704a3d0, 2026-08-08)
+
+- `TailwindClass` struct with implicit operators
+- Complete typed object implementation (Display, Flex, Bg, Text, etc.)
+- Helper methods (Dark, Hover, Responsive, etc.)
+- Simplified `TWBuilder` (no inheritance code smell)
 
 ### ⏳ Pending (Compiler Work)
 
@@ -204,7 +207,7 @@ When implementing compile-time evaluation in the compiler:
 - **v0.1.2**
   - Added `[CompileTimeEvaluate]` attribute
   - Implemented `TailwindClass` with typed objects
-  - Created `ClassBuilder` in Core
+  - Created `ClassBuilder` (in `eQuantic.UI.Core`, where it lived at the time)
   - Comprehensive documentation
   - Awaiting compiler implementation
 - **Since then**

--- a/docs/COMPILE-TIME-EVALUATION-INDEX.md
+++ b/docs/COMPILE-TIME-EVALUATION-INDEX.md
@@ -9,7 +9,7 @@ This directory contains comprehensive documentation for implementing **compile-t
 ### For Framework Users
 
 - **[README.md](README.md)** - Main project documentation with Tailwind examples
-- **[TYPED-EXAMPLES.md](src/eQuantic.UI.Tailwind/TYPED-EXAMPLES.md)** - Real-world examples using typed objects with + operator
+- **TYPED-EXAMPLES.md** - shipped with the Tailwind adapter and removed with it (see *Tailwind Implementation* below)
 
 ### For Compiler Developers
 
@@ -41,17 +41,18 @@ This directory contains comprehensive documentation for implementing **compile-t
 
 | File | Description |
 |------|-------------|
-| `src/eQuantic.UI.Core/Styling/CompileTimeEvaluateAttribute.cs` | Generic attribute for marking types |
-| `src/eQuantic.UI.Core/Styling/ClassBuilder.cs` | Generic CSS class builder (framework-agnostic) |
+| `src/eQuantic.UI.Web/Styling/CompileTimeEvaluateAttribute.cs` | Generic attribute for marking types |
+| `src/eQuantic.UI.Web/Styling/ClassBuilder.cs` | Generic CSS class builder (framework-agnostic) |
 
-### Tailwind Implementation
+Both lived in `eQuantic.UI.Core` until that assembly was dissolved into the ones that owned its parts
+(#83); the DOM-side styling helpers went to **Web**.
 
-| File | Description |
-|------|-------------|
-| `src/eQuantic.UI.Tailwind/TailwindClass.cs` | Typed value object with `[CompileTimeEvaluate]` |
-| `src/eQuantic.UI.Tailwind/TWTyped.cs` | All Tailwind utilities as typed objects |
-| `src/eQuantic.UI.Tailwind/TWBuilder.cs` | Fluent builder (delegates to ClassBuilder) |
-| `src/eQuantic.UI.Tailwind/TYPED-EXAMPLES.md` | Real-world usage examples |
+### Tailwind Implementation (removed)
+
+The `eQuantic.UI.Tailwind` project — `TailwindClass`, `TWTyped`, `TWBuilder` and `TYPED-EXAMPLES.md` —
+was removed in 0704a3d0 (2026-08-08): the atomic styling engine is the product, and the framework
+ships exactly one styling engine. The `TW.*` examples on this page describe that removed adapter; the
+generic pieces (`ClassBuilder`, `[CompileTimeEvaluate]`) are what remains.
 
 ## Implementation Status
 
@@ -72,7 +73,7 @@ This directory contains comprehensive documentation for implementing **compile-t
 - [ ] Expression evaluator implementation
 - [ ] Integration into code generator
 - [ ] Unit tests for compiler
-- [ ] End-to-end testing with TodoListApp
+- [ ] End-to-end testing with the web sample (`samples/DefaultUIDashboard`)
 
 ## Quick Example
 
@@ -161,23 +162,21 @@ ClassName = MUI.Flex + MUI.P(2)
 
 ### Manual Testing (Current)
 
-1. Build Core and Tailwind packages:
+The samples build against the framework PROJECTS — the SDK's `Sdk.props` switches to project
+references beside a source tree — so there is no pack, no local feed and no cache step between an
+edit and the sample:
+
+1. Build and run the web sample:
    ```bash
-   dotnet pack src/eQuantic.UI.Core -c Release -o artifacts/packages
-   dotnet pack src/eQuantic.UI.Tailwind -c Release -o artifacts/packages
+   dotnet build samples/DefaultUIDashboard
+   dotnet run --project samples/DefaultUIDashboard
    ```
 
-2. Clear cache and restore:
-   ```bash
-   dotnet msbuild samples/TodoListApp -t:ClearEQuanticCache
-   dotnet restore samples/TodoListApp --force-evaluate
-   ```
+2. Read the emitted JavaScript under `samples/DefaultUIDashboard/wwwroot/_equantic/`.
 
-3. Build and run:
-   ```bash
-   dotnet build samples/TodoListApp
-   dotnet run --project samples/TodoListApp
-   ```
+To validate the same change through the real consumer path (packages, `global.json`, restore), use
+the local-feed recipe on the wiki's [BuildFlow](https://github.com/equantic/equantic-ui/wiki/BuildFlow)
+page.
 
 ### Automated Testing (Pending)
 
@@ -195,19 +194,22 @@ When implementing compile-time evaluation in the compiler:
 
 ## Questions?
 
-- **For usage questions:** See examples in `TYPED-EXAMPLES.md`
+- **For usage questions:** `TYPED-EXAMPLES.md` went with the Tailwind adapter; the `ClassBuilder` tests are the living examples
 - **For architecture questions:** Read `COMPILE-TIME-EVALUATION-SUMMARY.md`
 - **For implementation questions:** Check `COMPILER-IMPLEMENTATION-GUIDE.md`
 - **For detailed specs:** Consult `COMPILER-COMPILE-TIME-EVALUATION.md`
 
 ## Version History
 
-- **v0.1.2** (Current)
+- **v0.1.2**
   - Added `[CompileTimeEvaluate]` attribute
   - Implemented `TailwindClass` with typed objects
   - Created `ClassBuilder` in Core
   - Comprehensive documentation
   - Awaiting compiler implementation
+- **Since then**
+  - The Tailwind adapter was removed (0704a3d0, 2026-08-08)
+  - `ClassBuilder` and `[CompileTimeEvaluate]` moved to `eQuantic.UI.Web` when Core was dissolved (#83)
 
 ---
 

--- a/docs/COMPILE-TIME-EVALUATION-SUMMARY.md
+++ b/docs/COMPILE-TIME-EVALUATION-SUMMARY.md
@@ -52,7 +52,7 @@ A marker attribute that tells the compiler to evaluate expressions at compile-ti
 
 ## Implementation
 
-### 1. Core Attribute
+### 1. The attribute
 
 **File:** `src/eQuantic.UI.Web/Styling/CompileTimeEvaluateAttribute.cs`
 
@@ -70,9 +70,9 @@ public sealed class CompileTimeEvaluateAttribute : Attribute
 - Configurable fallback behavior
 - Framework-agnostic
 
-### 2. Tailwind Implementation
+### 2. Tailwind Implementation (removed)
 
-**File:** `src/eQuantic.UI.Tailwind/TailwindClass.cs`
+**File:** `src/eQuantic.UI.Tailwind/TailwindClass.cs` — gone with the adapter (0704a3d0)
 
 ```csharp
 [CompileTimeEvaluate]

--- a/docs/COMPILE-TIME-EVALUATION-SUMMARY.md
+++ b/docs/COMPILE-TIME-EVALUATION-SUMMARY.md
@@ -1,5 +1,11 @@
 # Compile-Time Evaluation - Implementation Summary
 
+> **Status note.** The `TW.*` syntax on this page belongs to the `eQuantic.UI.Tailwind`
+> adapter, removed in 0704a3d0 (2026-08-08) — the atomic styling engine is the product, and
+> the framework ships exactly one styling engine. What survives is the generic mechanism:
+> `[CompileTimeEvaluate]` and `ClassBuilder`, now in `eQuantic.UI.Web.Styling`. Read the
+> examples as illustrations of the mechanism, not as an API you can call today.
+
 ## Problem Statement
 
 We needed a **generic, extensible solution** for compile-time evaluation of CSS class builders (Tailwind, Bootstrap, Material UI, etc.) **without hardcoding** framework-specific logic in the compiler.
@@ -12,7 +18,7 @@ A marker attribute that tells the compiler to evaluate expressions at compile-ti
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                    eQuantic.UI.Core                         │
+│                    eQuantic.UI.Web                          │
 │  ┌───────────────────────────────────────────────────────┐  │
 │  │  CompileTimeEvaluateAttribute                         │  │
 │  │  - Generic marker for any CSS framework              │  │
@@ -48,7 +54,7 @@ A marker attribute that tells the compiler to evaluate expressions at compile-ti
 
 ### 1. Core Attribute
 
-**File:** `src/eQuantic.UI.Core/Styling/CompileTimeEvaluateAttribute.cs`
+**File:** `src/eQuantic.UI.Web/Styling/CompileTimeEvaluateAttribute.cs`
 
 ```csharp
 [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class)]
@@ -126,7 +132,7 @@ private bool IsCompileTimeEvaluatable(ITypeSymbol typeSymbol)
 {
     return typeSymbol.GetAttributes()
         .Any(attr => attr.AttributeClass?.Name == "CompileTimeEvaluateAttribute" &&
-                     attr.AttributeClass.ContainingNamespace.ToDisplayString() == "eQuantic.UI.Core.Styling");
+                     attr.AttributeClass.ContainingNamespace.ToDisplayString() == "eQuantic.UI.Web.Styling");
 }
 ```
 
@@ -267,11 +273,11 @@ className: "flex gap-4 p-6"
 
 ### Created
 
-1. **`src/eQuantic.UI.Core/Styling/CompileTimeEvaluateAttribute.cs`**
+1. **`src/eQuantic.UI.Web/Styling/CompileTimeEvaluateAttribute.cs`**
    - Generic attribute for any CSS framework
    - Configurable fallback behavior
 
-2. **`src/eQuantic.UI.Core/Styling/ClassBuilder.cs`**
+2. **`src/eQuantic.UI.Web/Styling/ClassBuilder.cs`**
    - Generic fluent builder for CSS classes
    - Can be used by any framework (Tailwind, Bootstrap, etc.)
 
@@ -286,7 +292,7 @@ className: "flex gap-4 p-6"
 
 1. **`src/eQuantic.UI.Tailwind/TailwindClass.cs`**
    - Added `[CompileTimeEvaluate]` attribute
-   - Added `using eQuantic.UI.Core.Styling;`
+   - Added `using eQuantic.UI.Web.Styling;`
 
 2. **`src/eQuantic.UI.Tailwind/TWBuilder.cs`**
    - Simplified to delegate to `ClassBuilder`

--- a/docs/COMPILER-COMPILE-TIME-EVALUATION.md
+++ b/docs/COMPILER-COMPILE-TIME-EVALUATION.md
@@ -1,5 +1,11 @@
 # Compile-Time Evaluation in eQuantic.UI Compiler
 
+> **Status note.** The `TW.*` syntax on this page belongs to the `eQuantic.UI.Tailwind`
+> adapter, removed in 0704a3d0 (2026-08-08) — the atomic styling engine is the product, and
+> the framework ships exactly one styling engine. What survives is the generic mechanism:
+> `[CompileTimeEvaluate]` and `ClassBuilder`, now in `eQuantic.UI.Web.Styling`. Read the
+> examples as illustrations of the mechanism, not as an API you can call today.
+
 ## Overview
 
 The eQuantic.UI compiler supports **compile-time evaluation** of expressions involving types marked with the `[CompileTimeEvaluate]` attribute. This allows CSS class builders and similar constructs to be evaluated during compilation, producing optimized JavaScript output.
@@ -32,7 +38,7 @@ className: "flex gap-4 p-6"  // ✅ Pre-evaluated at compile time
 ### 1. Mark Type with Attribute
 
 ```csharp
-using eQuantic.UI.Core.Styling;
+using eQuantic.UI.Web.Styling;
 
 [CompileTimeEvaluate]
 public readonly struct TailwindClass
@@ -70,7 +76,7 @@ private bool IsCompileTimeEvaluatable(ITypeSymbol typeSymbol)
 {
     return typeSymbol.GetAttributes()
         .Any(attr => attr.AttributeClass?.Name == "CompileTimeEvaluateAttribute" &&
-                     attr.AttributeClass.ContainingNamespace.ToDisplayString() == "eQuantic.UI.Core.Styling");
+                     attr.AttributeClass.ContainingNamespace.ToDisplayString() == "eQuantic.UI.Web.Styling");
 }
 ```
 
@@ -384,7 +390,7 @@ public void CompileTimeEvaluation_OperatorOverload_EmitsConstantString()
 
 ## Examples from Real Projects
 
-### TodoListApp Example
+### The Tailwind sample, as it was written
 
 ```csharp
 // Before (string - no type safety)

--- a/extensions/vscode/scripts/build-host.mjs
+++ b/extensions/vscode/scripts/build-host.mjs
@@ -27,11 +27,12 @@ if (!existsSync(project)) {
 // the way it did two releases ago.
 rmSync(output, { recursive: true, force: true });
 
-// The repository's nuget.config declares a LOCAL package source, `artifacts/packages`, which nothing
-// fills any more (the Debug auto-pack that once did went in #88) and a fresh clone does not have.
-// NuGet refuses to restore against a source that is not there (NU1301) — so a clean checkout could
-// not publish the host, which is exactly what CI is. The host needs nothing from it; it only has to
-// exist.
+// The repository's nuget.config declares a LOCAL package source, `artifacts/packages`, and NuGet
+// refuses to restore against a source that is not there (NU1301) — so a checkout without it could
+// not publish the host, which is exactly what CI is. Nothing fills that directory any more (the
+// Debug auto-pack that once did went in #88); it only has to EXIST, and a tracked `.gitkeep` is what
+// makes a fresh clone have it. This mkdir is the belt to that pair of braces — it costs nothing and
+// covers a working copy where the directory was cleaned away.
 mkdirSync(resolve(extension, '../../artifacts/packages'), { recursive: true });
 
 const result = spawnSync(

--- a/extensions/vscode/scripts/build-host.mjs
+++ b/extensions/vscode/scripts/build-host.mjs
@@ -27,10 +27,11 @@ if (!existsSync(project)) {
 // the way it did two releases ago.
 rmSync(output, { recursive: true, force: true });
 
-// The repository's NuGet.config declares a LOCAL package source, `artifacts/packages`, which a Debug
-// build fills and a fresh clone does not have. NuGet refuses to restore against a source that is not
-// there (NU1301) — so a clean checkout could not publish the host, which is exactly what CI is. The
-// host needs nothing from it; it only has to exist.
+// The repository's nuget.config declares a LOCAL package source, `artifacts/packages`, which nothing
+// fills any more (the Debug auto-pack that once did went in #88) and a fresh clone does not have.
+// NuGet refuses to restore against a source that is not there (NU1301) — so a clean checkout could
+// not publish the host, which is exactly what CI is. The host needs nothing from it; it only has to
+// exist.
 mkdirSync(resolve(extension, '../../artifacts/packages'), { recursive: true });
 
 const result = spawnSync(

--- a/src/eQuantic.UI.Compiler/CodeGen/Strategies/Invocation/ServiceProviderStrategy.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/Strategies/Invocation/ServiceProviderStrategy.cs
@@ -134,7 +134,7 @@ public class ServiceProviderStrategy : IConversionStrategy
             var typeArg = genericName.TypeArgumentList.Arguments[0];
             var typeName = typeArg.ToString();
 
-            // Extract the simple interface name (e.g., IAppTheme from eQuantic.UI.Core.Theme.IAppTheme)
+            // Extract the simple interface name (e.g., IAppTheme from eQuantic.UI.Primitives.IAppTheme)
             var simpleTypeName = typeName;
             if (typeName.Contains('.'))
             {


### PR DESCRIPTION
A sweep of the build-flow documentation for claims that no longer hold on `main` — the wiki half is
already pushed to [equantic-ui.wiki](https://github.com/eQuantic/equantic-ui/wiki) (`8ba573b`), this
is the repository half.

Nothing compiles a doc, so these rotted quietly across three changes: `eQuantic.UI.Core` dissolved
(#83), the build tools became graph edges and the Debug auto-pack went (#88), and the samples moved
to project references long before either.

## Method

Every claim was checked against `Sdk.props`, `Sdk.targets`, the csproj files and the CI workflow, and
the two flows the docs describe were actually run:

| What was run | Result |
|---|---|
| `dotnet build samples/DefaultUIDashboard` | 0 errors — the dev-mode loop the docs now describe |
| `dotnet pack -c Release -p:PackageVersion=1.0.0-dev -o artifacts/local-feed` | 49 packages, samples and tests excluded — the local-feed recipe |
| `WikiVersionMarkTests`, `DiagnosticsDocumentedTests` | 2 + 3 passed |

The emitted `wwwroot/_equantic/` from that sample build is what the rewritten "Bundle Strategy"
section lists.

## What was wrong

**The dev loop.** `CLAUDE.md` and `AGENTS.md` opened with a "Bootstrap Build (required before first
build)" that packed three packages, then a "Development Workflow" pointing at
`scripts/dev-rebuild.sh` and two samples deleted in February, through a pack → cache → restore chain,
under the sentence "the samples use NuGet packages (like a real consumer would)". They do not, and
have not for a long time. `Sdk.props` detects the source tree (`IsEQuanticDevMode`) and swaps every
`PackageReference` for a `ProjectReference`; since #88 `eqc` and `eqicon` are `ProjectReference`
edges with `ReferenceOutputAssembly=false`, so a cold build orders them itself. One command is the
whole loop, and the real consumer path is one link away.

**Phantom build outputs.** "Bundle Strategy" promised `/_equantic/widgets.js`, `/_equantic/pages/*.js`
and `/_equantic/chunks/`. The compiler emits none of them: there is no chunk splitting, `widgets` is a
word this repo does not use, and the shared component library ships *inside* `runtime.js`. It now
lists what a build writes, with no sizes quoted.

**A string the compiler compares.** The two compile-time-evaluation specs named
`eQuantic.UI.Core.Styling`. The evaluator compares `eQuantic.UI.Web.Styling` — so a reader following
those docs would have marked a type with an attribute the evaluator never matches. All three docs in
that set now carry a status note that the Tailwind adapter went in `0704a3d0` and the generic
mechanism (`[CompileTimeEvaluate]`, `ClassBuilder`) is what remains.

**Smaller ones.** The product principle said the SDK adds "Core, Components, Web, Server, Runtime";
the project tree listed `eQuantic.UI.Tailwind` and `eQuantic.UI.CLI` (both removed) and three bun
packages instead of six, with no Sdk.Native, Generators, Templates or the two tool projects; a
compiler comment gave `eQuantic.UI.Core.Theme.IAppTheme` for a type that lives in Primitives; and two
comments claimed a Debug build fills `artifacts/packages/`, which #88 established it never did.

## Left alone deliberately

`docs/SHARED-COMPONENTS-PLAN.md` and `docs/HANDOFF-FIDELITY-AUDIT.md` still name `eQuantic.UI.Core`.
That is the record of what was true when they were written, which is what a plan and an audit are
for — rewriting their premise would destroy the record rather than refresh it.