### PR TITLE
🐛 fix: the constructor protocol writes only where a slot exists

### DIFF
--- a/src/eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
+++ b/src/eQuantic.UI.Compiler/CodeGen/TypeScriptEmitter.cs
@@ -450,7 +450,10 @@ public class TypeScriptEmitter
                         .Where(p => !p.IsStatic && IsAutoProperty(p)
                                     && (p.DefaultValueNode != null || p.ImplicitDefaultJs != null))
                         .ToList();
-                    var hasCtorBody = ctorDef?.BodyNode != null;
+                    // EITHER form of body counts: a block, or the arrow a one-line constructor is
+                    // written with. Only the block was read, so `public Chart(x) => _x = x;` emitted a
+                    // constructor that assigned nothing and left the field undefined.
+                    var hasCtorBody = ctorDef?.BodyNode != null || ctorDef?.ExpressionBodyNode != null;
                     if (ctorParams.Count > 0 || autoDefaults.Count > 0 || hasCtorBody)
                     {
                         // C# optional parameters keep their defaults as JS default parameters
@@ -514,12 +517,21 @@ public class TypeScriptEmitter
                             foreach (var param in passed)
                             {
                                 var camelName = param.Name.ToCamelCase();
+                                var target = component.Properties
+                                    .FirstOrDefault(pr => !pr.IsStatic && pr.Name.ToCamelCase() == camelName);
                                 // PRIMARY-constructor params are implicit fields — always assign. With an
                                 // EXPLICIT ctor body, only params that map onto a real auto-property assign
                                 // here; one that merely feeds a private/state field (`NestedChild(label)` →
                                 // `_label`) has no `this.<name>` to write — the C# ctor body does the wiring.
-                                if (hasCtorBody && !component.Properties.Any(pr => !pr.IsStatic && pr.Name.ToCamelCase() == camelName))
-                                    continue;
+                                if (hasCtorBody && target == null) continue;
+                                // Nor does one whose twin is a GETTER: `Series => _series;` beside a `series`
+                                // parameter emitted `get series()` and `this.series = series` into one class,
+                                // which tsc rejects and which throws at `new` in the browser. The value still
+                                // arrives, through the constructor body the author wrote — writing the field
+                                // themselves is what a read-only property is FOR. Only the explicit-ctor path
+                                // skips: a primary constructor has no body to do that wiring, so dropping the
+                                // assignment there would lose the value instead of relocating it.
+                                if (hasCtorBody && target != null && !IsAssignableSlot(target)) continue;
                                 statements.Add(JsStatement.If(
                                     JsExpr.Binary(JsExpr.Identifier(camelName), "!==", JsExpr.Identifier("undefined")),
                                     Assign(JsExpr.ThisMember(camelName), JsExpr.Identifier(camelName)), null));
@@ -537,11 +549,13 @@ public class TypeScriptEmitter
                                 statements.Add(DefaultIfUndefined(cn, def));
                             }
                             var bodyLine = statements.Count + 1;
-                            if (hasCtorBody) statements.Add(Contents(ctorDef!.BodyNode!));
+                            if (ctorDef?.BodyNode is { } ctorBlock) statements.Add(Contents(ctorBlock));
+                            else if (ctorDef?.ExpressionBodyNode is { } ctorExpression)
+                                statements.Add(JsStatement.Raw(ExpressionBodyStatement(ctorExpression)));
                             // …and the initializer last, which is where C# runs it.
                             statements.Add(JsStatement.Raw("if (props && typeof props === 'object') Object.assign(this, props);"));
                             c.Member(JsClassMember.Constructor(signature, JsStatement.Block(statements)),
-                                bodySource: ctorDef?.BodyNode, bodyLine: bodyLine);
+                                bodySource: (SyntaxNode?)ctorDef?.BodyNode ?? ctorDef?.ExpressionBodyNode, bodyLine: bodyLine);
                         }
                     }
 
@@ -1162,6 +1176,33 @@ public class TypeScriptEmitter
         if (node.ExpressionBody != null) return false;
         if (node.AccessorList == null) return true;
         return node.AccessorList.Accessors.All(a => a.Body == null && a.ExpressionBody == null);
