### PR TITLE
📝 docs: the JIT entitlement is not enough for a WASM engine

### DIFF
--- a/src/eQuantic.UI.Native.Hosting/PhotonEntitlementsBuilder.cs
+++ b/src/eQuantic.UI.Native.Hosting/PhotonEntitlementsBuilder.cs
@@ -24,12 +24,16 @@ public sealed class PhotonEntitlementsBuilder
     /// <summary>What this app declared, in case it wants to explain itself.</summary>
     public IReadOnlyCollection<string> Declared => _declared;
 
-    /// <summary>An embedded engine that compiles code at run time — a WASM runtime, a scripting VM.
-    /// Without it the hardened runtime kills the process at its first generated page.</summary>
+    /// <summary>An engine that maps executable pages the platform way (<c>MAP_JIT</c>) — .NET's own
+    /// JIT, JavaScriptCore. Without it the hardened runtime kills the process at its first such
+    /// page. Not enough on its own for an engine that writes plain executable memory: a WASM
+    /// runtime needs <see cref="RequireUnsignedExecutableMemory"/> beside it (see
+    /// <see cref="PhotonEntitlements.AllowJit"/> for what was measured).</summary>
     public PhotonEntitlementsBuilder RequireJit() => Require(PhotonEntitlements.AllowJit);
 
-    /// <summary>Executable memory the app writes itself and did not sign. Broader than
-    /// <see cref="RequireJit"/> — reach for that one first.</summary>
+    /// <summary>Executable memory the app writes itself, outside <c>MAP_JIT</c> and unsigned — a
+    /// WASM engine such as wasmtime. NOT a fallback to reach for after <see cref="RequireJit"/>:
+    /// for an engine of that shape it is the requirement, and the measured pair is both.</summary>
     public PhotonEntitlementsBuilder RequireUnsignedExecutableMemory() =>
         Require(PhotonEntitlements.AllowUnsignedExecutableMemory);
 

--- a/src/eQuantic.UI.Native.Hosting/PhotonEntitlementsBuilder.cs
+++ b/src/eQuantic.UI.Native.Hosting/PhotonEntitlementsBuilder.cs
@@ -25,15 +25,17 @@ public sealed class PhotonEntitlementsBuilder
     public IReadOnlyCollection<string> Declared => _declared;
 
     /// <summary>An engine that maps executable pages the platform way (<c>MAP_JIT</c>) — .NET's own
-    /// JIT, JavaScriptCore. Without it the hardened runtime kills the process at its first such
-    /// page. Not enough on its own for an engine that writes plain executable memory: a WASM
-    /// runtime needs <see cref="RequireUnsignedExecutableMemory"/> beside it (see
-    /// <see cref="PhotonEntitlements.AllowJit"/> for what was measured).</summary>
+    /// JIT, JavaScriptCore. Rarely worth declaring: a hardened non-AOT build already gets this key
+    /// from the SDK, because the .NET runtime needs it for itself. A WASM engine is NOT this case
+    /// and calling this instead ships a binary that dies — see
+    /// <see cref="RequireUnsignedExecutableMemory"/> and <see cref="PhotonEntitlements.AllowJit"/>
+    /// for what was measured.</summary>
     public PhotonEntitlementsBuilder RequireJit() => Require(PhotonEntitlements.AllowJit);
 
     /// <summary>Executable memory the app writes itself, outside <c>MAP_JIT</c> and unsigned — a
-    /// WASM engine such as wasmtime. NOT a fallback to reach for after <see cref="RequireJit"/>:
-    /// for an engine of that shape it is the requirement, and the measured pair is both.</summary>
+    /// WASM engine such as wasmtime. NOT a fallback to reach for after <see cref="RequireJit"/>: for
+    /// an engine of that shape it is the requirement, and for a hardened non-AOT app it is the ONE
+    /// key to declare, since the SDK already puts the JIT key in the bundle.</summary>
     public PhotonEntitlementsBuilder RequireUnsignedExecutableMemory() =>
         Require(PhotonEntitlements.AllowUnsignedExecutableMemory);
 

--- a/src/eQuantic.UI.Native.Hosting/PhotonEntitlementsBuilder.cs
+++ b/src/eQuantic.UI.Native.Hosting/PhotonEntitlementsBuilder.cs
@@ -26,16 +26,16 @@ public sealed class PhotonEntitlementsBuilder
 
     /// <summary>An engine that maps executable pages the platform way (<c>MAP_JIT</c>) — .NET's own
     /// JIT, JavaScriptCore. Rarely worth declaring: a hardened non-AOT build already gets this key
