### PR TITLE
🔧 chore: 0.2.0-preview.50

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.2.0-preview.49</Version>
+        <Version>0.2.0-preview.50</Version>
         <Authors>eQuantic</Authors>
         <Company>eQuantic</Company>
         <Product>eQuantic.UI</Product>


### PR DESCRIPTION
Cuts 0.2.0-preview.50. One line, as a version bump is.

## What is in this release, since 0.2.0-preview.49

| PR | What |
|---|---|
| #90, #95 | **Charts.** `eQuantic.UI.Charts` is a write-once library on Primitives — `BarChart` renders from one piece of C# on web SSR, in the browser and on Photon. Colour comes from `IAppTheme.Data` (`DataPalette`, defaulted so no existing theme breaks) and its `PaletteAudit`. |
| #92 | **The Windows shell.** `eQuantic.UI.Native.Shell.Windows` — the same csproj that opens an NSWindow on a Mac opens an HWND on Windows, Vulkan where an ICD exists and the Reference backend where none does. |
| #91 | **`IWorkspace.OpenUrl` hands over only the schemes the app opens.** A behaviour change, with a migration note. |
| #94 | A Release solution build builds every project in Release. Repository-only; nothing ships from it. |
| #93 | The build-flow documentation describes the tree as it is. |

## Two behaviour changes a consumer meets

Both are in the tag's migration notes, which go out with the tag itself as they did for .49:

- **`IWorkspace.OpenUrl` refuses schemes the app did not open** (#91). An app that opened `mailto:`, `tel:` or another app's scheme through it now gets `false` and a log line naming the one-line fix, until it declares that scheme in `Program.cs`. A `file:` URL moves to `OpenFile`/`Reveal`.
- **`VisualNode.Key` now has effect** (#95). Documented as reconciler identity since the vocabulary existed and read by neither realizer; both read it now. That is a fix — a virtualized list stops losing focus as its window slides — and it makes real a contract nothing was checking: duplicate keys among siblings stop being harmless.

## Verification

The version is one line in `Directory.Build.props` and it appears nowhere else in the tree — checked across sources, props, targets, csproj, JSON, workflows and Markdown, including comments, which is where the .49 bump left a stale mention.