+    }
+
+    /// <summary>
+    /// True when the emitted class has a slot this property can be WRITTEN to, which is what decides
+    /// whether the constructor protocol may assign a same-named parameter onto it.
+    /// <para>
+    /// An auto-property is emitted type-only and filled from outside (the base `Object.assign(props)`
+    /// or the constructor), so it takes an assignment. Anything with a real accessor takes one only
+    /// when a SETTER is emitted beside the getter — and an expression-bodied property
+    /// (`Series => _series;`) emits a getter alone.
+    /// </para>
+    /// <para>
+    /// Getting this wrong is not a cosmetic mismatch. `get series()` and `this.series = series` in
+    /// one class is TS2540 to the type checker, and a class body is strict-mode code, so the
+    /// assignment THROWS a TypeError at `new` — a component the server rendered perfectly dies at
+    /// hydration. Found while writing the first chart, whose shape (private field, read-only
+    /// property, constructor parameter of the same name) is ordinary C# any consumer can write.
+    /// </para>
+    /// </summary>
+    private static bool IsAssignableSlot(PropertyDefinition p)
+    {
+        // No syntax to read (a property the parser knew without a declaration): keep the old answer
+        // rather than guess a new one.
+        if (IsAutoProperty(p)) return true;
+        if (p.Node?.AccessorList is not { } list) return false;   // expression-bodied: a getter alone
+        var setter = list.Accessors.FirstOrDefault(a => a.Keyword.Text is "set" or "init");
+        return setter is not null && (setter.Body != null || setter.ExpressionBody != null);
     }
 
     /// <summary>Unwrap a converted block body (`{ … }`) to its inner statements for inlining into an

--- a/src/eQuantic.UI.Compiler/Models/ComponentDefinition.cs
+++ b/src/eQuantic.UI.Compiler/Models/ComponentDefinition.cs
@@ -223,6 +223,13 @@ public class MethodDefinition
     /// <see cref="MethodDeclarationSyntax"/>), so the emitter can transpile and run a ctor's body.</summary>
     public Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax? BodyNode { get; set; }
     /// <summary>
+    /// The other half a body can take: <c>public Chart(x) =&gt; _x = x;</c>. Held beside
+    /// <see cref="BodyNode"/> because a constructor written this way has no block, and reading only
+    /// the block dropped the author's wiring on the floor — the twin ran a constructor that did
+    /// nothing while the C# one assigned a field. Form decides first, then behaviour.
+    /// </summary>
+    public Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax? ExpressionBodyNode { get; set; }
+    /// <summary>
     /// A C# 12 PRIMARY constructor, whose parameters are implicit fields rather than locals: members
     /// read them as <c>this.name</c>, so whatever the constructor puts in one has to land there.
     /// </summary>

--- a/src/eQuantic.UI.Compiler/Parser/ComponentParser.cs
+++ b/src/eQuantic.UI.Compiler/Parser/ComponentParser.cs
@@ -711,7 +711,8 @@ public class ComponentParser
                 ReturnType = "void",
                 Body = ctor.Body?.ToString() ?? ctor.ExpressionBody?.Expression.ToString() ?? "",
                 SyntaxNode = null,
-                BodyNode = ctor.Body
+                BodyNode = ctor.Body,
+                ExpressionBodyNode = ctor.ExpressionBody?.Expression,
             };
 
             foreach (var param in ctor.ParameterList.Parameters)