-    /// from the SDK, because the .NET runtime needs it for itself. A WASM engine is NOT this case
-    /// and calling this instead ships a binary that dies — see
-    /// <see cref="RequireUnsignedExecutableMemory"/> and <see cref="PhotonEntitlements.AllowJit"/>
-    /// for what was measured.</summary>
+    /// from the SDK, because the .NET runtime needs it for itself. An engine that writes plain
+    /// executable memory instead is NOT this case and calling this for it ships a binary that
+    /// dies — wasmtime is the one measured; see <see cref="RequireUnsignedExecutableMemory"/> and
+    /// <see cref="PhotonEntitlements.AllowJit"/>.</summary>
     public PhotonEntitlementsBuilder RequireJit() => Require(PhotonEntitlements.AllowJit);
 
-    /// <summary>Executable memory the app writes itself, outside <c>MAP_JIT</c> and unsigned — a
-    /// WASM engine such as wasmtime. NOT a fallback to reach for after <see cref="RequireJit"/>: for
-    /// an engine of that shape it is the requirement, and for a hardened non-AOT app it is the ONE
-    /// key to declare, since the SDK already puts the JIT key in the bundle.</summary>
+    /// <summary>Executable memory the app writes itself, outside <c>MAP_JIT</c> and unsigned —
+    /// wasmtime is the measured case. NOT a fallback to reach for after <see cref="RequireJit"/>:
+    /// for an engine of that shape it is the requirement, and for a hardened non-AOT app it is the
+    /// ONE key to declare, since the SDK already puts the JIT key in the bundle.</summary>
     public PhotonEntitlementsBuilder RequireUnsignedExecutableMemory() =>
         Require(PhotonEntitlements.AllowUnsignedExecutableMemory);
 

--- a/src/eQuantic.UI.Primitives/Devices/PhotonEntitlementAttribute.cs
+++ b/src/eQuantic.UI.Primitives/Devices/PhotonEntitlementAttribute.cs
@@ -52,7 +52,9 @@ public static class PhotonEntitlements
     /// NOT enough on its own for every engine that compiles at run time, which is what the name
     /// suggests and what this comment used to say. An engine that writes plain executable memory
     /// rather than going through <c>MAP_JIT</c> needs <see cref="AllowUnsignedExecutableMemory"/>,
-    /// and wasmtime — so YARA-X, which embeds it — is exactly that case.
+    /// and wasmtime — so YARA-X, which embeds it — is measured to be that shape. Which shape a
+    /// given engine is, is the engine's own business: "a WASM runtime" is not the answer, because
+    /// nothing stops one from mapping the platform way.
     /// </para>
     /// <para>
     /// AN APP RARELY DECLARES THIS ONE. A hardened non-AOT build already gets it from the SDK
@@ -68,8 +70,9 @@ public static class PhotonEntitlements
     public const string AllowJit = "com.apple.security.cs.allow-jit";
 
     /// <summary>
-    /// Executable memory the app writes itself, outside <c>MAP_JIT</c> and unsigned — a WASM engine
-    /// such as wasmtime, some interpreters, older engines.
+    /// Executable memory the app writes itself, outside <c>MAP_JIT</c> and unsigned — wasmtime,
+    /// some interpreters, older engines. The shape is what decides, not the category: an engine is
+    /// this case because of how it maps its pages, and another WASM runtime may well not be.
     /// <para>
     /// NOT a broader fallback to try after <see cref="AllowJit"/>, which is what this comment used
     /// to say and which sent a consumer to ship a binary that died on its first scan. For an engine
@@ -77,8 +80,9 @@ public static class PhotonEntitlements
     /// is the REQUIREMENT.
     /// </para>
     /// <para>
-    /// So for a hardened NON-AOT app embedding a WASM engine, this is the ONE key the app declares:
-    /// <see cref="AllowJit"/> is already in the bundle from the SDK. Measured, all three rows with a
+    /// So for a hardened NON-AOT app embedding an engine of that shape — wasmtime is the one
+    /// measured — this is the ONE key the app declares: <see cref="AllowJit"/> is already in the
+    /// bundle from the SDK. Measured, all three rows with a
     /// real certificate — JIT alone SIGKILLs (<c>"namespace":"CODESIGNING"</c>,
     /// <c>"indicator":"Invalid Page"</c>); JIT plus this passes; and THIS ALONE passes too, which is
     /// what proved the JIT declaration was never the variable. Under <c>PublishAot</c> the SDK

--- a/src/eQuantic.UI.Primitives/Devices/PhotonEntitlementAttribute.cs
+++ b/src/eQuantic.UI.Primitives/Devices/PhotonEntitlementAttribute.cs
@@ -51,11 +51,18 @@ public static class PhotonEntitlements
     /// <para>
     /// NOT enough on its own for every engine that compiles at run time, which is what the name
     /// suggests and what this comment used to say. An engine that writes plain executable memory
-    /// rather than going through <c>MAP_JIT</c> also needs
-    /// <see cref="AllowUnsignedExecutableMemory"/>, and wasmtime — so YARA-X, which embeds it — is
-    /// exactly that case. Measured by a consumer with a real certificate: <c>allow-jit</c> alone
-    /// SIGKILLs on the first scan (<c>"namespace":"CODESIGNING"</c>, <c>"indicator":"Invalid
-    /// Page"</c>); the two together pass.
+    /// rather than going through <c>MAP_JIT</c> needs <see cref="AllowUnsignedExecutableMemory"/>,
+    /// and wasmtime — so YARA-X, which embeds it — is exactly that case.
+    /// </para>
+    /// <para>
+    /// AN APP RARELY DECLARES THIS ONE. A hardened non-AOT build already gets it from the SDK
+    /// beside <see cref="DisableLibraryValidation"/>, because the .NET runtime JITs its own methods
+    /// (see <c>_EqRuntimeEntitlements</c> in the native SDK's targets). Declaring it again is a
+    /// harmless no-op — and worth knowing, because a consumer declared it, watched the crash stop,
+    /// and credited the wrong key: the entitlement that changed was the other one, and this had
+    /// been in every one of their bundles all along. Under <c>PublishAot</c> the SDK adds nothing,
+    /// so an AOT app that embeds such an engine declares whatever it needs itself — a case nobody
+    /// here has measured.
     /// </para>
     /// </summary>
     public const string AllowJit = "com.apple.security.cs.allow-jit";
@@ -67,7 +74,15 @@ public static class PhotonEntitlements
     /// NOT a broader fallback to try after <see cref="AllowJit"/>, which is what this comment used
     /// to say and which sent a consumer to ship a binary that died on its first scan. For an engine
     /// that maps executable pages the platform way, JIT is the answer; for one that does not, this
-    /// is the REQUIREMENT, and the measured pair for wasmtime is both keys together.
+    /// is the REQUIREMENT.
+    /// </para>
+    /// <para>
+    /// So for a hardened NON-AOT app embedding a WASM engine, this is the ONE key the app declares:
+    /// <see cref="AllowJit"/> is already in the bundle from the SDK. Measured, all three rows with a
+    /// real certificate — JIT alone SIGKILLs (<c>"namespace":"CODESIGNING"</c>,
+    /// <c>"indicator":"Invalid Page"</c>); JIT plus this passes; and THIS ALONE passes too, which is
+    /// what proved the JIT declaration was never the variable. Under <c>PublishAot</c> the SDK
+    /// declares nothing and the recipe is the app's own to work out; nobody has measured it.
     /// </para>
     /// <para>
     /// Nothing without a signing certificate exercises the hardened runtime, so a mistake here