--- a/tests/eQuantic.UI.Compiler.Tests/ReadOnlyPropertyCtorTests.cs
+++ b/tests/eQuantic.UI.Compiler.Tests/ReadOnlyPropertyCtorTests.cs
@@ -1,0 +1,224 @@
+using System.Text.RegularExpressions;
+using eQuantic.UI.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace eQuantic.UI.Compiler.Tests;
+
+/// <summary>
+/// The constructor protocol assigns a parameter onto the same-named property. It must not do that
+/// when the twin has no slot to write.
+/// <para>
+/// A private field, a read-only property over it, and a constructor parameter of the same name is
+/// ordinary C# — it is how anything with computed or validated state is written. Emitted naively
+/// the class carried <c>get series()</c> AND <c>this.series = series</c>: TS2540 to the type
+/// checker, and because a class body is strict-mode code, a TypeError thrown at <c>new</c>. The
+/// component rendered perfectly on the server and died at hydration.
+/// </para>
+/// <para>
+/// The value is not lost by skipping. The author's own constructor body writes the field, which is
+/// the whole point of a read-only property.
+/// </para>
+/// </summary>
+public class ReadOnlyPropertyCtorTests
+{
+    private static string TypeScriptOf(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source, path: "Probe.cs");
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .Append(MetadataReference.CreateFromFile(typeof(eQuantic.UI.Primitives.VisualNode).Assembly.Location));
+        var compilation = CSharpCompilation.Create("Probe", [tree], references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        var compiler = new ComponentCompiler();
+        compiler.SetProjectCompilation(compilation);
+        var result = compiler.CompileSource(source, "Probe.cs").Single();
+        Assert.True(result.Success, string.Join("\n", result.Errors.Select(e => e.Message)));
+        return result.TypeScript;
+    }
+
+    private const string Head = """
+        using System;
+        using System.Collections.Generic;
+        using eQuantic.UI.Primitives;
+
+        namespace Demo;
+
+        """;
+
+    /// <summary>The reported shape, from the first chart: `_series`, `Series => _series`, `series`.</summary>
+    [Fact]
+    public void AnExpressionBodiedProperty_GetsNoAssignment_AndTheBodyStillWritesTheField()
+    {
+        var ts = TypeScriptOf(Head + """
+            public sealed class Chart : StatelessComponent
+            {
+                private readonly IReadOnlyList<string> _series;
+
+                public Chart(IReadOnlyList<string> series) => _series = series;
+
+                public IReadOnlyList<string> Series => _series;
+
+                public override VisualNode Build(ComponentContext context) =>
+                    new Text(_series.Count.ToString(), TypeRole.BodyM);
+            }
+            """);
+
+        Assert.Contains("get series()", ts);
+        Assert.DoesNotContain("this.series = series", ts);
+        // The parameter still lands, through the constructor the author wrote.
+        Assert.Contains("this._series = series", ts);
+    }
+
+    /// <summary>The same shape spelled with a bodied getter rather than an expression body.</summary>
+    [Fact]
+    public void ABodiedGetterWithNoSetter_GetsNoAssignmentEither()
+    {
+        var ts = TypeScriptOf(Head + """
+            public sealed class Gauge : StatelessComponent
+            {
+                private readonly int _value;
+
+                public Gauge(int value)
+                {
+                    _value = value;
+                }
+
+                public int Value { get { return _value; } }
+
+                public override VisualNode Build(ComponentContext context) =>
+                    new Text(_value.ToString(), TypeRole.BodyM);
+            }
+            """);
+
+        Assert.Contains("get value()", ts);
+        Assert.DoesNotContain("this.value = value", ts);
+        Assert.Contains("this._value = value", ts);
+    }
+
+    /// <summary>
+    /// The other half of the rule, so the fix cannot be "never assign": a property the twin emits a
+    /// SETTER for is written exactly as before. A computed property is not automatically read-only.
+    /// </summary>
+    [Fact]
+    public void APropertyWithASetter_IsStillAssigned()
+    {
+        var ts = TypeScriptOf(Head + """
+            public sealed class Slider : StatelessComponent
+            {
+                private int _amount;
+
+                public Slider(int amount)
+                {
+                    _amount = amount;
+                }
+
+                public int Amount
+                {
+                    get { return _amount; }
+                    set { _amount = value; }
+                }
+
+                public override VisualNode Build(ComponentContext context) =>
+                    new Text(_amount.ToString(), TypeRole.BodyM);
+            }
+            """);
+
+        Assert.Contains("set amount(", ts);
+        Assert.Contains("this.amount = amount", ts);
+    }
+
+    /// <summary>
+    /// The defect the reported shape was hiding behind: a constructor written with an ARROW had no
+    /// block, the emitter read only the block, and the author's wiring never reached the twin. The
+    /// C# constructor assigned a field and its twin ran a constructor that did nothing.
+    /// </summary>
+    [Fact]
+    public void AnExpressionBodiedConstructor_StillRunsItsBody()
+    {
+        var ts = TypeScriptOf(Head + """
+            public sealed class Ticker : StatelessComponent
+            {
+                private readonly int _count;
+
+                public Ticker(int count) => _count = count;
+
+                public override VisualNode Build(ComponentContext context) =>
+                    new Text(_count.ToString(), TypeRole.BodyM);
+            }
+            """);
+
+        Assert.Contains("this._count = count", ts);
+    }
+
+    /// <summary>
+    /// The RULE, rather than one spelling of it: whatever the emitter writes a getter for, nothing
+    /// may assign. Stated over the emitted module itself, so a future change that reaches the same
+    /// wrong output by another route fails here even if the string this file asserts elsewhere has
+    /// moved on. Both defects are the same sentence in JavaScript: a getter with no setter is not a
+    /// slot, and a class body is strict-mode code, so writing to one throws instead of being ignored.
+    /// </summary>
+    [Fact]
+    public void NothingTheEmitterGivesAGetter_IsEverAssigned()
+    {
+        var ts = TypeScriptOf(Head + """
+            public sealed class Panel : StatelessComponent
+            {
+                private readonly string _caption;
+                private readonly int _weight;
+
+                public Panel(string caption, int weight)
+                {
+                    _caption = caption;
+                    _weight = weight;
+                }
+
+                public string Caption => _caption;
+                public int Weight { get { return _weight; } }
+                public bool Wide => _weight > 10;
+
+                public override VisualNode Build(ComponentContext context) =>
+                    new Text(_caption, TypeRole.BodyM);
+            }
+            """);
+
+        var getters = Regex.Matches(ts, @"^\s*get\s+(\w+)\s*\(", RegexOptions.Multiline)
+            .Select(m => m.Groups[1].Value)
+            .ToList();
+        Assert.NotEmpty(getters);
+
+        var setters = Regex.Matches(ts, @"^\s*set\s+(\w+)\s*\(", RegexOptions.Multiline)
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet();
+
+        foreach (var name in getters.Where(g => !setters.Contains(g)))
+            Assert.DoesNotContain($"this.{name} =", ts);
+    }
+
+    /// <summary>And an ordinary auto-property, which the twin fills from outside, keeps its assignment.</summary>
+    [Fact]
+    public void AnAutoProperty_IsStillAssigned()
+    {
+        var ts = TypeScriptOf(Head + """
+            public sealed class Label : StatelessComponent
+            {
+                public Label(string caption)
+                {
+                    Caption = caption;
+                }
+
+                public string Caption { get; init; }
+
+                public override VisualNode Build(ComponentContext context) =>
+                    new Text(Caption, TypeRole.BodyM);
+            }
+            """);
+
+        Assert.Contains("this.caption = caption", ts);
+    }
+}


### PR DESCRIPTION
Two defects in the emitter's constructor protocol, the second found while fixing the first, and both
in shapes any consumer's component can have.

## A parameter was assigned onto a property with no slot

A private field, a read-only property over it, and a constructor parameter of the same name is
ordinary C#. It is how anything computed or validated is written:

```csharp
private readonly IReadOnlyList<ChartSeries> _series;
public BarChart(IReadOnlyList<ChartSeries> series) { _series = series; }
public IReadOnlyList<ChartSeries> Series => _series;
```

The emitter put both halves into one class:

```ts
get series() { return this._series; }
constructor(series?: any, props?: any) {
    super();
    if (series !== undefined) this.series = series;   // ← TS2540
}
```

`tsc` rejects it, and since a class body is strict-mode code the assignment **throws a TypeError at
`new`** rather than being ignored. A component the server rendered perfectly dies at hydration.

The protocol now asks whether the twin has a slot to write, not merely whether a property of that
name exists. An auto-property is emitted type-only and filled from outside, so it takes the
assignment; anything with a real accessor takes one only when a **setter** is emitted beside the
getter. The parameter still arrives, through the constructor body the author wrote, which is what a
read-only property is for.

Only the explicit-ctor path skips. A primary constructor has no body to do that wiring, so dropping
the assignment there would lose the value instead of relocating it.

## The defect it was hiding behind

Reproducing the first one with an arrow constructor turned up a second: the parser kept
`ctor.Body` and nothing else, so

```csharp
public Chart(IReadOnlyList<string> series) => _series = series;
```

reached the emitter with no body at all. The twin ran a constructor that assigned nothing while the
C# one assigned a field. Both halves of a body are now carried, and the arrow form is emitted as the
statement it is.

This matters to the first fix: skipping the property assignment is only safe because the author's
own wiring reaches the twin, and for an arrow constructor it did not.

## Proof

Six tests in `ReadOnlyPropertyCtorTests`, each A/B'd against the fix removed rather than only
against its absence:

- the reported shape, expression-bodied property, and the same shape with a bodied getter — no
  assignment, and the field still written;
- a property **with** a setter, and a plain auto-property — still assigned, so the fix cannot be
  "never assign";
- the arrow constructor, which must still run its body;
- and the rule rather than one spelling of it: whatever the emitted module gives a getter and no
  setter, nothing assigns. Stated over the module itself, so a future change reaching the same wrong
  output by another route fails here.

The shared-component pins are **byte-identical**, which is the right answer: no component in the
library has either shape, so nothing regresses.

| suite | passed | skipped |
| --- | --- | --- |
| Compiler | 845 | 0 |
| Web | 664 | 0 |
| Conformance | 1146 | 1 |
| Native.Engine | 1180 | 19 |
| Server | 153 | 0 |
| Design | 104 | 0 |
| vitest | 983 | 0 |

`tsc --noEmit` clean, and both samples build with no change to their generated output.