--- a/src/eQuantic.UI.Primitives/Devices/PhotonEntitlementAttribute.cs
+++ b/src/eQuantic.UI.Primitives/Devices/PhotonEntitlementAttribute.cs
@@ -44,14 +44,36 @@ public sealed class PhotonEntitlementAttribute(string entitlement) : Attribute
 /// </summary>
 public static class PhotonEntitlements
 {
-    /// <summary>Required by any embedded engine that compiles code at run time — a WASM runtime
-    /// (wasmtime, YARA-X), a scripting VM, a regex JIT. Without it the hardened runtime kills the
-    /// process at the first executable page it maps, with SIGKILL/CODESIGNING: no exception, no
-    /// stack, the process is simply gone.</summary>
+    /// <summary>
+    /// Pages the app maps through Apple's JIT protocol (<c>MAP_JIT</c>) — .NET's own JIT,
+    /// JavaScriptCore. Without it the hardened runtime kills the process at the first such page,
+    /// with SIGKILL/CODESIGNING: no exception, no stack, the process is simply gone.
+    /// <para>
+    /// NOT enough on its own for every engine that compiles at run time, which is what the name
+    /// suggests and what this comment used to say. An engine that writes plain executable memory
+    /// rather than going through <c>MAP_JIT</c> also needs
+    /// <see cref="AllowUnsignedExecutableMemory"/>, and wasmtime — so YARA-X, which embeds it — is
+    /// exactly that case. Measured by a consumer with a real certificate: <c>allow-jit</c> alone
+    /// SIGKILLs on the first scan (<c>"namespace":"CODESIGNING"</c>, <c>"indicator":"Invalid
+    /// Page"</c>); the two together pass.
+    /// </para>
+    /// </summary>
     public const string AllowJit = "com.apple.security.cs.allow-jit";
 
-    /// <summary>Executable memory the app writes itself and did not sign — some interpreters and
-    /// older engines. Broader than <see cref="AllowJit"/>: reach for JIT first.</summary>
+    /// <summary>
+    /// Executable memory the app writes itself, outside <c>MAP_JIT</c> and unsigned — a WASM engine
+    /// such as wasmtime, some interpreters, older engines.
+    /// <para>
+    /// NOT a broader fallback to try after <see cref="AllowJit"/>, which is what this comment used
+    /// to say and which sent a consumer to ship a binary that died on its first scan. For an engine
+    /// that maps executable pages the platform way, JIT is the answer; for one that does not, this
+    /// is the REQUIREMENT, and the measured pair for wasmtime is both keys together.
+    /// </para>
+    /// <para>
+    /// Nothing without a signing certificate exercises the hardened runtime, so a mistake here
+    /// survives a fully green suite and appears at the first notarized release.
+    /// </para>
+    /// </summary>
     public const string AllowUnsignedExecutableMemory =
         "com.apple.security.cs.allow-unsigned-executable-memory";
 

--- a/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
+++ b/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
@@ -192,9 +192,14 @@
             `[assembly: PhotonEntitlement(…)]` declarations. This is the release half of the
             capability idea and it is invisible until release, which is what makes it dangerous: a
             development build signs ad hoc, where the hardened runtime is not in force and nothing
-            needs permitting, so an app that JITs (a WASM engine, a scripting VM) runs perfectly for
-            months and is then killed with SIGKILL/CODESIGNING on the first machine that installs
-            the signed build. No catch sees it; the process is simply gone.
+            needs permitting, so an app that generates code (a scripting VM, a WASM engine) runs
+            perfectly for months and is then killed with SIGKILL/CODESIGNING on the first machine
+            that installs the signed build. No catch sees it; the process is simply gone.
+
+            Note which key each shape needs, because the names mislead: allow-jit below covers pages
+            mapped through MAP_JIT, which is what the .NET runtime uses and why it is here. An engine
+            that writes plain executable memory — wasmtime, so YARA-X — needs
+            allow-unsigned-executable-memory instead, and declares it itself.
         -->
         <Exec Command="dotnet &quot;$(_EqIconToolDir)eqicon.dll&quot; entitlements --assembly &quot;$(TargetDir)$(TargetFileName)&quot; --plist &quot;$(_EqIconDir)/$(AssemblyName).entitlements&quot; --also &quot;$(_EqRuntimeEntitlements)&quot;"
               StandardOutputImportance="normal" />

--- a/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
+++ b/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
@@ -196,10 +196,11 @@
             perfectly for months and is then killed with SIGKILL/CODESIGNING on the first machine
             that installs the signed build. No catch sees it; the process is simply gone.
 
-            Note which key each shape needs, because the names mislead: allow-jit below covers pages
-            mapped through MAP_JIT, which is what the .NET runtime uses and why it is here. An engine
-            that writes plain executable memory — wasmtime, so YARA-X — needs
-            allow-unsigned-executable-memory instead, and declares it itself.
+            Note which key each shape needs, because the names mislead: the allow-jit in
+            _EqRuntimeEntitlements covers pages mapped through MAP_JIT, which is what the .NET
+            runtime uses and why the SDK declares it. An engine that writes plain executable
+            memory — wasmtime, so YARA-X — needs allow-unsigned-executable-memory instead, and
+            declares that one itself.
         -->
         <Exec Command="dotnet &quot;$(_EqIconToolDir)eqicon.dll&quot; entitlements --assembly &quot;$(TargetDir)$(TargetFileName)&quot; --plist &quot;$(_EqIconDir)/$(AssemblyName).entitlements&quot; --also &quot;$(_EqRuntimeEntitlements)&quot;"
               StandardOutputImportance="normal" />

--- a/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
+++ b/src/eQuantic.UI.Sdk.Native/Sdk/Sdk.targets
@@ -198,9 +198,9 @@
 
             Note which key each shape needs, because the names mislead: the allow-jit in
             _EqRuntimeEntitlements covers pages mapped through MAP_JIT, which is what the .NET
-            runtime uses and why the SDK declares it. An engine that writes plain executable
-            memory — wasmtime, so YARA-X — needs allow-unsigned-executable-memory instead, and
-            declares that one itself.
+            runtime uses and why the SDK declares it. An app whose engine writes plain executable
+            memory instead — wasmtime, so YARA-X — needs allow-unsigned-executable-memory, and
+            declares that one itself through PhotonEntitlement.
         -->
         <Exec Command="dotnet &quot;$(_EqIconToolDir)eqicon.dll&quot; entitlements --assembly &quot;$(TargetDir)$(TargetFileName)&quot; --plist &quot;$(_EqIconDir)/$(AssemblyName).entitlements&quot; --also &quot;$(_EqRuntimeEntitlements)&quot;"
               StandardOutputImportance="normal" />


### PR DESCRIPTION
`PhotonEntitlements.AllowJit` named **"a WASM runtime (wasmtime, YARA-X)"** as its own case, and
`AllowUnsignedExecutableMemory` said it was *"broader than AllowJit: reach for JIT first"*. Both are
wrong for exactly the engine the first one names, and the consequence is not a lint: an app that
follows this advice ships a binary the hardened runtime kills on first use.

`allow-jit` covers pages mapped through Apple's JIT protocol (`MAP_JIT`) — .NET's own JIT,
JavaScriptCore. wasmtime writes plain executable memory instead, so it needs
`allow-unsigned-executable-memory` as well.

## Measured, by a consumer holding a real certificate

| declared by the app | in the bundle | result |
| --- | --- | --- |
| `RequireJit()` | jit + library-validation | **SIGKILL** — `"namespace":"CODESIGNING"`, `"indicator":"Invalid Page"` |
| `RequireJit()` + `RequireUnsignedExecutableMemory()` | all three | **pass** |
| `RequireUnsignedExecutableMemory()` alone | **all three** | **pass** |

The third row is the one that decides the recipe, and it took a second pass to get. `allow-jit` is in
**every** hardened non-AOT bundle already: the SDK declares it beside `disable-library-validation`
because the .NET runtime JITs its own methods (`_EqRuntimeEntitlements`, `Sdk.targets:183`). So it
was present in all three runs and was never the variable — the consumer had declared it, watched the
crash stop, and credited the wrong key.

**An app with a WASM engine therefore declares ONE entitlement**, the broad one. `RequireJit()`
beside it is a harmless no-op that teaches the wrong thing. Under `PublishAot` the SDK declares
nothing, so that recipe is the app's own to work out; nobody has measured it, and the comments say
so rather than guess.

Reported by the OS Cleaner session, which embeds YARA-X (and therefore wasmtime) and signed with an
`Apple Development` identity — enough to turn the hardened runtime on, which is the only way to see
any of this.

## Why it survived everything

**Nothing without a signing certificate exercises the hardened runtime.** Their suite is 699 tests
and 22 screenshots on ad-hoc signing, all green, and the binary would have died at the first scan of
the first notarized release. The doc comments now say that too, because it is the fact that makes
this class of mistake expensive rather than annoying.

## What changed

Four doc comments — the two constants in `PhotonEntitlements` and the two `PhotonEntitlementsBuilder`
methods — now say which SHAPE of engine needs which key, and which key the SDK already supplies. The
targets file carried the same conflation in the very sentence that warns about this failure ("an app
that JITs (a WASM engine, a scripting VM)") and now names them apart. They are written
in the register the neighbouring `DisableLibraryValidation` comment already uses, which states what
was measured and both ways it was tried; that comment is why the SDK adds library validation itself,
and the same consumer confirmed in passing that it is what let their app launch at all.

The wiki's Photon page carries the short version, EN and pt-BR, already published.

No code path changes, so the suites are unaffected: Native.Engine 1180, Web 664, Compiler 839,
PhotonDesktop builds.
